### PR TITLE
fix(events): guard delegated matching for text nodes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 * Fixed Radio circular dependency with log and debug
 * Fixed event interop with Backbone
+* Fixed delegated event matching so nested matching ancestors fire once per event
 
 ### v5.0.0-alpha.1
 

--- a/config/event-delegator.js
+++ b/config/event-delegator.js
@@ -22,21 +22,22 @@ export default {
       const delegateHandler = function(evt) {
         let node = evt.target;
         for (; node && node !== rootEl; node = node.parentNode) {
-          if (Element.prototype.matches.call(node, selector)) {
+          if (node.nodeType === 1 && node.matches(selector)) {
             evt.delegateTarget = node;
             handler(evt);
+            break;
           }
         }
       };
 
       events.push({ eventName, handler: delegateHandler });
-      Element.prototype.addEventListener.call(rootEl, eventName, delegateHandler, shouldCapture);
+      rootEl.addEventListener(eventName, delegateHandler, shouldCapture);
 
       return;
     }
 
     events.push({ eventName, handler });
-    Element.prototype.addEventListener.call(rootEl, eventName, handler, shouldCapture);
+    rootEl.addEventListener(eventName, handler, shouldCapture);
   },
 
   // this.$el.off('.delegateEvents' + this.cid);
@@ -45,7 +46,7 @@ export default {
 
     each(events, ({ eventName, handler }) => {
       const shouldCapture = this.shouldCapture(eventName);
-      Element.prototype.removeEventListener.call(rootEl, eventName, handler, shouldCapture);
+      rootEl.removeEventListener(eventName, handler, shouldCapture);
     });
 
     events.length = 0;

--- a/test/unit/config/event-delegator.spec.js
+++ b/test/unit/config/event-delegator.spec.js
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+import sinon from 'sinon';
+
+import EventDelegator from '../../../config/event-delegator';
+
+describe('EventDelegator', function() {
+  let dom;
+  let events;
+  let rootEl;
+
+  beforeEach(function() {
+    dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost' });
+    events = [];
+    rootEl = dom.window.document.getElementById('root');
+  });
+
+  afterEach(function() {
+    EventDelegator.undelegateAll({ events, rootEl });
+  });
+
+  function delegate(eventName, selector, handler) {
+    EventDelegator.delegate({
+      eventName,
+      selector,
+      handler,
+      events,
+      rootEl
+    });
+  }
+
+  function dispatchClick(node) {
+    node.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  }
+
+  it('handles delegated events with text-node targets', function() {
+    const handler = sinon.spy();
+
+    rootEl.innerHTML = '<button class="foo">click text</button>';
+    delegate('click', '.foo', handler);
+
+    expect(function() {
+      dispatchClick(rootEl.querySelector('.foo').firstChild);
+    }).to.not.throw();
+    expect(handler.callCount).to.equal(1);
+  });
+
+  it('fires once when nested ancestors match the selector', function() {
+    const handler = sinon.spy();
+
+    rootEl.innerHTML = '<div class="foo"><button class="foo">click</button></div>';
+    delegate('click', '.foo', handler);
+
+    dispatchClick(rootEl.querySelector('button'));
+
+    expect(handler.callCount).to.equal(1);
+    expect(handler.firstCall.args[0].delegateTarget).to.equal(rootEl.querySelector('button'));
+  });
+
+  it('delegates focus events during capture', function() {
+    const handler = sinon.spy();
+
+    rootEl.innerHTML = '<input class="foo">';
+    delegate('focus', '.foo', handler);
+
+    rootEl.querySelector('input').dispatchEvent(new dom.window.FocusEvent('focus'));
+
+    expect(handler.callCount).to.equal(1);
+  });
+});


### PR DESCRIPTION
Closes #53

## Summary
- Guard delegated selector matching to element nodes before calling `node.matches(selector)`.
- Stop delegated ancestor traversal after the first matching ancestor so one delegated handler fires once per event.
- Add focused EventDelegator regressions for text-node click targets, nested matching ancestors, and focus capture delegation.

## Public Behavior Boundary
- Preserves delegated event registration and focus/blur capture behavior.
- Does not change package exports, build configuration, dist publishing, or runtime architecture.

## Allowed Behavior Changes
- Delegated handlers no longer throw when an event target is a text node.
- A delegated handler now fires once for the nearest matching ancestor instead of once per matching ancestor in the event path.

## Tests/Validation Run
- `npm install --ignore-scripts` to install local test/build dependencies in the issue worktree.
- `npx mocha --require @babel/register --reporter dot test/unit/config/event-delegator.spec.js` - passed, 3 tests.
- `npx eslint config/event-delegator.js test/unit/config/event-delegator.spec.js` - passed.
- `npm run build` - passed; Rollup reported the existing circular dependency warning.
- `npx mocha --config ./test/.mocharc.json --reporter dot test/unit/config/event-delegator.spec.js` - blocked before tests by the existing Node 24 harness issue: `Cannot set property navigator of #<Object> which has only a getter` in `test/setup/node.js`.

## Docs Impact
- None.

## Scope Creep Check
- No package exports, dist build wiring, shim work, or broader event architecture changes.
- `dist/` was not committed because the local build also regenerated older artifact drift from already-merged runtime fixes outside #53.

## Follow-Up Issues
- Fix the Node 24 Mocha setup so the repo-configured unit command can run without bypassing `test/setup/node.js`.
- Reconcile generated `dist/` artifacts in a dedicated artifact-sync/release-prep change if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delegated event handling in `EventDelegator` by ignoring text-node targets and stopping at the first matching ancestor. Prevents errors and avoids duplicate handler calls.

- **Bug Fixes**
  - Only match selectors on element nodes (`node.nodeType === 1`) before calling `node.matches`.
  - Break ancestor traversal after the first match so a delegated handler fires once per event.
  - Documented the behavior change in `changelog.md`.

<sup>Written for commit 52ae87df6ed1bf1f04a66adc0ee7b2c35d7aa8ca. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/94?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event delegation internals for more reliable handler invocation and safer matching.

* **Bug Fix**
  * Fixed delegated event matching so nested matching elements trigger handlers exactly once; capture-phase focus delegation now behaves correctly.

* **Tests**
  * Added unit tests covering text-node targets, nested element delegation, and capture-phase events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->