### PR TITLE
fix(deps): make backbone an optional peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,13 @@
   },
   "github": "https://github.com/marionettejs/marionette",
   "peerDependencies": {
+    "backbone": "^1.4.0",
     "underscore": "^1.11.0"
   },
-  "optionalDependencies": {
-    "backbone": "1.4.0"
+  "peerDependenciesMeta": {
+    "backbone": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "7.12.3",


### PR DESCRIPTION
Closes #47

## Summary
- Remove `optionalDependencies.backbone` (which installs by default in npm 7+ and only treats install failures as optional).
- Add `backbone: "^1.4.0"` to `peerDependencies`.
- Add `peerDependenciesMeta.backbone.optional = true` so npm 7+ neither installs Backbone automatically nor warns when it is absent.

## Public behavior boundary
- Public runtime behavior is unchanged. v5 core does not import Backbone; the optional shim at the `marionette/backbone` subpath remains the only consumer.
- The main `marionette` entry still does not auto-run the Backbone shim.

## Allowed behavior changes
- `npm install marionette` on npm 7+ no longer pulls in Backbone for consumers who do not use the optional shim, and no peer warning is emitted when Backbone is absent.

## Tests / validation run
- `grep` for `from 'backbone'` and `require('backbone')` across `src/`, `index.js`, `mixins/`, `config/`, `build/`, and `backbone.js`: the only match is in `backbone.js` (the opt-in shim). v5 core has zero direct Backbone imports.
- `npm install` succeeded with no peer warnings related to Backbone.
- `npm pack --dry-run` succeeded; the published manifest contains no `dependencies.backbone` and no `optionalDependencies.backbone`.

## Package / install fixture impact
- Published manifest changes:
  - `optionalDependencies.backbone` removed.
  - `peerDependencies.backbone = "^1.4.0"` added.
  - `peerDependenciesMeta.backbone.optional = true` added.
- No install fixture was added in this PR; a no-Backbone core install fixture is the right place to assert the new behavior end-to-end and can land as a follow-up.
- `package-lock.json` is intentionally not regenerated here: the existing lockfile is `lockfileVersion: 1` and a fresh install rewrites ~10k lines unrelated to this change. Backbone remains in `devDependencies`, so the lockfile entry stays valid for the repo's own tests.

## Docs impact
- None. Existing docs already describe Backbone as optional; no doc references to `optionalDependencies` exist.

## Scope creep check
- Did not change `exports`, `sideEffects`, `files`, `engines`, `browserslist`, or build config.
- Did not modify v5 core source.
- Did not touch the optional shim source at `backbone.js` or its built artifacts.
- Did not introduce a jQuery peer entry (the jQuery DomApi adapter and its `marionette/jquery-dom-api` subpath are not yet implemented).
- Did not modify files under `logs/`.

## Follow-up issues
- Add a no-Backbone install fixture that asserts (a) `npm install marionette` on npm 7+ does not install Backbone, (b) no peer warning, and (c) `require('marionette')` works without Backbone present.
- When the jQuery DomApi adapter lands, add `jquery` as an optional peer alongside Backbone with the same `peerDependenciesMeta` pattern.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `backbone` an optional peer dependency so npm 7+ won’t auto-install it or warn when it’s missing. Runtime behavior is unchanged; only the `marionette/backbone` shim consumes Backbone.

- **Dependencies**
  - Removed `optionalDependencies.backbone`.
  - Added `peerDependencies.backbone: "^1.4.0"` with `peerDependenciesMeta.backbone.optional = true`.

<sup>Written for commit 2fcf68c86ab69505d584817e4ba42c6827b9f765. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/88?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency declarations to optimize compatibility management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->