### PR TITLE
docs(dom): document detachContents policy

### DIFF
--- a/docs/dom.api.md
+++ b/docs/dom.api.md
@@ -70,6 +70,14 @@ Returns a boolean indicating if the `el` has child nodes.
 Remove the inner contents of `el` from the DOM while leaving `el` itself in the
 DOM.
 
+The default native implementation clears via `el.textContent = ''`. It is
+fast and jQuery-free. Apps that depend on v4's jQuery detach semantics
+(`$(el).contents().detach()`) — for example, apps that detach-then-reinsert
+children externally and rely on jQuery's handler/data bookkeeping surviving
+that cycle — can opt into the optional jQuery DomApi adapter at app boot via
+`setDomApi(JQueryDomApi)` from `marionette/jquery-dom-api`. See the
+[upgrade guide](../upgradeGuide.md) for the migration entry.
+
 ## The default API
 
 The API used by Marionette by default is attached as `Marionette.DomApi`.

--- a/test/unit/region-detach-contents.spec.js
+++ b/test/unit/region-detach-contents.spec.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { JSDOM } from 'jsdom';
+
+import Region from '../../modules/region';
+
+// Locks the v5 native `detachContents` policy: `Region.empty()` clears the
+// region element when no view is shown. The contrasting jQuery DomApi behavior
+// is covered by `test/unit/jquery-dom-api.spec.js`
+// ("preserves detached content listeners with the jQuery DomApi"). Together
+// these tests document the v5 policy: native default clears via
+// `el.textContent = ''`; the optional jQuery adapter calls
+// `$(el).contents().detach()` for v4-compatible detach-for-reinsertion
+// semantics.
+
+describe('Region.empty() with the native DomApi', function() {
+  let document;
+  let previousDocument;
+  let previousWindow;
+
+  beforeEach(function() {
+    previousDocument = global.document;
+    previousWindow = global.window;
+
+    const dom = new JSDOM('<!doctype html><html><body><div id="region"></div></body></html>');
+    document = dom.window.document;
+    global.document = document;
+    global.window = dom.window;
+  });
+
+  afterEach(function() {
+    global.document = previousDocument;
+    global.window = previousWindow;
+  });
+
+  it('clears the region element contents when no view is shown', function() {
+    const root = document.getElementById('region');
+    root.appendChild(document.createElement('span'));
+    root.appendChild(document.createTextNode('inner'));
+
+    const region = new Region({ el: root });
+    region.empty();
+
+    expect(root.childNodes).to.have.length(0);
+    expect(root.textContent).to.equal('');
+  });
+});

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -61,3 +61,32 @@ Todo
     }
   });
   ```
+
+## `detachContents` policy
+
+- The default native DomApi `detachContents(el)` clears the element via
+  `el.textContent = ''`. Children are removed from `el` and Marionette no
+  longer holds references to them.
+- v4 used jQuery's `$(el).contents().detach()`, which is jQuery's documented
+  detach-for-reinsertion path. It removes children from `el` while preserving
+  jQuery's internal handler/data bookkeeping on those elements.
+- For most apps the user-visible difference is small — `Region.empty()`
+  discards the detached content in both cases, and DOM event listeners
+  attached via `addEventListener` remain on referenced child elements either
+  way. The difference matters for apps that detach-then-reinsert children
+  externally and rely on jQuery's `.on()` handlers, `.data()` cache, or other
+  jQuery-internal element bookkeeping surviving that cycle.
+- Legacy code that depends on the v4 jQuery semantics can opt into the
+  optional jQuery DomApi adapter at app boot:
+
+  ```js
+  import { setDomApi } from 'marionette';
+  import JQueryDomApi from 'marionette/jquery-dom-api';
+
+  setDomApi(JQueryDomApi);
+  ```
+
+  The adapter's `detachContents(el)` calls `$(el).contents().detach()`,
+  matching the v4 behavior.
+
+- The native default is also described in [docs/dom.api.md](docs/dom.api.md).


### PR DESCRIPTION
Closes #61

## Summary
- Documents the v5 native `detachContents(el)` behavior (`el.textContent = ''`) and the contrasting v4 jQuery semantics (`$(el).contents().detach()`).
- Points apps that depend on v4-style detach-for-reinsertion semantics at the optional `marionette/jquery-dom-api` adapter at app boot.
- Adds a focused native-baseline test confirming `Region.empty()` clears the region element when no view is shown.

## Public Behavior Boundary
- Core Marionette remains jQuery-free; no jQuery import is added on the main entry.
- Native `detachContents` continues to clear via `el.textContent = ''`. No behavior change.
- The optional jQuery DomApi adapter is unchanged. Adapter `detachContents(el)` continues to call `$(el).contents().detach()`.
- No View, CollectionView, Behavior, or Region runtime change.

## Allowed Behavior Changes
- None at runtime. This is a documentation + targeted-test change.

## Docs Impact
- `upgradeGuide.md`: new "`detachContents` policy" section. Documents the native default, contrasts with v4 jQuery semantics, and shows the `setDomApi(JQueryDomApi)` opt-in for apps that need the v4 behavior. The framing is deliberately measured — for typical apps the user-visible difference is small (DOM event listeners attached via `addEventListener` are preserved on referenced child elements either way). The difference matters specifically for apps that detach-then-reinsert children externally and rely on jQuery's `.on()` handlers, `.data()` cache, or other jQuery-internal bookkeeping surviving that cycle.
- `docs/dom.api.md`: expanded the `detachContents(el)` entry with the native default behavior and a pointer to the upgrade-guide entry.

## Tests/Validation Run
- `npx mocha --require @babel/register --reporter spec test/unit/region-detach-contents.spec.js` — 1 passing.
- `npx mocha --require @babel/register --file ./test/setup/jquery-dom-api.js test/unit/jquery-dom-api.spec.js test/unit/region-detach-contents.spec.js` — 12 passing (the existing jQuery DomApi spec at `test/unit/jquery-dom-api.spec.js` already covers "preserves detached content listeners with the jQuery DomApi"; no new jQuery-side test was needed).
- `npx eslint test/unit/region-detach-contents.spec.js` — clean.
- `npm run build` — passed; the existing Rollup circular-dependency warning is unchanged.
- `rg "detachContents|jquery-dom-api|setDomApi" upgradeGuide.md docs/` — confirms the policy is documented in both `upgradeGuide.md` and `docs/dom.api.md` and cross-linked.

## Scope Creep Check
- No `logs/` changes.
- No native DomApi behavior change; native `detachContents` is unchanged.
- No jQuery import from the main entry; `marionette/jquery-dom-api` adapter unchanged.
- No new runtime architecture.
- No reopening of #59 (default namespace / `Mn.Object` / `Object` alias).
- Did not commit regenerated `dist/marionette*` or `dist/jquery-dom-api*` bundles.

## Follow-Up Issues
- None identified for issue #61. (Full Region/View DOM contract coverage remains scoped to #72 as expected.)

## Honesty Note on Doc Framing
While drafting, I initially framed the native `textContent = ''` path as "drops DOM event listeners attached to children." That's not accurate — listeners attached via `addEventListener` remain on the child element object across removal (verified with a small JSDOM repro). The committed text reflects the more accurate picture: the practical user-visible difference between native and jQuery `detachContents` is narrow for typical apps; the meaningful gap is in jQuery-specific internal bookkeeping. The adapter remains the documented opt-in for apps that depend on that bookkeeping.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the v5 `detachContents(el)` policy (native clear via `el.textContent = ''`) and contrasts it with v4’s jQuery `$(el).contents().detach()`, with migration guidance to opt into `marionette/jquery-dom-api` via `setDomApi(JQueryDomApi)` for apps that rely on v4 behavior. Adds a focused test confirming `Region.empty()` clears the region element; no runtime changes.

<sup>Written for commit 3b0e9d1f9e3c69e7f37876fd77f40b5f94865b26. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated DOM API documentation clarifying element content clearing behavior.
  * Added upgrade guide section detailing content removal changes with optional backward-compatible adapter option.

* **Tests**
  * Added unit tests validating element clearing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->