### PR TITLE
fix(backbone): stop shim namespace pollution

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -2,11 +2,9 @@ import { extend } from 'underscore';
 import Backbone from 'backbone';
 import { Events } from './index.js';
 
-extend(Backbone, Events);
 extend(Backbone.Model.prototype, Events);
 extend(Backbone.Collection.prototype, Events);
 extend(Backbone.View.prototype, Events);
 extend(Backbone.Router.prototype, Events);
-extend(Backbone.History.prototype, Events);
 
 export default Backbone;

--- a/dist/backbone.cjs
+++ b/dist/backbone.cjs
@@ -8,11 +8,9 @@ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'defau
 
 var Backbone__default = /*#__PURE__*/_interopDefaultLegacy(Backbone);
 
-underscore.extend(Backbone__default['default'], marionette.Events);
 underscore.extend(Backbone__default['default'].Model.prototype, marionette.Events);
 underscore.extend(Backbone__default['default'].Collection.prototype, marionette.Events);
 underscore.extend(Backbone__default['default'].View.prototype, marionette.Events);
 underscore.extend(Backbone__default['default'].Router.prototype, marionette.Events);
-underscore.extend(Backbone__default['default'].History.prototype, marionette.Events);
 
 module.exports = Backbone__default['default'];

--- a/dist/backbone.js
+++ b/dist/backbone.js
@@ -3,9 +3,7 @@ import Backbone from 'backbone';
 export { default } from 'backbone';
 import { Events } from 'marionette';
 
-extend(Backbone, Events);
 extend(Backbone.Model.prototype, Events);
 extend(Backbone.Collection.prototype, Events);
 extend(Backbone.View.prototype, Events);
 extend(Backbone.Router.prototype, Events);
-extend(Backbone.History.prototype, Events);

--- a/test/unit/backbone-shim.spec.js
+++ b/test/unit/backbone-shim.spec.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+
+describe('Backbone shim', function() {
+  let Backbone;
+  let ShimmedBackbone;
+  let historyMethods;
+  let namespaceMethods;
+  let previousDocument;
+  let previousWindow;
+
+  before(function() {
+    previousDocument = global.document;
+    previousWindow = global.window;
+
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+
+    Backbone = require('backbone');
+    Backbone.$ = require('jquery');
+
+    namespaceMethods = {
+      on: Backbone.on,
+      off: Backbone.off,
+      trigger: Backbone.trigger,
+      triggerMethod: Backbone.triggerMethod,
+      bindEvents: Backbone.bindEvents,
+      stopListening: Backbone.stopListening
+    };
+    historyMethods = {
+      triggerMethod: Backbone.History.prototype.triggerMethod
+    };
+
+    ShimmedBackbone = require('../../backbone').default;
+  });
+
+  after(function() {
+    global.document = previousDocument;
+    global.window = previousWindow;
+  });
+
+  it('does not mix Marionette Events into the Backbone namespace', function() {
+    expect(ShimmedBackbone).to.equal(Backbone);
+
+    expect(Backbone.on).to.equal(namespaceMethods.on);
+    expect(Backbone.off).to.equal(namespaceMethods.off);
+    expect(Backbone.trigger).to.equal(namespaceMethods.trigger);
+    expect(Backbone.triggerMethod).to.equal(namespaceMethods.triggerMethod);
+    expect(Backbone.bindEvents).to.equal(namespaceMethods.bindEvents);
+    expect(Backbone.stopListening).to.equal(namespaceMethods.stopListening);
+  });
+
+  it('does not mix Marionette Events into Backbone.History', function() {
+    expect(Backbone.History.prototype.triggerMethod).to.equal(historyMethods.triggerMethod);
+  });
+
+  it('mixes Marionette Events into supported Backbone instances', function() {
+    [
+      new Backbone.Model(),
+      new Backbone.Collection(),
+      new Backbone.View(),
+      new Backbone.Router()
+    ].forEach(instance => {
+      let callCount = 0;
+
+      expect(instance.triggerMethod).to.be.a('function');
+      instance.on('shim:test', function() {
+        callCount += 1;
+      });
+      instance.triggerMethod('shim:test');
+      expect(callCount).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #55

## Summary
- Remove Marionette Events mixing from the Backbone namespace object.
- Limit shim prototype patching to Backbone Model, Collection, View, and Router prototypes.
- Update built Backbone shim artifacts and add focused shim interop regressions.

## Public Behavior Boundary
- Explicit shim imports still patch supported Backbone model, collection, view, and router instances.
- No package exports, sideEffects, dependency metadata, or build configuration changes.

## Allowed Behavior Changes
- The shim no longer introduces or replaces namespace-level Backbone event methods such as `Backbone.on`, `Backbone.trigger`, or `Backbone.triggerMethod`.
- `Backbone.History.prototype` is no longer patched by the shim; the intended supported prototypes remain Model, Collection, View, and Router.

## Tests/Validation Run
- `npm install --ignore-scripts` to install local test/build dependencies in the issue worktree.
- `npx mocha --require @babel/register --reporter dot test/unit/backbone-shim.spec.js` - passed, 3 tests.
- `npx eslint backbone.js test/unit/backbone-shim.spec.js` - passed.
- `npm run build` - passed; Rollup reported the existing circular dependency warning.
- Built shim smoke with `node` requiring `./dist/backbone.cjs` - passed.
- `npx mocha --config ./test/.mocharc.json --reporter dot test/unit/backbone-shim.spec.js` - blocked before tests by the existing Node 24 harness issue: `Cannot set property navigator of #<Object> which has only a getter` in `test/setup/node.js`.

## Docs Impact
- None.

## Scope Creep Check
- Did not change package exports, sideEffects, dependency metadata, or build configuration.
- Restored unrelated main `dist/marionette*` regeneration from the local build; only `dist/backbone.*` is included with the shim source change.

## Follow-Up Issues
- Fix the Node 24 Mocha setup so repo-configured unit runs no longer fail before loading tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes namespace pollution in the Backbone shim by removing `Events` from the `Backbone` object and `Backbone.History`, while keeping mixins on `Model`, `Collection`, `View`, and `Router` prototypes. Adds focused tests and rebuilds the shim artifacts. Closes #55.

- **Bug Fixes**
  - Stop mixing `Events` into the `Backbone` namespace; do not patch `Backbone.History.prototype`.
  - Limit shim to `Backbone.Model`, `Backbone.Collection`, `Backbone.View`, `Backbone.Router` prototypes; add unit tests and update `dist/backbone.*`.

<sup>Written for commit a5e57519115aa8b1cc11ac4a4e869211ca3c77d0. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/95?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated event handling implementation for Model, Collection, View, and Router components to optimize extension behavior.

* **Tests**
  * Added unit tests to verify correct event handling and `triggerMethod` behavior across Backbone components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->