### PR TITLE
fix(build): emit backbone shim bundles

### DIFF
--- a/dist/backbone.cjs
+++ b/dist/backbone.cjs
@@ -1,0 +1,18 @@
+'use strict';
+
+var underscore = require('underscore');
+var Backbone = require('backbone');
+var marionette = require('marionette');
+
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var Backbone__default = /*#__PURE__*/_interopDefaultLegacy(Backbone);
+
+underscore.extend(Backbone__default['default'], marionette.Events);
+underscore.extend(Backbone__default['default'].Model.prototype, marionette.Events);
+underscore.extend(Backbone__default['default'].Collection.prototype, marionette.Events);
+underscore.extend(Backbone__default['default'].View.prototype, marionette.Events);
+underscore.extend(Backbone__default['default'].Router.prototype, marionette.Events);
+underscore.extend(Backbone__default['default'].History.prototype, marionette.Events);
+
+module.exports = Backbone__default['default'];

--- a/dist/backbone.js
+++ b/dist/backbone.js
@@ -1,0 +1,11 @@
+import { extend } from 'underscore';
+import Backbone from 'backbone';
+export { default } from 'backbone';
+import { Events } from 'marionette';
+
+extend(Backbone, Events);
+extend(Backbone.Model.prototype, Events);
+extend(Backbone.Collection.prototype, Events);
+extend(Backbone.View.prototype, Events);
+extend(Backbone.Router.prototype, Events);
+extend(Backbone.History.prototype, Events);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "browser": "lib/marionette.umd.js",
   "main": "index.js",
   "module": "index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/backbone.js",
+    "./dist/backbone.cjs"
+  ],
   "browserslist": [
     ">0.5%",
     "Explorer >= 10",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,21 @@ const globals = {
   underscore: '_',
 };
 
+const shimExternal = ['underscore', 'backbone', 'marionette'];
+const shimMainExternal = {
+  name: 'shim-main-external',
+  resolveId(source, importer) {
+    const normalizedImporter = importer && importer.replace(/\\/g, '/');
+
+    // Keep the built shim pointed at the package entry instead of bundling Marionette.
+    if (source === './index.js' && normalizedImporter && normalizedImporter.endsWith('/backbone.js')) {
+      return { id: 'marionette', external: true };
+    }
+
+    return null;
+  },
+};
+
 export default [
   {
     input: 'build/version.js',
@@ -63,6 +78,26 @@ export default [
     plugins: [
       babel({ babelHelpers: 'bundled' }),
       terser(),
+    ]
+  },
+  {
+    input: 'backbone.js',
+    external: shimExternal,
+    output: [
+      {
+        file: 'dist/backbone.js',
+        format: 'es',
+      },
+      {
+        file: 'dist/backbone.cjs',
+        format: 'cjs',
+        exports: 'default',
+      },
+    ],
+    plugins: [
+      shimMainExternal,
+      eslint({ exclude: ['node_modules/**', './version.js'] }),
+      babel({ babelHelpers: 'bundled' }),
     ]
   },
 ]


### PR DESCRIPTION
Closes #45

## Summary
- Add Rollup output for the optional Backbone shim at `dist/backbone.js` and `dist/backbone.cjs`.
- Keep `underscore`, `backbone`, and the main `marionette` entry external for the shim build.
- Update `package.json#sideEffects` to preserve the published shim artifacts when imported for side effects only.

## Public behavior boundary
- Public runtime behavior is intended to remain unchanged unless the shim is explicitly imported.
- The main Marionette entry still does not auto-run the Backbone shim.

## Allowed behavior changes
- Consumers that explicitly import the built Backbone shim path can get Backbone prototype patching from the built artifact once package exports are wired.

## Tests / validation run
- `npm run build` passed.
- Confirmed `dist/backbone.js` and `dist/backbone.cjs` are emitted.
- Confirmed `package.json#sideEffects` is `["./dist/backbone.js", "./dist/backbone.cjs"]`.
- Confirmed `npm pack --dry-run --json` includes `dist/backbone.js`, `dist/backbone.cjs`, and `package.json`.
- Confirmed `dist/backbone.cjs` patches Backbone prototypes when the external `marionette` dependency is resolved to the built main CJS bundle in a local smoke check.

## Package / install fixture impact
- The packed artifact now includes the built Backbone shim files.
- The shim build references the main `marionette` entry externally instead of bundling the full library.
- No install fixture tests were added here because package exports are still pending.

## Docs impact
- None.

## Scope creep check
- Did not auto-run the shim from the main entry.
- Did not implement `package.json#exports` or public subpath wiring.
- Did not implement the jQuery DomApi adapter.
- Did not change runtime architecture or public APIs outside the built shim availability.
- Did not modify files under `logs/`.

## Follow-up issues
- #43 remains responsible for the full package exports map, including public `marionette/backbone` subpath resolution.
- Install fixture coverage for `import 'marionette/backbone'` should land once #43 wires the package subpath.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit optional Backbone shim bundles so consumers can opt into Backbone prototype patching via an explicit import. Runtime stays the same unless the shim is imported; the main `marionette` entry does not auto-run it.

- **Bug Fixes**
  - Build and publish the shim at `dist/backbone.js` (ESM) and `dist/backbone.cjs` (CJS).
  - Keep `underscore`, `backbone`, and `marionette` external; add a Rollup resolve shim to reference the `marionette` package entry instead of bundling it.
  - Set `package.json#sideEffects` to include the shim files for side-effect-only imports.
  - Public subpath exports (e.g., `import 'marionette/backbone'`) will be added in #43.

<sup>Written for commit 0f05a450d94ffbad5d93be4c4a1293ebd2e24d9f. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Declare specific distribution files as containing side effects in package configuration.
  * Add a dedicated build target for the Backbone component to the bundler configuration.
  * Emit both ECMAScript and CommonJS artifacts for that build target.
  * Apply standard build plugins and a resolution shim to support the new build target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->