### PR TITLE
test(package): add npm pack install fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Coverage
         run: npm run coverage
 
+      - name: Test package fixtures
+        run: npm run test:fixtures
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/package.json
+++ b/package.json
@@ -62,10 +62,11 @@
     "build": "rollup -c --noConflict",
     "coverage": "vitest run --coverage",
     "coveralls": "npm run coverage && cat coverage/lcov.info | coveralls",
-    "lint:base": "eslint backbone.js config/ index.js jquery-dom-api.js mixins/ modules/ test/setup/vitest.js test/unit/ utils/ vitest.config.js",
+    "lint:base": "eslint backbone.js config/ index.js jquery-dom-api.js mixins/ modules/ test/fixtures/ test/setup/vitest.js test/unit/ utils/ vitest.config.js",
     "lint": "npm run lint:base -- --fix",
     "lint:ci": "npm run lint:base -- --max-warnings=0",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:fixtures": "node test/fixtures/run.mjs"
   },
   "bugs": {
     "url": "https://github.com/marionettejs/marionette/issues"

--- a/test/fixtures/cjs-node/package.json
+++ b/test/fixtures/cjs-node/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "validate": "node validate.cjs"
+  },
+  "dependencies": {
+    "underscore": "^1.13.0"
+  }
+}

--- a/test/fixtures/cjs-node/validate.cjs
+++ b/test/fixtures/cjs-node/validate.cjs
@@ -1,0 +1,5 @@
+const assert = require('assert');
+const Mn = require('marionette');
+
+assert.strictEqual(typeof Mn.View, 'function');
+assert.strictEqual(typeof Mn.MnObject, 'function');

--- a/test/fixtures/esm-node/package.json
+++ b/test/fixtures/esm-node/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "underscore": "^1.13.0"
+  }
+}

--- a/test/fixtures/esm-node/validate.mjs
+++ b/test/fixtures/esm-node/validate.mjs
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import * as Mn from 'marionette';
+
+assert.strictEqual(typeof Mn.View, 'function');
+assert.strictEqual(typeof Mn.MnObject, 'function');
+assert.strictEqual(Object.prototype.hasOwnProperty.call(Mn, 'default'), false);

--- a/test/fixtures/jquery-dom-api/package.json
+++ b/test/fixtures/jquery-dom-api/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "jquery": "^3.5.0",
+    "jsdom": "^24.1.3",
+    "underscore": "^1.13.0"
+  }
+}

--- a/test/fixtures/jquery-dom-api/validate.mjs
+++ b/test/fixtures/jquery-dom-api/validate.mjs
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+
+const { View } = await import('marionette');
+const JQueryDomApi = (await import('marionette/jquery-dom-api')).default;
+const $ = (await import('jquery')).default;
+
+const JQueryView = View.extend();
+JQueryView.setDomApi(JQueryDomApi);
+
+const el = document.createElement('div');
+el.innerHTML = '<span class="child">child</span>';
+const view = new JQueryView({ el });
+const result = view.$('.child');
+
+assert.ok(result instanceof $);
+assert.strictEqual(result[0].textContent, 'child');
+assert.strictEqual(Object.prototype.hasOwnProperty.call(view, '$el'), false);

--- a/test/fixtures/no-default-export/package.json
+++ b/test/fixtures/no-default-export/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "underscore": "^1.13.0"
+  }
+}

--- a/test/fixtures/no-default-export/validate.mjs
+++ b/test/fixtures/no-default-export/validate.mjs
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { spawnSync } from 'child_process';
+
+const result = spawnSync(process.execPath, [
+  '--input-type=module',
+  '--eval',
+  'import Mn from "marionette"; console.log(Mn);',
+], {
+  cwd: process.cwd(),
+  encoding: 'utf8',
+});
+
+assert.notStrictEqual(result.status, 0);
+assert.match(result.stderr, /default|does not provide/i);

--- a/test/fixtures/peer-underscore-min/package.json
+++ b/test/fixtures/peer-underscore-min/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "underscore": "1.13.0"
+  }
+}

--- a/test/fixtures/peer-underscore-min/validate.mjs
+++ b/test/fixtures/peer-underscore-min/validate.mjs
@@ -1,0 +1,9 @@
+import assert from 'assert';
+import { createRequire } from 'module';
+import { View } from 'marionette';
+
+const require = createRequire(import.meta.url);
+const underscorePackage = require('underscore/package.json');
+
+assert.strictEqual(underscorePackage.version, '1.13.0');
+assert.strictEqual(typeof View, 'function');

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -1,0 +1,72 @@
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, '../..');
+const packDir = resolve(rootDir, 'test/tmp/pack-fixtures');
+const fixtures = [
+  'cjs-node',
+  'esm-node',
+  'no-default-export',
+  'shim',
+  'jquery-dom-api',
+  'vite',
+  'peer-underscore-min',
+];
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    cwd: options.cwd || rootDir,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      npm_config_fund: 'false',
+      npm_config_audit: 'false',
+      npm_config_package_lock: 'false',
+    },
+  });
+}
+
+function cleanFixture(fixtureDir) {
+  rmSync(resolve(fixtureDir, 'dist'), { force: true, recursive: true });
+  rmSync(resolve(fixtureDir, 'node_modules'), { force: true, recursive: true });
+  rmSync(resolve(fixtureDir, 'package-lock.json'), { force: true });
+}
+
+rmSync(packDir, { force: true, recursive: true });
+mkdirSync(packDir, { recursive: true });
+
+try {
+  run('npm', ['run', 'build']);
+  run('npm', ['pack', '--pack-destination', packDir]);
+
+  const packedTarballs = readdirSync(packDir)
+    .filter(fileName => fileName.endsWith('.tgz'));
+
+  if (packedTarballs.length !== 1) {
+    throw new Error(`Expected one packed tarball, found ${packedTarballs.length}`);
+  }
+
+  const tarballPath = resolve(packDir, packedTarballs[0]);
+
+  for (const fixtureName of fixtures) {
+    const fixtureDir = resolve(__dirname, fixtureName);
+
+    if (!existsSync(resolve(fixtureDir, 'package.json'))) {
+      throw new Error(`Fixture is missing package.json: ${fixtureName}`);
+    }
+
+    cleanFixture(fixtureDir);
+    try {
+      run('npm', ['install'], { cwd: fixtureDir });
+      run('npm', ['install', '--no-save', tarballPath], { cwd: fixtureDir });
+      run('npm', ['run', 'validate'], { cwd: fixtureDir });
+    } finally {
+      cleanFixture(fixtureDir);
+    }
+  }
+} finally {
+  rmSync(packDir, { force: true, recursive: true });
+}

--- a/test/fixtures/shim/package.json
+++ b/test/fixtures/shim/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "backbone": "^1.4.0",
+    "underscore": "^1.13.0"
+  }
+}

--- a/test/fixtures/shim/validate.mjs
+++ b/test/fixtures/shim/validate.mjs
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import Backbone from 'backbone';
+
+assert.strictEqual(Backbone.Model.prototype.triggerMethod, undefined);
+
+const ShimmedBackbone = (await import('marionette/backbone')).default;
+
+assert.strictEqual(ShimmedBackbone, Backbone);
+assert.strictEqual(typeof Backbone.Model.prototype.triggerMethod, 'function');
+
+let called = false;
+const model = new Backbone.Model();
+model.on('fixture:event', () => {
+  called = true;
+});
+model.triggerMethod('fixture:event');
+
+assert.strictEqual(called, true);

--- a/test/fixtures/vite/index.html
+++ b/test/fixtures/vite/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Marionette Vite Fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/test/fixtures/vite/package.json
+++ b/test/fixtures/vite/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "vite build"
+  },
+  "dependencies": {
+    "underscore": "^1.13.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/test/fixtures/vite/src/main.js
+++ b/test/fixtures/vite/src/main.js
@@ -1,0 +1,6 @@
+import { MnObject, View } from 'marionette';
+
+const view = new View();
+const object = new MnObject();
+
+document.getElementById('app').textContent = `${view.cid}:${object.cid}`;


### PR DESCRIPTION
Closes #67

## Summary
- Add isolated npm pack fixture projects for CJS, ESM, unsupported default import, Backbone shim, jQuery DomApi, Vite, and the minimum underscore peer.
- Add `npm run test:fixtures` to build, pack, install the tarball into each fixture, run each fixture validator, and clean generated fixture state.
- Run the package fixture command in CI after coverage.

## Public Behavior Boundary
- This PR validates published package behavior only. It does not change runtime source behavior or package exports.
- The default namespace import remains unsupported in v5.
- Backbone behavior is only patched through explicit `marionette/backbone` import.
- jQuery is only used by explicit `marionette/jquery-dom-api` import. The fixture validates the shipped adapter behavior: `view.$()` returns a jQuery collection while `$el` remains absent because the adapter does not provide `wrapEl`.

## Fixture List
- `test/fixtures/cjs-node`: `require("marionette")` exposes `View` and `MnObject`.
- `test/fixtures/esm-node`: `import * as Mn from "marionette"` exposes `View` and `MnObject`, with no default export.
- `test/fixtures/no-default-export`: default import fails in a controlled subprocess.
- `test/fixtures/shim`: explicit `marionette/backbone` import patches Backbone.
- `test/fixtures/jquery-dom-api`: jQuery DomApi works when jQuery is installed locally.
- `test/fixtures/vite`: `vite build` succeeds against the packed package.
- `test/fixtures/peer-underscore-min`: ESM import works with `underscore@1.13.0`.

## Package/Export Behavior Verified
- Fixtures install the produced `.tgz` with `npm install --no-save`, not source aliases.
- Core fixtures install underscore only; they do not install Backbone or jQuery.
- The Backbone shim fixture installs Backbone locally.
- The jQuery DomApi fixture installs jQuery locally.

## Validation Commands and Results
- `npm run lint:ci` passed.
- `npm run build` passed. Existing Browserslist freshness and Rollup circular dependency warnings were emitted.
- `npm pack` passed and listed the expected dist/package files.
- `npm run test:fixtures` passed for all seven fixtures. Existing Browserslist/Rollup warnings were emitted during the internal build; npm also emitted a transitive `whatwg-encoding` deprecation warning from the jsdom fixture install.
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml ok'"` passed.

## CI Integration Notes
- CI now runs `npm run test:fixtures` after coverage on Node 24.
- The workflow does not publish packages.

## Scope Creep Check
- No runtime source changes.
- No package export changes.
- No test runner migration changes.
- No files under `logs/` modified.

## Follow-up Issues
- Browser-specific install fixture coverage can be added later if the project decides to test browser variants beyond the current Vite package build check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `npm pack` install fixtures and an `npm run test:fixtures` script to verify the published `marionette` package across key usage scenarios. CI runs these checks after coverage to catch packaging and export issues.

- **New Features**
  - Seven fixtures: CJS (`require`), ESM (`import * as`), default import failure, `marionette/backbone` shim, `marionette/jquery-dom-api` with `jquery`, `vite` build, and `underscore@1.13.0` peer.
  - Validators ensure: no default export; Backbone patch only via `marionette/backbone`; jQuery only via `marionette/jquery-dom-api` (View.$ returns jQuery, `$el` not added); core uses only `underscore`.
  - Added `test/fixtures/run.mjs`; CI runs fixtures after coverage; included `test/fixtures/` in `lint:base`. No runtime source or export changes.

<sup>Written for commit c0d8b9620022d78dd4320194f659db0cd1f23b4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fixture-based integration testing across multiple environments (CommonJS, ES modules, Vite, DOM APIs).
  * New CI workflow step executes fixture validation before coverage analysis.
  * Test suite validates library behavior across CommonJS, ESM, jQuery DOM adapter, Backbone shimming, and build tool integration scenarios.

* **Chores**
  * Added `test:fixtures` npm script for running integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->