### PR TITLE
test(unit): repath specs from src

### DIFF
--- a/test/setup/setup.js
+++ b/test/setup/setup.js
@@ -15,18 +15,14 @@ module.exports = function() {
   // eslint-disable-next-line
   console.log('Using ' + lib + ': ' + _.VERSION);
 
-  const Backbone = require('backbone');
   const jQuery = require('jquery');
-  Backbone.$ = jQuery;
-  Backbone.Radio = require('backbone.radio');
-  let Marionette = require('../../src/backbone.marionette');
+  const Backbone = require('backbone');
+  const Marionette = require('../../index.js');
 
-  Marionette = 'default' in Marionette ? Marionette.default : Marionette;
-
-  global.$ = global.jQuery = jQuery;
   global._ = _;
   global.Backbone = Backbone;
-  global.Marionette = Backbone.Marionette = Marionette;
+  global.Marionette = Marionette;
+  global.Radio = Marionette.Radio;
 
   global.expect = global.chai.expect;
 
@@ -43,8 +39,8 @@ module.exports = function() {
   }
 
   before(function() {
-    $fixtures = $('<div id="fixtures">');
-    $('body').append($fixtures);
+    $fixtures = jQuery('<div id="fixtures">');
+    jQuery('body').append($fixtures);
     this.setFixtures = setFixtures;
     this.clearFixtures = clearFixtures;
   });

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -1,8 +1,8 @@
 'use strict';
 
 import _ from 'underscore';
-import Application from '../../src/application';
-import View from '../../src/view';
+import Application from '../../modules/application';
+import View from '../../modules/view';
 
 describe('Marionette Application', function() {
 

--- a/test/unit/backbone.marionette.spec.js
+++ b/test/unit/backbone.marionette.spec.js
@@ -1,29 +1,28 @@
 import _ from 'underscore';
 
-import * as Mn from '../../src/backbone.marionette';
-import Marionette from '../../src/backbone.marionette';
+import * as Mn from '../../index.js';
 
 import {version} from '../../package.json';
 
-import extend from '../../src/utils/extend';
+import extend from '../../utils/extend';
 
-import monitorViewEvents from '../../src/common/monitor-view-events';
+import monitorViewEvents from '../../modules/common/monitor-view-events';
 
-import Events from '../../src/mixins/events';
+import Events from '../../mixins/events';
 
-import MnObject from '../../src/object';
-import View from '../../src/view';
-import CollectionView from '../../src/collection-view';
-import Behavior from '../../src/behavior';
-import Region from '../../src/region';
-import Application from '../../src/application';
+import MnObject from '../../modules/object';
+import View from '../../modules/view';
+import CollectionView from '../../modules/collection-view';
+import Behavior from '../../modules/behavior';
+import Region from '../../modules/region';
+import Application from '../../modules/application';
 
-import DomApi from '../../src/config/dom';
+import DomApi from '../../config/dom';
 
 import {
   isEnabled,
   setEnabled
-} from '../../src/config/features';
+} from '../../config/features';
 
 
 describe('backbone.marionette', function() {
@@ -47,33 +46,6 @@ describe('backbone.marionette', function() {
       it(`should have named export ${ key }`, function() {
         expect(Mn[key]).to.equal(val);
       });
-    });
-  });
-
-  describe('Default Export', function() {
-    const namedExports = {
-      View,
-      CollectionView,
-      MnObject,
-      Region,
-      Behavior,
-      Application,
-      isEnabled,
-      setEnabled,
-      monitorViewEvents,
-      Events,
-      extend,
-      DomApi,
-    };
-
-    _.each(namedExports, (val, key) => {
-      it(`should have key ${ key }`, function() {
-        expect(Marionette[key]).to.equal(val);
-      });
-    });
-
-    it('should have key Object', function() {
-      expect(Marionette.Object).to.equal(MnObject);
     });
   });
 

--- a/test/unit/behavior.spec.js
+++ b/test/unit/behavior.spec.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
-import Behavior from '../../src/behavior';
-import Region from '../../src/region';
-import View from '../../src/view';
-import CollectionView from '../../src/collection-view';
-import { bindEvents } from '../../src/backbone.marionette';
+import Behavior from '../../modules/behavior';
+import Region from '../../modules/region';
+import View from '../../modules/view';
+import CollectionView from '../../modules/collection-view';
+import { bindEvents } from '../../index.js';
 
 describe('Behavior', function() {
   describe('when instantiating a behavior with some options', function() {

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import ChildViewContainer from '../../src/child-view-container';
+import ChildViewContainer from '../../modules/child-view-container';
 
 describe('#ChildViewContainer', function() {
 

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -3,10 +3,10 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import ChildViewContainer from '../../../src/child-view-container';
-import View from '../../../src/view';
-import Region from '../../../src/region';
+import CollectionView from '../../../modules/collection-view';
+import ChildViewContainer from '../../../modules/child-view-container';
+import View from '../../../modules/view';
+import Region from '../../../modules/region';
 
 
 describe('CollectionView Children', function() {

--- a/test/unit/collection-view/collection-view-childviewcontainer.sepc.js
+++ b/test/unit/collection-view/collection-view-childviewcontainer.sepc.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
 
 describe('CollectionView - childViewContainer', function() {
   let MyCollectionView;

--- a/test/unit/collection-view/collection-view-data.spec.js
+++ b/test/unit/collection-view/collection-view-data.spec.js
@@ -3,8 +3,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
 
 describe('CollectionView Data', function() {
   let MyCollectionView;

--- a/test/unit/collection-view/collection-view-empty.spec.js
+++ b/test/unit/collection-view/collection-view-empty.spec.js
@@ -2,10 +2,10 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
-import Region from '../../../src/region';
-import Events from '../../../src/mixins/events';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
+import Region from '../../../modules/region';
+import Events from '../../../mixins/events';
 
 describe('CollectionView -  Empty', function() {
   let MyEmptyView;

--- a/test/unit/collection-view/collection-view-filtering.spec.js
+++ b/test/unit/collection-view/collection-view-filtering.spec.js
@@ -2,9 +2,9 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import Region from '../../../src/region';
-import View from '../../../src/view';
+import CollectionView from '../../../modules/collection-view';
+import Region from '../../../modules/region';
+import View from '../../../modules/view';
 
 function renderModels(models) {
   return _.map(models, model => `<li>${ model.get('num') }</li>`);

--- a/test/unit/collection-view/collection-view-sorting.spec.js
+++ b/test/unit/collection-view/collection-view-sorting.spec.js
@@ -2,8 +2,8 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
 
 describe('CollectionView - Sorting', function() {
   let collection;

--- a/test/unit/collection-view/collection-view-viewmixin.spec.js
+++ b/test/unit/collection-view/collection-view-viewmixin.spec.js
@@ -2,8 +2,8 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
 
 describe('CollectionView - ViewMixin', function() {
 

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -3,9 +3,9 @@
 import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
-import Events from '../../../src/mixins/events';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
+import Events from '../../../mixins/events';
 
 describe('CollectionView', function() {
   let MyChildView;

--- a/test/unit/common/bind-events.spec.js
+++ b/test/unit/common/bind-events.spec.js
@@ -1,4 +1,4 @@
-import { bindEvents, unbindEvents } from '../../../src/common/bind-events';
+import { bindEvents, unbindEvents } from '../../../modules/common/bind-events';
 
 describe('bind-events', function() {
   let entity;

--- a/test/unit/common/bind-request.spec.js
+++ b/test/unit/common/bind-request.spec.js
@@ -1,4 +1,4 @@
-import { bindRequests, unbindRequests } from '../../../src/common/bind-requests';
+import { bindRequests, unbindRequests } from '../../../modules/common/bind-requests';
 
 describe('bind-requests', function() {
   let channel;

--- a/test/unit/common/build-region.spec.js
+++ b/test/unit/common/build-region.spec.js
@@ -1,5 +1,5 @@
-import View from '../../../src/view';
-import Region from '../../../src/region';
+import View from '../../../modules/view';
+import Region from '../../../modules/region';
 
 describe('Region', function() {
   describe('.buildRegion', function() {

--- a/test/unit/common/get-option.spec.js
+++ b/test/unit/common/get-option.spec.js
@@ -1,4 +1,4 @@
-import getOption from '../../../src/common/get-option';
+import getOption from '../../../modules/common/get-option';
 
 describe('get option', function() {
   describe('when calling without arguments', function() {

--- a/test/unit/common/merge-options.spec.js
+++ b/test/unit/common/merge-options.spec.js
@@ -1,4 +1,4 @@
-import mergeOptions from '../../../src/common/merge-options';
+import mergeOptions from '../../../modules/common/merge-options';
 
 describe('mergeOptions', function() {
   let target;

--- a/test/unit/common/monitor-view-events.js
+++ b/test/unit/common/monitor-view-events.js
@@ -1,5 +1,5 @@
-import View from '../../../src/view';
-import monitorViewEvents from '../../../src/common/monitor-view-events';
+import View from '../../../modules/view';
+import monitorViewEvents from '../../../modules/common/monitor-view-events';
 
 describe('monitorViewEvents', function() {
   describe('when the monitor is disabled', function() {

--- a/test/unit/common/normalize-methods.spec.js
+++ b/test/unit/common/normalize-methods.spec.js
@@ -1,4 +1,4 @@
-import View from '../../../src/view';
+import View from '../../../modules/view';
 
 describe('normalizeMethods', function() {
   'use strict';

--- a/test/unit/common/trigger-method.spec.js
+++ b/test/unit/common/trigger-method.spec.js
@@ -1,4 +1,4 @@
-import triggerMethod from '../../../src/common/trigger-method';
+import triggerMethod from '../../../modules/common/trigger-method';
 
 describe('triggerMethod', function() {
   let target;

--- a/test/unit/common/view.spec.js
+++ b/test/unit/common/view.spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import { renderView, destroyView } from '../../../src/common/view';
+import { renderView, destroyView } from '../../../modules/common/view';
 
 describe('common view methods', function() {
   let view;

--- a/test/unit/config/dom.js
+++ b/test/unit/config/dom.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import _ from 'underscore';
-import DomApi, { setDomApi } from '../../../src/config/dom';
+import DomApi, { setDomApi } from '../../../config/dom';
 
 // Copied from https://github.com/jashkenas/underscore/blob/1.8.3/underscore.js#L137
 const MAX_ARRAY_INDEX = Math.pow(2, 53) - 1;

--- a/test/unit/config/features.spec.js
+++ b/test/unit/config/features.spec.js
@@ -1,4 +1,4 @@
-import { setEnabled, isEnabled } from '../../../src/config/features';
+import { setEnabled, isEnabled } from '../../../config/features';
 
 describe('features', function() {
   it('enabled when its present and true', function() {

--- a/test/unit/config/renderer.spec.js
+++ b/test/unit/config/renderer.spec.js
@@ -1,4 +1,4 @@
-import { setRenderer } from '../../../src/config/renderer';
+import { setRenderer } from '../../../config/renderer';
 
 describe('#setRenderer', function() {
   let MyObject;

--- a/test/unit/destroying-views.spec.js
+++ b/test/unit/destroying-views.spec.js
@@ -1,4 +1,4 @@
-import View from '../../src/view';
+import View from '../../modules/view';
 
 
 describe('destroying views', function() {

--- a/test/unit/get-immediate-children.spec.js
+++ b/test/unit/get-immediate-children.spec.js
@@ -1,4 +1,4 @@
-import View from '../../src/view';
+import View from '../../modules/view';
 
 describe('_getImmediateChildren', function() {
   let BaseView;

--- a/test/unit/mixins/behaviors.spec.js
+++ b/test/unit/mixins/behaviors.spec.js
@@ -2,8 +2,8 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-import BehaviorsMixin from '../../../src/mixins/behaviors';
-import Behavior from '../../../src/behavior';
+import BehaviorsMixin from '../../../mixins/behaviors';
+import Behavior from '../../../modules/behavior';
 
 describe('Behaviors Mixin', function() {
   let Behaviors;

--- a/test/unit/mixins/common.spec.js
+++ b/test/unit/mixins/common.spec.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import CommonMixin from '../../../src/mixins/common';
+import CommonMixin from '../../../mixins/common';
 
 describe('Common Mixin', function() {
   describe('#setOptions', function() {

--- a/test/unit/mixins/delegate-entity-events.spec.js
+++ b/test/unit/mixins/delegate-entity-events.spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import DelegateEntityEventsMixin from '../../../src/mixins/delegate-entity-events';
+import DelegateEntityEventsMixin from '../../../mixins/delegate-entity-events';
 
 describe('delegate entity events mixin', function() {
   let obj;

--- a/test/unit/mixins/destroy.spec.js
+++ b/test/unit/mixins/destroy.spec.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import DestroyMixin from '../../../src/mixins/destroy';
+import DestroyMixin from '../../../mixins/destroy';
 
 describe('Destroy Mixin', function() {
   let obj;

--- a/test/unit/mixins/radio.spec.js
+++ b/test/unit/mixins/radio.spec.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
-import Backbone from 'backbone';
-import Radio from 'backbone.radio';
-import RadioMixin from '../../../src/mixins/radio';
+import Events from '../../../mixins/events';
+import Radio from '../../../modules/radio';
+import RadioMixin from '../../../mixins/radio';
 
 describe('Radio Mixin on Marionette.Object', function() {
   let radioObject;
@@ -15,7 +15,7 @@ describe('Radio Mixin on Marionette.Object', function() {
       },
       bindEvents: this.sinon.stub(),
       bindRequests: this.sinon.stub(),
-    }, Backbone.Events, RadioMixin);
+    }, Events, RadioMixin);
 
     channelFoo = Radio.channel('foo');
   });

--- a/test/unit/mixins/template-render.spec.js
+++ b/test/unit/mixins/template-render.spec.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import TemplateRenderMixin from '../../../src/mixins/template-render';
+import TemplateRenderMixin from '../../../mixins/template-render';
 
 describe('template-render', function() {
   let renderer;

--- a/test/unit/mixins/ui.spec.js
+++ b/test/unit/mixins/ui.spec.js
@@ -1,4 +1,4 @@
-import View from '../../../src/view';
+import View from '../../../modules/view';
 
 describe('normalizeUIKeys', function() {
   'use strict';

--- a/test/unit/mixins/view.spec.js
+++ b/test/unit/mixins/view.spec.js
@@ -1,6 +1,6 @@
-import { setEnabled } from '../../../src/backbone.marionette';
-import CollectionView from '../../../src/collection-view';
-import View from '../../../src/view';
+import { setEnabled } from '../../../index.js';
+import CollectionView from '../../../modules/collection-view';
+import View from '../../../modules/view';
 
 describe('view mixin', function() {
   'use strict';

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -1,4 +1,4 @@
-import MnObject from '../../src/object';
+import MnObject from '../../modules/object';
 
 describe('marionette object', function() {
 

--- a/test/unit/on-attach.spec.js
+++ b/test/unit/on-attach.spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
-import View from '../../src/view';
-import Region from '../../src/region';
+import View from '../../modules/view';
+import Region from '../../modules/region';
 
 describe('onAttach', function() {
   const expectTriggerMethod = (method, target, retval, before = null) => {

--- a/test/unit/on-dom-refresh.spec.js
+++ b/test/unit/on-dom-refresh.spec.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import Events from '../../src/mixins/events';
-import View from '../../src/view';
-import Region from '../../src/region';
+import Events from '../../mixins/events';
+import View from '../../modules/view';
+import Region from '../../modules/region';
 
 describe('onDomRefresh', function() {
   'use strict';

--- a/test/unit/on-dom-remove.spec.js
+++ b/test/unit/on-dom-remove.spec.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import Events from '../../src/mixins/events';
-import View from '../../src/view';
-import Region from '../../src/region';
+import Events from '../../mixins/events';
+import View from '../../modules/view';
+import Region from '../../modules/region';
 
 describe('onDomRemove', function() {
   'use strict';

--- a/test/unit/region.spec.js
+++ b/test/unit/region.spec.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import Events from '../../src/mixins/events';
-import Region from '../../src/region';
-import View from '../../src/view';
-import CollectionView from '../../src/collection-view';
+import Events from '../../mixins/events';
+import Region from '../../modules/region';
+import View from '../../modules/view';
+import CollectionView from '../../modules/collection-view';
 
 describe('region', function() {
   'use strict';

--- a/test/unit/utils/deprecate.spec.js
+++ b/test/unit/utils/deprecate.spec.js
@@ -1,6 +1,6 @@
-import deprecate from '../../../src/utils/deprecate';
+import deprecate from '../../../utils/deprecate';
 
-import {setEnabled} from '../../../src/config/features';
+import {setEnabled} from '../../../config/features';
 
 describe('deprecate', function() {
   beforeEach(function() {

--- a/test/unit/utils/error.spec.js
+++ b/test/unit/utils/error.spec.js
@@ -1,5 +1,5 @@
-import { VERSION } from '../../../src/backbone.marionette';
-import MarionetteError from '../../../src/utils/error';
+import { VERSION } from '../../../index.js';
+import MarionetteError from '../../../utils/error';
 
 describe('MarionetteError', function() {
   it('should be subclass of native Error', function() {

--- a/test/unit/utils/get-namespaced-event-name.spec.js
+++ b/test/unit/utils/get-namespaced-event-name.spec.js
@@ -1,7 +1,0 @@
-import getNamespacedEventName from '../../../src/utils/get-namespaced-event-name';
-
-describe('getNamespacedEventName', function() {
-  it('should postfix a namespace to the event', function() {
-    expect(getNamespacedEventName('click a.name', 'test')).to.equal('click.test a.name');
-  });
-});

--- a/test/unit/utils/proxy.spec.js
+++ b/test/unit/utils/proxy.spec.js
@@ -1,4 +1,4 @@
-import proxy from '../../../src/utils/proxy';
+import proxy from '../../../utils/proxy';
 
 describe('proxy', function() {
   let method;

--- a/test/unit/view.child-views.spec.js
+++ b/test/unit/view.child-views.spec.js
@@ -7,7 +7,7 @@ describe('layoutView', function() {
       return '<span class=".craft"></span><h1 id="#a-fun-game"></h1>';
     };
 
-    this.View = Backbone.Marionette.View.extend({
+    this.View = Marionette.View.extend({
       template: this.layoutViewManagerTemplateFn,
       regions: {
         regionOne: '#regionOne',
@@ -28,7 +28,7 @@ describe('layoutView', function() {
 
     this.CustomRegion1 = function() {};
 
-    this.CustomRegion2 = Backbone.Marionette.Region.extend();
+    this.CustomRegion2 = Marionette.Region.extend();
 
     this.ViewNoDefaultRegion = this.View.extend({
       regions: {
@@ -114,7 +114,7 @@ describe('layoutView', function() {
 
     it('should instantiate marionette regions is no regionClass is specified', function() {
       let layoutViewManagerNoDefault = new this.ViewNoDefaultRegion();
-      expect(layoutViewManagerNoDefault.getRegion('regionTwo')).to.be.instanceof(Backbone.Marionette.Region);
+      expect(layoutViewManagerNoDefault.getRegion('regionTwo')).to.be.instanceof(Marionette.Region);
     });
 
     it('should pass extra options to the custom regionClass', function() {
@@ -140,7 +140,7 @@ describe('layoutView', function() {
     });
 
     it('should build the regions from the returns object literal', function() {
-      expect(this.layoutView.getRegion('regionOne')).to.be.instanceof(Backbone.Marionette.Region);
+      expect(this.layoutView.getRegion('regionOne')).to.be.instanceof(Marionette.Region);
     });
   });
 
@@ -356,7 +356,7 @@ describe('layoutView', function() {
         suite.regionOne._ensureElement();
       };
 
-      this.region = new Backbone.Marionette.Region({
+      this.region = new Marionette.Region({
         el: '#mgr'
       });
 
@@ -526,12 +526,12 @@ describe('layoutView', function() {
         }
       };
 
-      this.layoutView = new Backbone.Marionette.View({
+      this.layoutView = new Marionette.View({
         template: this.template,
         regions: this.regionOptions
       });
 
-      this.layoutView2 = new Backbone.Marionette.View({
+      this.layoutView2 = new Marionette.View({
         template: this.template,
         regions: function() {
           return suite.regionOptions;
@@ -556,7 +556,7 @@ describe('layoutView', function() {
 
   describe('when defining region selectors using @ui. syntax', function() {
     beforeEach(function() {
-      let UIView = Backbone.Marionette.View.extend({
+      let UIView = Marionette.View.extend({
         template: this.template,
         regions: {
           war: '@ui.war',
@@ -617,7 +617,7 @@ describe('layoutView', function() {
         this.setFixtures(fixture);
         this.layout.render();
         this.regions = this.layout.getRegions();
-        this.View = Backbone.Marionette.View.extend({
+        this.View = Marionette.View.extend({
           el: '.region-hash-no-template-spec .some-layout-view',
           template: _.noop,
           regions: {

--- a/test/unit/view.renderer.js
+++ b/test/unit/view.renderer.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
-import View from '../../src/view';
+import View from '../../modules/view';
 
 describe('View.setRenderer', function() {
   let ViewClass;

--- a/test/unit/view.spec.js
+++ b/test/unit/view.spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
-import Region from '../../src/region';
-import View from '../../src/view';
+import Region from '../../modules/region';
+import View from '../../modules/view';
 
 describe('item view', function() {
   'use strict';

--- a/test/unit/view.triggers.spec.js
+++ b/test/unit/view.triggers.spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
-import { setEnabled } from '../../src/config/features';
-import View from '../../src/view';
+import { setEnabled } from '../../config/features';
+import View from '../../modules/view';
 
 describe('view triggers', function() {
   'use strict';


### PR DESCRIPTION
Closes #64

## Summary
- Repath stale unit-spec imports from removed `src/` paths to the current v5 module layout (`modules/`, `mixins/`, `config/`, `utils/`, and `index.js`).
- Update shared test setup to load Marionette from `index.js` and use the built-in `Radio` export instead of `backbone.radio`.
- Remove stale default-export / `Object` alias assertions and the removed `get-namespaced-event-name` utility spec.

## Public Behavior Boundary
- Test-suite repair only.
- No runtime source changes.
- No dependency changes; `backbone.radio` is not added back.
- No Mocha-to-Vitest migration.
- No coverage threshold work.

## Test Setup Changes
- `test/setup/setup.js` now requires `../../index.js` instead of `../../src/backbone.marionette`.
- Removed `Backbone.$ = jQuery` and `Backbone.Radio = require('backbone.radio')` setup coupling.
- Exposes `global.Radio = Marionette.Radio` for legacy tests that still need the current built-in Radio object.
- Fixture setup keeps jQuery local to the helper instead of installing global `$` / `jQuery`.

## Removed / Rewritten Stale Tests
- Removed the default export and `Object` alias assertions from `backbone.marionette.spec.js`; those APIs are intentionally not restored in v5.
- Rewrote `mixins/radio.spec.js` from `backbone.radio` / `Backbone.Events` to the v5 built-in `modules/radio` and `mixins/events`.
- Rewrote `view.child-views.spec.js` references from `Backbone.Marionette.*` to `Marionette.*`.
- Deleted `test/unit/utils/get-namespaced-event-name.spec.js`; that removed utility is not part of the v5 module surface.

## Validation Commands and Results
- `rg "\\.\\./\\.\\./src|\\.\\./\\.\\./\\.\\./src" test/`
  - Result: no matches.
- `rg "backbone\\.radio|Backbone\\.Radio|Backbone\\.\\$|Backbone\\.Marionette|global\\.\\$|global\\.jQuery" test/setup test/unit`
  - Result: no matches.
- `npx mocha --config ./test/.mocharc.json --reporter json`
  - Result: suite loads and runs: `776 passing`, `140 failing`, `868 tests`.
  - Exit status is nonzero because stale behavioral assertions still fail.
- `git diff --check`
  - Result: passed.

## Remaining Failures
- This issue / stale test repair: remaining old tests still assume v4 jQuery-shaped surfaces such as `$el`, jQuery `.find()`, `.trigger()`, and chai-jq HTML helpers.
- Stale tests for removed APIs: some tests still assert View/CollectionView selector-string `el`, Backbone.View inheritance, `delegateEvents`, `_removeElement`, and direct Behavior construction without a host view.
- Potential runtime follow-up: failures around native attach/detach assertions may need review once stale jQuery and removed-API expectations are separated.
- #65 Vitest migration: not addressed here.

## Scope Creep Check
- No changes under `logs/`.
- No runtime source changes.
- No `backbone.radio` dependency added.
- No global Backbone/jQuery behavior restored to satisfy stale tests.
- No test runner migration.

## Follow-up Issues
- Continue stale jQuery/Backbone assertion cleanup in follow-up test repair work.
- Migrate the test runner under #65.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repaired the v5 unit test suite by repathing imports from removed `src/` to the current module layout and updating the shared setup to load `index.js` with the built‑in `Radio`. No runtime or dependency changes.

- **Refactors**
  - Repathed tests to `modules/`, `mixins/`, `config/`, `utils/`, and `index.js`.
  - Updated test setup to require `../../index.js`, stop installing global `$`/`jQuery`, and expose `global.Radio = Marionette.Radio`.
  - Replaced `backbone.radio` and `Backbone.Events` usage with built-in `modules/radio` and `mixins/events`.
  - Removed default-export/Object alias assertions and deleted the removed `utils/get-namespaced-event-name.spec.js`.
  - Suite loads; remaining failures come from stale v4 jQuery expectations and removed APIs.

<sup>Written for commit 25088cf5726c2a6210626af82505c7ce672b657b. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/107?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Restructured test imports to align with the new module organization across all unit tests.
* Updated test environment setup configuration for proper library wiring.
* Consolidated test references to use new entry points.
* Removed a deprecated utility test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->