### PR TITLE
fix(events): use _rdInternal guard key consistently

### DIFF
--- a/mixins/events.js
+++ b/mixins/events.js
@@ -228,7 +228,7 @@ export default {
         listenToObj._rdEvents = offReducer(events, args);
 
         // Call `off` for interop
-        listenToObj.off(args.name, args.callback, this, { _reInternal: true });
+        listenToObj.off(args.name, args.callback, this, { _rdInternal: true });
       });
     }
 


### PR DESCRIPTION
## Linked issue

- Closes #54

## Summary

`mixins/events.js:231` wrote the cleanup-guard option as `{ _reInternal: true }`, but the two existing checkers on lines 137 and 151 read `opts._rdInternal`. Because the setter key and the checker key disagree by one character, the early-return guard never fires and the `off` call re-enters the Events cleanup logic. Fix the option key spelling to match.

## Why this matters

The cleanup guard is the mechanism that prevents the Events mixin's `off` call inside `stopListening` from re-entering its own cleanup logic. Because the setter at line 231 wrote `_reInternal` (typo) but the checker at lines 137 and 151 read `_rdInternal` (intended), the early-return path never executed for listenTo-driven cleanup. That is the exact 'intended guard can run' acceptance the issue asks for.

## Public behavior boundary

- [x] This PR is linked to a focused issue.
- [x] This PR preserves public runtime behavior unless the issue explicitly allows a change.
- [x] This PR does not expand v5 runtime architecture.
- [x] I did not opportunistically refactor unrelated code.

## Allowed behavior changes, if any

The issue allows: "Internal cleanup uses the intended guard key. Public behavior should remain preserved." This PR makes exactly that change - `_rdInternal: true` now reaches the guard check, where the typo previously made it fall through. Externally observable behavior of `on` / `off` / `listenTo` / `stopListening` is unchanged because `_rdInternal` is a private marker on the options bag, never exposed to user code.

## Tests run

- [x] I added or updated tests for the acceptance criteria, or explained why not.
- [x] I ran the relevant validation commands and listed them below.

No new tests: the Events mixin has no existing test file under `test/unit/mixins/` and adding one would mean introducing harness scaffolding the v5 milestone has not yet built. The issue's "if practical" framing on the regression test fits leaving that work to a follow-up rather than expanding scope here. Verified manually via grep that all four references to the internal key now agree:

```sh
$ grep -n "_reInternal\|_rdInternal" mixins/events.js
108:  obj.on(name, callback, context, { _rdInternal: true });
137:    if (opts && opts._rdInternal) {return;}
151:    if (opts && opts._rdInternal) {return;}
231:        listenToObj.off(args.name, args.callback, this, { _rdInternal: true });
```

## Package / install fixture impact

- [x] No package entrypoints, exports, peers, or dist artifacts changed.
- Impact: none.

## Docs impact

- [x] No docs change needed.
- Impact: none - `_rdInternal` is not user-facing.

## Scope creep check

- [x] This PR stays within the linked issue scope.
- [x] This PR does not introduce statecharts, signals, virtual DOM, schema/effect/query platforms, public topology runtime APIs, built-in router, full app rewrite guidance, or AI-native product claims.

## Agent/human review notes

One-character source change at `mixins/events.js:231`. The fix lines up with the matching setter pattern at line 108, so all four references now reference the same internal key.

Fixes #54

AI-assisted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the intended `_rdInternal` key (not `_reInternal`) for the Events cleanup guard so the early-return check works and `off` doesn’t re-enter cleanup during `stopListening` (no public API change).

<sup>Written for commit f36aec2c4e8d69eb9707657cabe6586e84d083fe. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/92?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event handler cleanup logic that was using an incorrect internal flag during event unbinding operations, preventing potential issues with inter-object event interoperability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->