### PR TITLE
fix(deps): raise underscore peer floor to ^1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "github": "https://github.com/marionettejs/marionette",
   "peerDependencies": {
     "backbone": "^1.4.0",
-    "underscore": "^1.11.0"
+    "underscore": "^1.13.0"
   },
   "peerDependenciesMeta": {
     "backbone": {

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -1,3 +1,10 @@
 ## From backbone.marionette.js
 
 Todo
+
+## Peer dependency requirements
+
+- Underscore must be `1.13.0` or later. Marionette v5 publishes named ESM imports
+  from `underscore`, and Underscore versions before 1.13 are CJS-only with no
+  package `exports` map, so modern Node and bundler ESM resolution cannot satisfy
+  the named imports.


### PR DESCRIPTION
Closes #48

## Summary
- Raise `peerDependencies.underscore` from `^1.11.0` to `^1.13.0`.
- Document the new minimum supported Underscore version in `upgradeGuide.md`.

This is an ESM/runtime compatibility fix, not a freshness bump. `dist/marionette.js` uses named ESM imports from `underscore`, and Underscore versions before 1.13 are CJS-only with no package `exports` map, so modern Node and bundler ESM resolution cannot satisfy those named imports.

## Public behavior boundary
- Public runtime behavior is unchanged for consumers already on Underscore `>= 1.13`.
- The main `marionette` entry continues to export the same API.

## Allowed behavior changes
- Consumers on Underscore versions before `1.13.0` must upgrade Underscore to use Marionette v5. npm 7+ will surface this as a peer-dependency warning at install time.

## Tests / validation run
- `npm run build` succeeded; `dist/` artifacts unchanged.
- ESM smoke test in an isolated fixture (`/tmp`) with `underscore@1.13.7` + `backbone@1.4.0` + `jsdom`:
  - `await import('./dist/marionette.js')` resolved 26 named exports including `View`, `Application`, `VERSION`.
- CJS smoke test in the same fixture:
  - `require('./dist/marionette.cjs')` resolved the same 26 exports.
- Inspected `node_modules/underscore@1.13.7/package.json` and confirmed it ships a package `exports` map (the resolution mechanism this floor relies on).

## Package / install fixture impact
- Published manifest change: `peerDependencies.underscore` is now `^1.13.0`.
- No permanent install fixture was added in this PR; the in-tree fixture infrastructure for "ESM import against `underscore@1.13.x`" called out in the acceptance criteria does not exist yet. The smoke check above is a temporary stand-in.
- `devDependencies.underscore` is intentionally left at `^1.11.0` — this PR limits its diff to the published peer-dependency contract and the upgrade-guide note. A repo-internal dev bump can land separately.

## Docs impact
- Added a `## Peer dependency requirements` section to `upgradeGuide.md` documenting the `>= 1.13.0` requirement and the ESM-import reason. Placed at the end of the existing (stub) document so it slots in cleanly when the rest of the v5 upgrade guide is written under plan issue #33.

## Scope creep check
- Did not change `exports`, `sideEffects`, `files`, `engines`, `browserslist`, or build config.
- Did not change Backbone peer metadata.
- Did not remove Underscore.
- Did not replace any Underscore usage in source.
- Did not perform a broader Underscore audit.
- Did not bump `devDependencies.underscore`.
- Did not modify files under `logs/`.

## Follow-up issues
- Land a permanent install fixture that asserts `import('marionette')` resolves all named exports against `underscore@1.13.x` (the acceptance-criterion check that was deferred here).
- When the broader v5 upgrade guide lands (plan issue #33), the new "Peer dependency requirements" section may want to be reorganized alongside other peer/runtime notes.
- Optionally bump `devDependencies.underscore` to `^1.13.0` so the repo's own tests run against the same floor v5 advertises.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the `underscore` peer dependency to `^1.13.0` to ensure ESM compatibility with `marionette` v5’s named imports. Adds a note in `upgradeGuide.md`; no runtime changes for apps already on `underscore@>=1.13`.

- **Dependencies**
  - Set `peerDependencies.underscore` to `^1.13.0`.

- **Migration**
  - If you use `underscore<1.13.0`, upgrade to `>=1.13.0`. No other changes required.

<sup>Written for commit 712ba2919d9bc6fadb54f952ad1a93caf1b9cfaf. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/89?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum Underscore peer dependency requirement to version 1.13.0 or later.

* **Documentation**
  * Added a "Peer dependency requirements" section to the upgrade guide documenting Underscore version compatibility and requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->