### PR TITLE
fix(pkg): wire built package entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,22 @@
   "description": "The Composite Javascript Framework",
   "version": "5.0.0-alpha.2",
   "homepage": "https://marionettejs.com/",
-  "browser": "lib/marionette.umd.js",
-  "main": "index.js",
-  "module": "index.js",
+  "browser": "dist/marionette.umd.js",
+  "main": "dist/marionette.cjs",
+  "module": "dist/marionette.js",
+  "exports": {
+    ".": {
+      "import": "./dist/marionette.js",
+      "require": "./dist/marionette.cjs",
+      "default": "./dist/marionette.js"
+    },
+    "./backbone": {
+      "import": "./dist/backbone.js",
+      "require": "./dist/backbone.cjs",
+      "default": "./dist/backbone.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": [
     "./dist/backbone.js",
     "./dist/backbone.cjs"


### PR DESCRIPTION
Closes #43

## Summary
- Point fallback package fields at built artifacts: `main` -> `dist/marionette.cjs`, `module` -> `dist/marionette.js`, and `browser` -> `dist/marionette.umd.js`.
- Add an `exports` map for the top-level package, `./backbone`, and `./package.json`.
- Export only artifacts that currently exist in `dist/`; no jQuery DomApi or type declaration paths are added here.

## Public behavior boundary
- Public runtime behavior is intended to remain unchanged except for package resolution now targeting built artifacts.
- The main package entry resolves to the built CJS bundle for `require` and the built ESM bundle for `import`.
- The Backbone shim remains explicit opt-in through the `./backbone` subpath.
- Adding `exports` intentionally restricts undeclared deep imports under Node-style package resolution; this should be called out in v5 release notes/migration docs.

## Allowed behavior changes
- `require('marionette')` resolves to `dist/marionette.cjs`.
- `import('marionette')` resolves to `dist/marionette.js`.
- `require('marionette/backbone')` resolves to `dist/backbone.cjs` and can apply the explicit Backbone shim.

## Tests / validation run
- `npm run build` passed.
- `npm pack --dry-run --json` passed and confirmed packed `dist/` artifacts.
- Ran a package metadata check confirming all `main`, `module`, `browser`, and `exports` paths point to files that exist.
- Installed the packed tarball into a temporary fixture and verified:
  - `require('marionette')` succeeds.
  - `import('marionette')` succeeds.
  - `require('marionette/backbone')` patches Backbone prototypes.

## Package / install fixture impact
- Package entrypoints now resolve built artifacts instead of root source files or the nonexistent `lib/marionette.umd.js` path.
- No permanent install fixture was added; validation used a temporary packed-package install.

## Docs impact
- No docs files changed in this PR.
- v5 release notes/migration docs should mention that the new exports map blocks undeclared deep imports.

## Scope creep check
- Did not implement the jQuery DomApi adapter.
- Did not add `./jquery-dom-api` exports because no `dist/jquery-dom-api.*` artifacts exist yet.
- Did not add type declaration exports because no `dist/*.d.ts` artifacts exist yet.
- Did not change runtime architecture, build outputs, dependencies, or files under `logs/`.

## Follow-up issues
- jQuery DomApi adapter work remains required before adding a `./jquery-dom-api` export.
- Type declaration work remains required before adding `types` fields or `types` export conditions that point to real declaration artifacts.
- v5 release notes/migration docs should document the exports-map deep-import boundary.