### PR TITLE
fix(events): return from trigger after object-map dispatch

### DIFF
--- a/mixins/events.js
+++ b/mixins/events.js
@@ -250,6 +250,7 @@ export default {
           args: [name[key]],
         });
       });
+      return this;
     }
 
     if (name && eventSplitter.test(name)) {

--- a/test/unit/mixins/events.spec.js
+++ b/test/unit/mixins/events.spec.js
@@ -1,0 +1,85 @@
+import _ from 'underscore';
+import EventsMixin from '../../../mixins/events';
+
+describe('Events Mixin', function() {
+  describe('#trigger with an object map', function() {
+    let object;
+
+    beforeEach(function() {
+      object = _.extend({}, EventsMixin);
+    });
+
+    it('should invoke each handler with the mapped value as its argument', function() {
+      const onA = this.sinon.stub();
+      const onB = this.sinon.stub();
+      object.on('a', onA);
+      object.on('b', onB);
+
+      object.trigger({ a: 1, b: 2 });
+
+      expect(onA).to.have.been.calledOnce.and.calledWith(1);
+      expect(onB).to.have.been.calledOnce.and.calledWith(2);
+    });
+
+    it('should not throw when triggering with an object map', function() {
+      object.on('a', _.noop);
+      object.on('b', _.noop);
+
+      // Before the fix this fell through into the eventSplitter branch and
+      // called `name.split(...)` on the object map, throwing a TypeError.
+      expect(function() {
+        object.trigger({ a: 1, b: 2 });
+      }).to.not.throw();
+    });
+
+    it('should not fall through to the eventSplitter branch for object input', function() {
+      // If the object-form branch fell through, triggerApi would be called a
+      // second time with the object literal as the event name. Spying on
+      // `keys(name)` is messy, so we instead assert each per-key handler is
+      // invoked exactly once (a fall-through would re-dispatch nothing useful
+      // but exercises the broken split path).
+      const onA = this.sinon.stub();
+      object.on('a', onA);
+
+      object.trigger({ a: 'value' });
+
+      expect(onA).to.have.been.calledOnce;
+    });
+
+    it('should return the receiver so calls can be chained', function() {
+      object.on('a', _.noop);
+
+      const result = object.trigger({ a: 1 });
+
+      expect(result).to.equal(object);
+    });
+  });
+
+  describe('#trigger with a string event name', function() {
+    let object;
+
+    beforeEach(function() {
+      object = _.extend({}, EventsMixin);
+    });
+
+    it('should still dispatch a single-name string event', function() {
+      const handler = this.sinon.stub();
+      object.on('foo', handler);
+
+      object.trigger('foo', 'arg');
+
+      expect(handler).to.have.been.calledOnce.and.calledWith('arg');
+    });
+
+    it('should still split a space-separated string event', function() {
+      const handler = this.sinon.stub();
+      object.on('foo', handler);
+      object.on('bar', handler);
+
+      object.trigger('foo bar', 'arg');
+
+      expect(handler).to.have.been.calledTwice;
+      expect(handler).to.have.been.calledWith('arg');
+    });
+  });
+});


### PR DESCRIPTION
Closes #51

## Summary
- `Events.trigger` handled an object-map argument by iterating its keys but never returned, so control fell through into the `eventSplitter` branch.
- `Object.prototype.toString()` yields `"[object Object]"` which contains whitespace, so `eventSplitter.test(name)` returned `true` and the subsequent `name.split(eventSplitter)` call threw `TypeError: name.split is not a function`.
- Add `return this;` after the object-map branch.
- Add a regression spec at `test/unit/mixins/events.spec.js` covering object-map dispatch, no-throw, no-fall-through, chaining, and preserved string-name behavior.

## Public Behavior Boundary
- Public runtime behavior is preserved except for the documented bug fix.
- String-event `trigger` semantics (single name and space-separated) are unchanged and covered by the new spec.

## Allowed Behavior Changes
- `obj.trigger({ a: 1, b: 2 })` no longer throws; it dispatches each mapped key with its value as the sole argument and returns the receiver.

## Tests / Validation Run
- Project-wide `npm test` and `npx mocha --config ./test/.mocharc.json` are broken on `master` (pre-existing, unrelated to this fix):
  - `npm test` runs `eslint --fix src/ ...`, but no `src/` directory exists.
  - The mocha bootstrap (`test/setup/node.js`) attempts `global.navigator = ...`, which throws on Node 21+ because `navigator` is a read-only built-in global.
  - `test/setup/setup.js` requires `../../src/backbone.marionette` which does not exist.
- To exercise the new spec without that broken bootstrap, the spec was run against a minimal local-only chai/sinon helper:
  - Before fix: 4 failing (all object-map cases), 2 passing (string-name baseline). Failure message: `TypeError: name.split is not a function at Object.trigger (mixins/events.js:256)` — matches the issue.
  - After fix: 6 passing, 0 failing.
- A standalone Node reproducer (`require('@babel/register')` + import the mixin + call `trigger({a:1,b:2})`) was used to confirm RED/GREEN as well.

## Package / Install Fixture Impact
- None. No package metadata or build output changed.

## Docs Impact
- None. The fix restores documented `trigger(events)` object-form behavior; no API surface change.

## Scope Creep Check
- Did not refactor `Events` more broadly.
- Did not modify any other mixin, util, or module.
- Did not change build config, dist, package.json, or `logs/`.
- Did not attempt to repair the pre-existing test-runner bootstrap (out of scope; tracked separately).

## Follow-Up Issues
- The project-wide test runner needs repair before this spec (and others) can run via `npm test`:
  - Resolve the `src/` import paths used throughout `test/setup/setup.js` and most existing specs.
  - Replace the `global.navigator = window.navigator` assignment with a Node 21+-compatible JSDOM bootstrap (e.g. `Object.defineProperty` with `configurable: true`, or skip resetting `navigator`).
  - Fix the `eslint --fix src/` script path or migrate the lint target.
- Consider adding additional `Events` mixin specs (on/off/once/listenTo) at the same canonical location once the bootstrap is repaired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `Events.trigger` when called with an object map by returning after per-key dispatch, preventing fall-through into string splitting. Restores the documented object-form behavior while keeping string and space-separated event handling unchanged.

- **Bug Fixes**
  - Return `this` after object-map dispatch in `mixins/events.js` to avoid `TypeError: name.split is not a function`.
  - Add regression tests for object-map dispatch, no-throw, chaining, and preserved string/space-separated behavior.

<sup>Written for commit 4ef3d50a65e48521d6130352c45c922e6ec04a84. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/91?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the event trigger method to properly handle multiple events specified as object maps while maintaining method chaining.

* **Tests**
  * Added unit tests verifying event dispatch behavior for various input formats and method chaining.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->