### PR TITLE
docs(upgrade): document jquery el migration

### DIFF
--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -32,3 +32,25 @@ Todo
 - `Region` continues to accept selector strings. That API is Marionette-native
   (the Region abstraction has always been "where to mount"), not inherited from
   Backbone, so it is preserved.
+
+## jQuery `$el` compatibility
+
+- v5 core does not create `view.$el`. If an app still has view code that expects
+  a jQuery-wrapped element, set it in your own view layer instead of configuring
+  Marionette globally.
+- For example, a legacy app can define a local base view:
+
+  ```js
+  import $ from 'jquery';
+  import { View } from 'marionette';
+
+  const LegacyView = View.extend({
+    initialize() {
+      this.$el = $(this.el);
+    }
+  });
+  ```
+
+- If the same view calls `setElement`, update `$el` in that app-specific override
+  as well. New v5 code should prefer `view.el`, `view.$(selector)`, and native DOM
+  APIs.


### PR DESCRIPTION
Related #58

## What
- Documents that Marionette v5 core does not create `view.$el`.
- Shows a local, app-owned `initialize` pattern for legacy code that still needs a jQuery-wrapped element.
- Points new v5 code toward `view.el`, `view.$(selector)`, and native DOM APIs.

## Why
- We do not want to ship a jQuery DomApi adapter that makes new Marionette feel coupled to old jQuery behavior.
- Apps that need `$el` can own that compatibility locally without expanding Marionette runtime surface area.

## Scope
- Upgrade guide only.
- No runtime, package, export, dependency, build, or dist changes.

## Deployment Impact
- Documentation-only change. No package redeploy behavior changes beyond normal docs publishing.

## Testing
- `git diff --check` - passed.
- No test suite run; documentation-only change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document that `Marionette v5` no longer creates `view.$el`. Show how to set `$el` locally for legacy `jQuery` code and recommend `view.el`, `view.$(selector)`, and native DOM APIs for new code.

- **Migration**
  - Core no longer sets `view.$el`.
  - For legacy views, create a local base view and set `this.$el = $(this.el)` in `initialize`; also update it in a `setElement` override.
  - Keep compatibility local; do not add a global `jQuery` adapter.

<sup>Written for commit d4f63d2aa252251748a0e303e29bf4645051b6fd. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/100?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive upgrade guide section on jQuery `$el` compatibility in Marionette v5, covering automatic property removal, legacy compatibility strategies, implementation examples, and best practices for modern development approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->