### PR TITLE
fix(test): define navigator in node setup

### DIFF
--- a/test/setup/node.js
+++ b/test/setup/node.js
@@ -26,7 +26,10 @@ if (!global.document || !global.window) {
 
   global.window = dom.window;
   global.document = global.window.document;
-  global.navigator = global.window.navigator;
+  Object.defineProperty(global, 'navigator', {
+    configurable: true,
+    value: global.window.navigator
+  });
 
 }
 require('./setup')();


### PR DESCRIPTION
Closes #63

## Summary
- Update `test/setup/node.js` to define `global.navigator` with `Object.defineProperty(..., { configurable: true })` instead of assigning directly.
- Keep the existing jsdom-backed `window` and `document` setup unchanged.
- No runtime source, runner migration, or broad test import changes.

## Public Behavior Boundary
- Test setup only.
- No Marionette runtime APIs or package exports changed.
- No Mocha-to-Vitest migration.
- No unit-suite `src/` import repath work.

## Validation Commands and Results
- `npx mocha --config ./test/.mocharc.json`
  - Result: no longer fails with `Cannot set property navigator of #<Object> which has only a getter`.
  - Remaining blocker: setup now stops at `Error: Cannot find module 'backbone.radio'` from `test/setup/setup.js`.
- `npx mocha --require @babel/register --file ./test/setup/jquery-dom-api.js ./test/unit/jquery-dom-api.spec.js`
  - Result: passed, `11 passing`.
- `git diff --check`
  - Result: passed.

## Remaining Test Failures
- `test/setup/setup.js` still requires `backbone.radio`, which is not installed in the current dependency set. That is separate from the modern Node getter-only `navigator` failure fixed here.
- Broader unit-suite execution still depends on later test harness/import cleanup work tracked outside this issue.

## Scope Creep Check
- No changes under `logs/`.
- No runtime source changes.
- No dependency changes.
- No test runner migration.
- No broad unit test import repath.

## Follow-up Issues
- Resolve the missing `backbone.radio` test setup dependency or update the affected radio tests as part of the broader v5 test migration work.
- Continue unit-suite import path cleanup under #64 and runner migration under #65.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Node test setup by defining `global.navigator` with `Object.defineProperty` (configurable) from jsdom’s `window.navigator`. This removes the "Cannot set property navigator..." error in modern Node while keeping the existing `window`/`document` setup unchanged and making no runtime or dependency changes.

<sup>Written for commit 1b5be3694c1b445db01c7f9ea908f9488f3ac480. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/105?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test environment setup configuration.

**Note:** No user-facing changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->