### PR TITLE
feat(dom): add jquery domapi adapter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### v5.0.0-alpha.2
 
+* Added optional `marionette/jquery-dom-api` adapter for jQuery-backed DomApi
+  operations without restoring `$el`
 * Fixed Radio circular dependency with log and debug
 * Fixed event interop with Backbone
 * Fixed delegated event matching so nested matching ancestors fire once per event

--- a/dist/jquery-dom-api.cjs
+++ b/dist/jquery-dom-api.cjs
@@ -1,0 +1,40 @@
+'use strict';
+
+var $ = require('jquery');
+
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var $__default = /*#__PURE__*/_interopDefaultLegacy($);
+
+var jqueryDomApi = {
+  // Finds the `selector` string within the el
+  // Returns a jQuery collection
+  findEl(el, selector) {
+    return $__default['default'](el).find(selector);
+  },
+
+  // Detach `el` from the DOM without removing listeners
+  detachEl(el) {
+    $__default['default'](el).detach();
+  },
+
+  // Replace the contents of `el` with the `html`
+  setContents(el, html) {
+    $__default['default'](el).html(html);
+  },
+
+  // Takes the DOM node `el` and appends the DOM node `contents`
+  // to the end of the element's contents.
+  appendContents(el, contents) {
+    $__default['default'](el).append(contents);
+  },
+
+  // Remove the inner contents of `el` from the DOM while leaving
+  // `el` itself in the DOM.
+  detachContents(el) {
+    $__default['default'](el).contents().detach();
+  }
+
+};
+
+module.exports = jqueryDomApi;

--- a/dist/jquery-dom-api.d.ts
+++ b/dist/jquery-dom-api.d.ts
@@ -1,0 +1,9 @@
+declare const JQueryDomApi: {
+  findEl(el: Element | Document, selector: string): any;
+  detachEl(el: Element): void;
+  setContents(el: Element, html: string): void;
+  appendContents(el: Element | DocumentFragment, contents: Element | DocumentFragment | string): void;
+  detachContents(el: Element): void;
+};
+
+export default JQueryDomApi;

--- a/dist/jquery-dom-api.js
+++ b/dist/jquery-dom-api.js
@@ -1,0 +1,34 @@
+import $ from 'jquery';
+
+var jqueryDomApi = {
+  // Finds the `selector` string within the el
+  // Returns a jQuery collection
+  findEl(el, selector) {
+    return $(el).find(selector);
+  },
+
+  // Detach `el` from the DOM without removing listeners
+  detachEl(el) {
+    $(el).detach();
+  },
+
+  // Replace the contents of `el` with the `html`
+  setContents(el, html) {
+    $(el).html(html);
+  },
+
+  // Takes the DOM node `el` and appends the DOM node `contents`
+  // to the end of the element's contents.
+  appendContents(el, contents) {
+    $(el).append(contents);
+  },
+
+  // Remove the inner contents of `el` from the DOM while leaving
+  // `el` itself in the DOM.
+  detachContents(el) {
+    $(el).contents().detach();
+  }
+
+};
+
+export default jqueryDomApi;

--- a/jquery-dom-api.js
+++ b/jquery-dom-api.js
@@ -1,0 +1,31 @@
+import $ from 'jquery';
+
+export default {
+  // Finds the `selector` string within the el
+  // Returns a jQuery collection
+  findEl(el, selector) {
+    return $(el).find(selector);
+  },
+
+  // Detach `el` from the DOM without removing listeners
+  detachEl(el) {
+    $(el).detach();
+  },
+
+  // Replace the contents of `el` with the `html`
+  setContents(el, html) {
+    $(el).html(html);
+  },
+
+  // Takes the DOM node `el` and appends the DOM node `contents`
+  // to the end of the element's contents.
+  appendContents(el, contents) {
+    $(el).append(contents);
+  },
+
+  // Remove the inner contents of `el` from the DOM while leaving
+  // `el` itself in the DOM.
+  detachContents(el) {
+    $(el).contents().detach();
+  }
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
       "require": "./dist/backbone.cjs",
       "default": "./dist/backbone.js"
     },
+    "./jquery-dom-api": {
+      "types": "./dist/jquery-dom-api.d.ts",
+      "import": "./dist/jquery-dom-api.js",
+      "require": "./dist/jquery-dom-api.cjs",
+      "default": "./dist/jquery-dom-api.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -79,10 +85,14 @@
   "github": "https://github.com/marionettejs/marionette",
   "peerDependencies": {
     "backbone": "^1.4.0",
+    "jquery": "^3.5.0",
     "underscore": "^1.13.0"
   },
   "peerDependenciesMeta": {
     "backbone": {
+      "optional": true
+    },
+    "jquery": {
       "optional": true
     }
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import { terser } from 'rollup-plugin-terser';
 
 const globals = {
   underscore: '_',
+  jquery: '$',
 };
 
 const shimExternal = ['underscore', 'backbone', 'marionette'];
@@ -96,6 +97,25 @@ export default [
     ],
     plugins: [
       shimMainExternal,
+      eslint({ exclude: ['node_modules/**', './version.js'] }),
+      babel({ babelHelpers: 'bundled' }),
+    ]
+  },
+  {
+    input: 'jquery-dom-api.js',
+    external: ['jquery'],
+    output: [
+      {
+        file: 'dist/jquery-dom-api.js',
+        format: 'es',
+      },
+      {
+        file: 'dist/jquery-dom-api.cjs',
+        format: 'cjs',
+        exports: 'default',
+      },
+    ],
+    plugins: [
       eslint({ exclude: ['node_modules/**', './version.js'] }),
       babel({ babelHelpers: 'bundled' }),
     ]

--- a/test/setup/jquery-dom-api.js
+++ b/test/setup/jquery-dom-api.js
@@ -12,11 +12,10 @@ global.sinon = sinon;
 if (!global.document || !global.window) {
   const dom = new JSDOM(`
     <html>
-      <head><script></script></head>
+      <head></head>
       <body></body>
     </html>
   `, {
-    runScripts: 'dangerously',
     url: 'http://localhost'
   });
 

--- a/test/setup/jquery-dom-api.js
+++ b/test/setup/jquery-dom-api.js
@@ -1,0 +1,38 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const JSDOM = require('jsdom').JSDOM;
+
+chai.use(sinonChai);
+
+global.chai = chai;
+global.expect = chai.expect;
+global.sinon = sinon;
+
+if (!global.document || !global.window) {
+  const dom = new JSDOM(`
+    <html>
+      <head><script></script></head>
+      <body></body>
+    </html>
+  `, {
+    runScripts: 'dangerously',
+    url: 'http://localhost'
+  });
+
+  global.window = dom.window;
+  global.document = global.window.document;
+  Object.defineProperty(global, 'navigator', {
+    configurable: true,
+    value: global.window.navigator
+  });
+}
+
+beforeEach(function() {
+  this.sinon = global.sinon.createSandbox();
+});
+
+afterEach(function() {
+  this.sinon.restore();
+  document.body.innerHTML = '';
+});

--- a/test/unit/jquery-dom-api.spec.js
+++ b/test/unit/jquery-dom-api.spec.js
@@ -91,6 +91,45 @@ describe('jQuery DomApi adapter', function() {
     expect(view).to.not.have.property('$el');
   });
 
+  it('detaches elements without removing listeners with the jQuery DomApi', function() {
+    const parent = document.createElement('div');
+    const child = document.createElement('button');
+    const onClick = this.sinon.stub();
+    child.addEventListener('click', onClick);
+    parent.appendChild(child);
+    document.body.appendChild(parent);
+
+    JQueryDomApi.detachEl(child);
+    child.click();
+
+    expect(parent.childNodes).to.have.length(0);
+    expect(document.body.contains(child)).to.be.false;
+    expect(onClick).to.have.been.calledOnce;
+  });
+
+  it('replaces element contents with the jQuery DomApi', function() {
+    const el = document.createElement('div');
+    const oldChild = document.createElement('span');
+    oldChild.className = 'old';
+    el.appendChild(oldChild);
+
+    JQueryDomApi.setContents(el, '<strong class="new">New</strong>');
+
+    expect(el.querySelector('.old')).to.be.null;
+    expect(el.querySelector('.new').textContent).to.equal('New');
+  });
+
+  it('appends contents with the jQuery DomApi', function() {
+    const el = document.createElement('div');
+    const child = document.createElement('span');
+    child.className = 'child';
+
+    JQueryDomApi.appendContents(el, child);
+
+    expect(el.childNodes).to.have.length(1);
+    expect(el.firstChild).to.equal(child);
+  });
+
   it('preserves detached content listeners with the jQuery DomApi', function() {
     const el = document.createElement('div');
     const child = document.createElement('button');
@@ -112,8 +151,8 @@ describe('jQuery DomApi adapter', function() {
     const JQueryRegion = Region.extend();
     JQueryRegion.setDomApi(JQueryDomApi);
 
-    const region = new JQueryRegion({ el: root });
-    region._setElement('#region-root');
+    const region = new JQueryRegion({ el: '#region-root' });
+    region.empty();
 
     expect(region.el).to.equal(root);
   });

--- a/test/unit/jquery-dom-api.spec.js
+++ b/test/unit/jquery-dom-api.spec.js
@@ -1,0 +1,120 @@
+import { execFileSync } from 'child_process';
+import $ from 'jquery';
+import {
+  CollectionView,
+  DomApi,
+  Region,
+  View
+} from '../../index';
+import JQueryDomApi from '../../jquery-dom-api';
+
+describe('jQuery DomApi adapter', function() {
+  it('allows core Marionette to require without importing jQuery', function() {
+    const script = `
+      require('@babel/register');
+      const Module = require('module');
+      const load = Module._load;
+      Module._load = function(request) {
+        if (request === 'jquery') {
+          throw new Error('jquery should not be imported');
+        }
+        return load.apply(this, arguments);
+      };
+      require('./index');
+    `;
+
+    expect(() => execFileSync(process.execPath, ['-e', script], { cwd: process.cwd() }))
+      .to.not.throw();
+  });
+
+  it('allows the core ESM graph to bundle without importing jQuery', function() {
+    const bundler = require('rollup');
+    const jqueryBlocker = {
+      name: 'jquery-blocker',
+      resolveId(source) {
+        if (source === 'jquery') {
+          throw new Error('jquery should not be imported');
+        }
+
+        return null;
+      }
+    };
+
+    return bundler.rollup({
+      input: 'index.js',
+      external: ['underscore'],
+      plugins: [jqueryBlocker]
+    });
+  });
+
+  it('does not create $el with the native DomApi', function() {
+    const view = new View();
+    const collectionView = new CollectionView();
+
+    expect(DomApi.wrapEl).to.be.undefined;
+    expect(view).to.not.have.property('$el');
+    expect(collectionView).to.not.have.property('$el');
+  });
+
+  it('does not provide wrapEl on the jQuery DomApi adapter', function() {
+    expect(JQueryDomApi.wrapEl).to.be.undefined;
+  });
+
+  it('returns native results from view.$() with the native DomApi', function() {
+    const view = new View({
+      el: document.createElement('div')
+    });
+    const child = document.createElement('span');
+    child.className = 'child';
+    view.el.appendChild(child);
+
+    const result = view.$('.child');
+
+    expect(result).to.be.instanceof(window.NodeList);
+    expect(result[0]).to.equal(child);
+  });
+
+  it('returns a jQuery collection from view.$() with the jQuery DomApi', function() {
+    const JQueryView = View.extend();
+    JQueryView.setDomApi(JQueryDomApi);
+    const view = new JQueryView({
+      el: document.createElement('div')
+    });
+    const child = document.createElement('span');
+    child.className = 'child';
+    view.el.appendChild(child);
+
+    const result = view.$('.child');
+
+    expect(result).to.be.instanceof($);
+    expect(result[0]).to.equal(child);
+    expect(view).to.not.have.property('$el');
+  });
+
+  it('preserves detached content listeners with the jQuery DomApi', function() {
+    const el = document.createElement('div');
+    const child = document.createElement('button');
+    const onClick = this.sinon.stub();
+    child.addEventListener('click', onClick);
+    el.appendChild(child);
+
+    JQueryDomApi.detachContents(el);
+    child.click();
+
+    expect(el.childNodes).to.have.length(0);
+    expect(onClick).to.have.been.calledOnce;
+  });
+
+  it('allows Region selector resolution with the jQuery DomApi findEl shape', function() {
+    const root = document.createElement('div');
+    root.id = 'region-root';
+    document.body.appendChild(root);
+    const JQueryRegion = Region.extend();
+    JQueryRegion.setDomApi(JQueryDomApi);
+
+    const region = new JQueryRegion({ el: root });
+    region._setElement('#region-root');
+
+    expect(region.el).to.equal(root);
+  });
+});

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -32,3 +32,32 @@ Todo
 - `Region` continues to accept selector strings. That API is Marionette-native
   (the Region abstraction has always been "where to mount"), not inherited from
   Backbone, so it is preserved.
+
+## jQuery DOM compatibility
+
+- v5 core does not depend on jQuery and does not create `view.$el`.
+- Apps that want Marionette DOM operations such as `view.$(selector)` to return
+  jQuery collections can opt into the `marionette/jquery-dom-api` adapter:
+
+  ```js
+  import { setDomApi } from 'marionette';
+  import JQueryDomApi from 'marionette/jquery-dom-api';
+
+  setDomApi(JQueryDomApi);
+  ```
+
+- The adapter imports `jquery`, so jQuery is an optional peer dependency only for
+  consumers that opt into this subpath.
+- The adapter intentionally does not add `$el`. If legacy app code still expects
+  `view.$el`, set it in your own view layer:
+
+  ```js
+  import $ from 'jquery';
+  import { View } from 'marionette';
+
+  const LegacyView = View.extend({
+    initialize() {
+      this.$el = $(this.el);
+    }
+  });
+  ```


### PR DESCRIPTION
Closes #58

## Summary
- Adds an optional `marionette/jquery-dom-api` adapter that imports `jquery` and implements jQuery-backed DomApi methods for `findEl`, `detachEl`, `setContents`, `appendContents`, and `detachContents`.
- Exposes the adapter through package exports and builds ESM/CJS/type artifacts under `dist/`.
- Documents that the adapter intentionally does not restore `view.$el`; legacy apps can set `$el` in their own view layer if needed.

## Public Behavior Boundary
- Core Marionette remains jQuery-free and does not import `jquery` from the main entry.
- The adapter does not export `wrapEl` and does not change View, CollectionView, or Behavior `$el` behavior.
- View and CollectionView remain element-only; selector-string `el` resolution is not restored.
- Region selector-string `el` support remains and is covered against the adapter `findEl` return shape.
- No `setJQuery($)`, global `$`/`jQuery` auto-detection, default namespace export, `Mn.Object`, or `Object` alias was added.

## Allowed Behavior Changes
- Consumers can opt into jQuery-shaped results for DomApi operations such as `view.$(selector)` by installing jQuery and using `marionette/jquery-dom-api` with `setDomApi`.
- `$el` remains app-owned compatibility code, not Marionette runtime surface.

## Package / Export Impact
- Adds `./jquery-dom-api` to `package.json#exports` with `types`, `import`, and `require` entries.
- Adds `dist/jquery-dom-api.js`, `dist/jquery-dom-api.cjs`, and `dist/jquery-dom-api.d.ts`.
- Keeps `jquery` external in the adapter bundle.
- `npm run build` was run; existing main dist bundle drift from `master` was not included because this PR does not change core runtime source.

## Optional Peer Dependency Impact
- Adds `jquery` as an optional peer dependency because only the adapter subpath imports it.
- The main Marionette import and core ESM graph continue to work without jQuery.

## Validation
- `./node_modules/.bin/mocha --require @babel/register --file ./test/setup/jquery-dom-api.js ./test/unit/jquery-dom-api.spec.js` - 11 passing.
- `npm run build` - passed; emitted adapter ESM/CJS bundles. Existing Browserslist stale-data and circular-dependency notices still appear.
- `npm pack --dry-run` - passed; confirmed `dist/jquery-dom-api.js`, `dist/jquery-dom-api.cjs`, and `dist/jquery-dom-api.d.ts` are included.
- CJS probe against `dist/jquery-dom-api.cjs` - passed and confirmed `wrapEl` is undefined.
- `git diff --check` - passed.

## Docs Impact
- Adds changelog and upgrade guide notes for the optional jQuery DomApi adapter and the app-owned `$el` migration path.

## Scope Creep Check
- Did not modify `logs/`.
- Did not modify View, CollectionView, or Behavior runtime code.
- Did not add `wrapEl` or restore `$el` support in Marionette.
- Did not rework IE/Node support from PR #90.
- Did not restore default namespace exports or removed object aliases from #59.

## Follow-Up Issues
- If the in-place CollectionView reorder work from `marionettejs/backbone.marionette#3732` is ported to v5, add the resulting `DomApi.insertContents(parent, child, beforeNode)` primitive to `marionette/jquery-dom-api` in the same change so the adapter continues to track the full DomApi surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional jQuery-backed DomApi adapter so apps can get jQuery results from Marionette DOM helpers without adding `jquery` to core or restoring `$el`. Adds tests to verify core stays jQuery-free and the adapter’s behavior.

- **New Features**
  - Added `marionette/jquery-dom-api` using `jquery` for `findEl`, `detachEl`, `setContents`, `appendContents`, and `detachContents`.
  - Opt-in via `setDomApi(...)` so `view.$(selector)` returns a jQuery collection; no `wrapEl` or `view.$el`. View/CollectionView still require element `el`; Region selector strings still work.
  - Exported ESM/CJS/types under `dist/`; added Rollup target; `jquery` stays external and is an optional peer dependency.
  - Added unit tests covering adapter methods and confirming the core `marionette` import and ESM bundle do not import `jquery`.

<sup>Written for commit bd6a2a7a95df6682172b65cef1fbb68abce369b9. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/101?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional jQuery-backed DOM adapter to support jQuery-based DOM operations for compatibility.

* **Documentation**
  * Added jQuery DOM compatibility guidance to the upgrade guide and noted the adapter in the changelog.

* **Build / Packaging**
  * Packaged the adapter for distribution and marked jQuery as an optional peer dependency.

* **Tests**
  * Added unit tests validating adapter behavior and DOM operation semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
