### PR TITLE
docs(installation): align with v5 package name and peers

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,20 +7,121 @@ While some integrations are listed here, more resources are available in the int
 
 ## Documentation Index
 
+* [Install](#install)
+* [Peer dependencies](#peer-dependencies)
+* [Quick start](#quick-start)
+* [Backbone is optional](#backbone-is-optional)
+* [jQuery DOM adapter is optional](#jquery-dom-adapter-is-optional)
 * [NPM and Webpack](#quick-start-using-npm-and-webpack)
 * [NPM and Brunch](#quick-start-using-npm-and-brunch)
 * [NPM and Browserify](#quick-start-using-npm-and-browserify)
 * [Browserify and Grunt](#browserify-and-grunt)
 * [Browserify and Gulp](#browserify-and-gulp)
-* [Backbone is optional](#backbone-is-optional)
 * [Getting Started](./basics.md)
+
+## Install
+
+The v5 package name is `marionette`.
+
+```
+npm install marionette
+```
+
+> The v4 package name has changed. See the [upgrade guide](../upgradeGuide.md)
+> for migration guidance from earlier releases.
+
+## Peer dependencies
+
+Marionette v5 declares the following peer dependencies. Only Underscore is
+required; the rest are optional.
+
+| Peer | Required? | When you need it |
+|---|---|---|
+| `underscore` `>= 1.13` | Required | Always. Marionette publishes named ESM imports from `underscore`, and versions before 1.13 are CJS-only with no package `exports` map, so modern Node and bundler ESM resolution cannot satisfy the imports. |
+| `backbone` `^1.4.0` | Optional | Only if your app uses Backbone models/collections, or imports the bundled `marionette/backbone` shim. See [Backbone is optional](#backbone-is-optional). |
+| `jquery` `^3.5.0` | Optional | Only if your app uses the `marionette/jquery-dom-api` adapter. See [jQuery DOM adapter is optional](#jquery-dom-adapter-is-optional). |
+
+Install the required peer alongside Marionette:
+
+```
+npm install marionette underscore
+```
+
+Optional peers are installed only when you opt into them:
+
+```
+# Only if you use Backbone models/collections or the bundled shim
+npm install backbone
+
+# Only if you use the jQuery DomApi adapter
+npm install jquery
+```
+
+## Quick start
+
+Marionette v5 exposes its public API through named ESM imports. There is no
+default-namespace export; use named imports only.
+
+```js
+import { Application, View, Region } from 'marionette';
+
+const RootView = View.extend({
+  template: () => '<div>Hello, Marionette.</div>'
+});
+
+const app = new Application({
+  region: document.getElementById('app'),
+  onStart() {
+    this.showView(new RootView());
+  }
+});
+
+app.start();
+```
+
+`View` and `CollectionView` accept a DOM element for `el`. They do not resolve
+selector strings — pass `document.querySelector('#root')` at the call site. See
+the [upgrade guide](../upgradeGuide.md) for the migration entry. `Region` continues
+to accept selector strings.
+
+## Backbone is optional
+
+Starting with v5, Marionette core does not depend on Backbone at runtime. Backbone is one valid implementation of the model and collection contracts Marionette consumes; any object that satisfies those contracts works equally well. Applications that want the v4-style Backbone integration can opt in with a side-effect import of the bundled shim:
+
+```javascript
+import 'marionette/backbone';
+```
+
+See [Optional Backbone](./optional-backbone.md) for the model/collection protocol and a small non-Backbone adapter example.
+
+## jQuery DOM adapter is optional
+
+Marionette v5 core is jQuery-free. The default DOM API uses native browser
+methods, and `view.$(selector)` returns a `NodeList`.
+
+Applications that want jQuery-shaped results from Marionette's DOM helpers —
+for example, `view.$(selector)` returning a jQuery collection — can opt into
+the optional `marionette/jquery-dom-api` adapter at app boot:
+
+```javascript
+import { setDomApi } from 'marionette';
+import JQueryDomApi from 'marionette/jquery-dom-api';
+
+setDomApi(JQueryDomApi);
+```
+
+The adapter imports `jquery`, so `jquery` is only required when you install the
+adapter. The adapter intentionally does not restore `view.$el`; legacy apps
+that still depend on `$el` should set it in their own view layer. See the
+[upgrade guide](../upgradeGuide.md) for the migration entries on jQuery DOM
+compatibility and the `detachContents` policy.
 
 ## Quick start using NPM and Webpack
 [NPM](https://www.npmjs.com/) is the package manager for JavaScript.
 
 Installing with NPM through command-line interface
 ```
-npm install backbone.marionette
+npm install marionette
 ```
 
 [Webpack][webpack] is a build tool that makes it easy to pull your dependencies
@@ -64,16 +165,6 @@ we prepared simple marionettejs skeleton with Browserify.
 [brunch]: http://brunch.io/
 [grunt]: http://gruntjs.com/
 [gulp]: http://gulpjs.com/
-
-## Backbone is optional
-
-Starting with v5, Marionette core does not depend on Backbone at runtime. Backbone is one valid implementation of the model and collection contracts Marionette consumes; any object that satisfies those contracts works equally well. Applications that want the v4-style Backbone integration can opt in with a side-effect import of the bundled shim:
-
-```javascript
-import 'marionette/backbone';
-```
-
-See [Optional Backbone](./optional-backbone.md) for the model/collection protocol and a small non-Backbone adapter example.
 
 ## Getting Started
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ While some integrations are listed here, more resources are available in the int
 
 The v5 package name is `marionette`.
 
-```
+```bash
 npm install marionette
 ```
 
@@ -37,19 +37,19 @@ required; the rest are optional.
 
 | Peer | Required? | When you need it |
 |---|---|---|
-| `underscore` `>= 1.13` | Required | Always. Marionette publishes named ESM imports from `underscore`, and versions before 1.13 are CJS-only with no package `exports` map, so modern Node and bundler ESM resolution cannot satisfy the imports. |
+| `underscore` `^1.13.0` | Required | Always. Marionette publishes named ESM imports from `underscore`, and versions before 1.13 are CJS-only with no package `exports` map, so modern Node and bundler ESM resolution cannot satisfy the imports. |
 | `backbone` `^1.4.0` | Optional | Only if your app uses Backbone models/collections, or imports the bundled `marionette/backbone` shim. See [Backbone is optional](#backbone-is-optional). |
 | `jquery` `^3.5.0` | Optional | Only if your app uses the `marionette/jquery-dom-api` adapter. See [jQuery DOM adapter is optional](#jquery-dom-adapter-is-optional). |
 
 Install the required peer alongside Marionette:
 
-```
+```bash
 npm install marionette underscore
 ```
 
 Optional peers are installed only when you opt into them:
 
-```
+```bash
 # Only if you use Backbone models/collections or the bundled shim
 npm install backbone
 
@@ -120,7 +120,7 @@ compatibility and the `detachContents` policy.
 [NPM](https://www.npmjs.com/) is the package manager for JavaScript.
 
 Installing with NPM through command-line interface
-```
+```bash
 npm install marionette
 ```
 


### PR DESCRIPTION
Closes #79

## Summary
- Renames install instructions in `docs/installation.md` to use the v5 package name `marionette`.
- Adds an explicit peer-dependencies table: `underscore >= 1.13` required; `backbone` and `jquery` optional.
- Adds a Quick start section that uses named ESM imports and explicitly states there is no default-namespace export.
- Adds a "jQuery DOM adapter is optional" section documenting the `marionette/jquery-dom-api` adapter and the `setDomApi(JQueryDomApi)` opt-in.
- Drops migration framing about the v4 package name from this page; points to the upgrade guide for v4 -> v5 migration.

## Public Behavior Boundary
- Documentation-only change. No runtime source code is modified.
- No test files modified.
- No `logs/` modifications.
- No package metadata changes (peer-dep versions and package name in this PR mirror what is already published in `package.json`).

## Docs Impact
- `docs/installation.md`:
  - Reordered/expanded documentation index.
  - New "Install" section with the `npm install marionette` command and a pointer to the upgrade guide for migration framing.
  - New "Peer dependencies" section with a required/optional table and example commands.
  - New "Quick start" section using `import { Application, View, Region } from 'marionette';`. Notes the View / CollectionView element-only contract and Region's preserved selector-string `el`.
  - Existing "Backbone is optional" section is preserved verbatim.
  - New "jQuery DOM adapter is optional" section.
  - The existing Webpack / Brunch / Browserify / Grunt / Gulp sections are left in place; the only edit within them is the install command (`npm install backbone.marionette` -> `npm install marionette`).

## Validation Commands and Results
- `rg "backbone\.marionette|Backbone\.Marionette|import Mn from|Mn\.Object" docs/installation.md` — no matches (stale guidance gone).
- `rg "npm install marionette|underscore|jquery-dom-api|setDomApi" docs/installation.md` — 9 matches, covering the `npm install marionette` line in the new "Install" section and within the Webpack quickstart, the `underscore` row of the peer-dependencies table, the `jquery` row referencing `marionette/jquery-dom-api`, the `marionette underscore` install example, the optional `jquery` install example, the adapter section's adapter import and `setDomApi(JQueryDomApi)` call, and the closing pointer back at the adapter section.
- No tests added or changed; this is a docs-only PR.
- No build run; this PR doesn't change build inputs.

## Scope Creep Check
- No `logs/` modifications.
- No runtime source modifications. No test modifications.
- Did not broaden into a full migration guide rewrite (that belongs to #75).
- Did not sweep `readme.md` or other docs (that belongs to #81).
- Did not restore a default-namespace export, `Mn.Object`, or any aliasing — consistent with #59 closed as not planned.
- Did not document selector-string `el` for View or CollectionView. Region selector-string `el` is mentioned as preserved (which it is in v5).
- Did not commit regenerated `dist/` artifacts.

## Follow-Up Issues
- None identified for #79 itself.
- Related, intentionally not bundled here:
  - `readme.md` and the rest of `docs/` still carry v4-era wording in places — that's #81's sweep.
  - The full v4 -> v5 migration ledger lives in #74 / Issue 32; the install-page migration pointer assumes that ledger lands.
  - The integration-skeleton repos at `marionettejs/marionette-integrations` likely target v4. Updating or replacing those skeletons is out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns installation docs with v5: use `marionette` in install commands, add a peer-deps table (`underscore ^1.13.0` required; `backbone`/`jquery` optional), and add a named ESM quick start. Documents the optional `marionette/jquery-dom-api` adapter with `setDomApi(JQueryDomApi)`, links v4 migration to the upgrade guide, and tags CLI snippets as `bash`; docs-only, no runtime changes.

<sup>Written for commit 61ddddac48a9541350e52fb3a8c6ac2cd65ecc6f. Summary will update on new commits. <a href="https://cubic.dev/pr/marionettejs/marionette/pull/108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation docs for Marionette v5 with the correct package name and npm install instructions.
  * Restored and clarified the NPM/Webpack quick-start with named ESM import usage (no default export).
  * Clarified element/selector handling and peer-dependency guidance.
  * Reorganized content, removed a duplicated section, and added a documentation index for easier navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marionettejs/marionette/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->