### PR TITLE
docs(v5): add v4 compatibility ledger

### DIFF
--- a/docs/migration-from-v4.md
+++ b/docs/migration-from-v4.md
@@ -1,0 +1,61 @@
+# Marionette v4 to v5 Compatibility Ledger
+
+This ledger records the public compatibility boundary between Marionette v4
+and v5. It is a reference, not the full procedural upgrade guide. Detailed
+upgrade steps that are not already documented belong to
+[the v4-to-v5 upgrade guide follow-up](https://github.com/marionettejs/marionette/issues/75).
+
+Status values describe the v5 outcome:
+
+- **Preserved**: the supported public behavior remains available.
+- **Changed**: the public behavior remains relevant but has a different contract.
+- **Removed**: the v4 behavior is not supported in v5.
+- **Optional**: the behavior is available only through an explicit opt-in.
+- **Renamed**: the capability remains under a different name.
+- **Documented**: the public extension point is retained and called out here.
+
+## Compatibility ledger
+
+| Area | v4 behavior | v5 behavior | Status | Migration note |
+| --- | --- | --- | --- | --- |
+| Package name | Installed as `backbone.marionette`. | Published as `marionette`. | Changed | Replace the package name. See [Installing Marionette](./installation.md#install). |
+| Install command | `npm install backbone.marionette` installed Marionette under the v4 name. | Install core with `npm install marionette underscore`; add optional peers only when used. | Changed | See [peer dependencies](./installation.md#peer-dependencies). |
+| Default export namespace | Namespace-style default import usage was supported. | A default namespace export is not supported. | Removed | Use named imports. See [Quick start](./installation.md#quick-start) and the [upgrade-guide follow-up](https://github.com/marionettejs/marionette/issues/75). |
+| Named exports | Classes and utilities were available as named exports. | Named exports are the supported module API. | Preserved | Import only what is needed, for example `import { View, Region } from 'marionette';`. |
+| Backbone dependency | Backbone was a required runtime dependency and supplied core entity and view behavior. | Marionette core does not import Backbone. | Optional | Install Backbone only for Backbone models or collections. See [Optional Backbone](./optional-backbone.md). |
+| Explicit Backbone shim | Backbone integration was applied as part of the v4 dependency relationship. | `marionette/backbone` explicitly patches Backbone with Marionette event helpers. | Optional | Import `marionette/backbone` only when the shim is required. See [Using the bundled Backbone shim](./optional-backbone.md#using-the-bundled-backbone-shim). |
+| jQuery dependency | jQuery commonly backed Backbone view and Marionette DOM behavior. | Marionette core does not import jQuery. | Optional | Install jQuery only when using `marionette/jquery-dom-api`. See [jQuery DOM adapter is optional](./installation.md#jquery-dom-adapter-is-optional). |
+| Optional jQuery DomApi | jQuery-backed DOM operations were part of the common v4 stack. | The `marionette/jquery-dom-api` subpath provides explicitly selected jQuery-backed DOM methods. | Optional | Configure it at app boot with `setDomApi`. See [jQuery DOM compatibility](../upgradeGuide.md#jquery-dom-compatibility). |
+| `$el` | Views commonly exposed a jQuery-wrapped `$el`. | Core and the optional jQuery DomApi do not create `$el`. | Removed | Set `$el` in an application-specific view layer if legacy code still requires it. See [jQuery DOM compatibility](../upgradeGuide.md#jquery-dom-compatibility). |
+| `view.$(selector)` | Returned a jQuery collection in the common Backbone/jQuery configuration. | Delegates to `DomApi.findEl`, which returns a native `NodeList` by default or a jQuery collection with the optional adapter. | Changed | Prefer native collection APIs, or opt into `marionette/jquery-dom-api`. See [jQuery DOM compatibility](../upgradeGuide.md#jquery-dom-compatibility). |
+| Region `el` | Accepted a selector string or DOM element. | Selector-string and DOM-element support are preserved. | Preserved | No change is required. Region remains the Marionette mount-point abstraction. See [View `el` is element-only](../upgradeGuide.md#view-el-is-element-only). |
+| View `el` | Selector strings commonly worked through Backbone and jQuery. | `View` accepts a DOM element only and throws a migration hint for strings. | Changed | Resolve selectors at the call site with `document.querySelector(...)`. See [View `el` is element-only](../upgradeGuide.md#view-el-is-element-only). |
+| CollectionView `setElement` | Selector strings commonly worked through inherited Backbone view behavior. | `CollectionView#setElement` accepts a DOM element only and throws for strings. | Changed | Resolve selectors before calling `setElement`. See [View `el` is element-only](../upgradeGuide.md#view-el-is-element-only). |
+| Detach semantics | jQuery detach operations preserved jQuery listener and data bookkeeping for detached nodes. | The native DomApi is the default; v4-style listener-preserving jQuery detach behavior requires the optional adapter. | Changed | Use `marionette/jquery-dom-api` only when detach-and-reinsert code relies on jQuery bookkeeping. See [`detachContents` policy](../upgradeGuide.md#detachcontents-policy). |
+| Radio | Applications commonly consumed the separate `backbone.radio` package. | Marionette exports its built-in `Radio` implementation as a named export. | Changed | Use `import { Radio } from 'marionette';`; do not add `backbone.radio` for Marionette internals. Further migration examples belong to [#75](https://github.com/marionettejs/marionette/issues/75). |
+| UMD global | Script builds exposed the `Marionette` global. | The UMD build continues to expose the `Marionette` global with named API properties. | Preserved | Existing direct-script integrations can retain the global while updating changed APIs. |
+| CJS entry | CommonJS consumers could require Marionette. | `require('marionette')` resolves to the CJS build and returns named API properties. | Preserved | Destructure the required API instead of expecting a restored default namespace contract. |
+| ESM entry | ES module named imports were supported. | `import` resolves to the ESM build and named imports remain supported. | Preserved | Use named imports from `marionette`. |
+| Underscore peer version | The supported peer range included Underscore 1.11 and 1.12. | The minimum supported version is `1.13.0`; the peer range is `underscore@^1.13.0`. | Changed | Upgrade Underscore before installing v5. See [peer dependency requirements](../upgradeGuide.md#peer-dependency-requirements). |
+| Event bookkeeping rename | Backbone-compatible private event fields such as `_events`, `_listeningTo`, and `_listenId` could be observed. | Marionette's built-in Events implementation uses private `_rdEvents`, `_rdListeningTo`, `_rdListeners`, and `_rdListenId` fields. | Renamed | Do not read or write event bookkeeping fields; use `on`, `off`, `listenTo`, and `stopListening`. Procedural guidance belongs to [#75](https://github.com/marionettejs/marionette/issues/75). |
+| `Mn.Object` | The default namespace exposed an `Object` alias for the Marionette object class. | The alias is not restored. | Removed | Use `import { MnObject } from 'marionette';`. See the [upgrade-guide follow-up](https://github.com/marionettejs/marionette/issues/75). |
+| `MnObject` | The Marionette object class was available as the named `MnObject` export. | `MnObject` remains a named export. | Preserved | Import it directly: `import { MnObject } from 'marionette';`. |
+| `onShow` | `Region` invoked `onShow(region, view, options)` for its `show` lifecycle event. | The Region `show` event and `onShow` method convention remain supported. | Preserved | No lifecycle rename is required. See [Region events](./events.class.md#show-and-beforeshow-events). |
+| Native DomApi customization | Applications could replace or partially override Marionette's DomApi globally or per class. | The native DomApi is the default and remains customizable with `setDomApi` or class-level setters. | Documented | Customization applies to `View`, `CollectionView`, and `Region`. See [Providing Your Own DOM API](./dom.api.md#providing-your-own-dom-api). |
+| EventDelegator customization | DOM event delegation was supplied through Backbone view and jQuery behavior. | Native delegation is the default and can be customized globally with `setEventDelegator` or per class. | Changed | Custom delegators must provide compatible `delegate` and `undelegateAll` methods. Detailed examples belong to [#75](https://github.com/marionettejs/marionette/issues/75). |
+
+## Reading changed and removed rows
+
+The highest-impact migration boundaries are:
+
+- update the package name and imports before addressing runtime behavior;
+- keep default-namespace and `Mn.Object` compatibility out of new v5 code;
+- explicitly opt into Backbone or jQuery compatibility only where an
+  application still needs it;
+- resolve `View` and `CollectionView` selector strings before construction or
+  `setElement`, while leaving Region selector strings unchanged; and
+- audit code that depends on `$el`, jQuery-shaped `view.$()` results, or
+  jQuery-preserved detach bookkeeping.
+
+The full ordered migration procedure, including before-and-after examples for
+rows that currently link to issue #75, will be written in that follow-up.

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -1,6 +1,8 @@
 ## From backbone.marionette.js
 
-Todo
+See the [v4-to-v5 compatibility ledger](docs/migration-from-v4.md) for the
+current public behavior boundary. The ordered migration procedure will be
+expanded in [issue #75](https://github.com/marionettejs/marionette/issues/75).
 
 ## Peer dependency requirements
 


### PR DESCRIPTION
Closes #74

## What
- Add `docs/migration-from-v4.md` with the public v4-to-v5 compatibility ledger.
- Cover all 25 required package, dependency, DOM, module-format, event, and lifecycle areas.
- Link migration notes to existing upgrade-guide sections or follow-up issue #75.

## Why
The v5 compatibility boundary currently spans installation docs, the partial upgrade guide, and implementation decisions. A single ledger gives reviewers and users a concise record of what is preserved, changed, removed, optional, renamed, or explicitly documented before the full upgrade guide is written.

## Public Behavior Boundary
- Documents the `marionette` package name and named-export-only module contract.
- Documents optional Backbone and jQuery integration without restoring default namespace or `Mn.Object` compatibility.
- Documents element-only View and CollectionView behavior while preserving Region selector strings.
- Documents native DomApi defaults, optional jQuery detach semantics, built-in Radio, UMD/CJS/ESM output, and the Underscore peer floor.
- Does not change runtime behavior.

## Ledger Coverage
The table includes every required row: package/install naming, exports, optional dependencies and adapters, DOM element/query/detach behavior, Radio, distribution formats, Underscore, event bookkeeping, object naming, `onShow`, DomApi customization, and EventDelegator customization.

## Changed and Removed Behavior
- Calls out the package rename, removed default namespace, removed `Mn.Object` alias, and removed automatic `$el`.
- Calls out element-only View and CollectionView APIs, native `view.$()` results, optional jQuery detach behavior, built-in Radio, private event-field renames, and the Underscore 1.13 floor.
- Uses only named v5 imports in recommended examples.

## Scope
- Documentation only: `docs/migration-from-v4.md`.
- No runtime source, tests, DOM docs, Events docs, or files under `logs/` changed.
- This is a ledger, not the full upgrade guide.

## Deployment Impact
No runtime deployment or package rebuild is required. This change affects documentation only.

## Testing
- `npm run lint:ci` passed.
- `git diff --check` passed.
- Required-row script confirmed all 25 ledger rows are present.
- `rg "backbone\\.marionette|Backbone\\.Marionette|import Mn from|Mn\\.Object" docs/migration-from-v4.md` found only explicit v4/history or migration-warning references.
- `rg "MnObject|jquery-dom-api|document.querySelector|Region|View|detach" docs/migration-from-v4.md` confirmed the required migration topics are covered.
- Referenced local documentation headings were checked for valid anchors.

## Scope Creep Check
- No full upgrade-guide procedure added.
- No DOM or Events documentation rewrite.
- No runtime or test changes.

## Follow-up Issues
- #75 will turn changed and removed ledger rows into the ordered v4-to-v5 upgrade guide with expanded examples.

The Linear issue key does not apply to this GitHub project; `FE-UNKNOWN` is included only because the local PR template requires a Linear reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v4-to-v5 compatibility ledger and links the upgrade guide to it so users have one place to see what’s preserved, changed, removed, optional, or renamed. Documentation-only; no runtime behavior changes.

- **Migration**
  - Added `docs/migration-from-v4.md`: a 25-row ledger covering packages/exports, DOM and selector rules, optional `backbone`/`jQuery` via `marionette/backbone` and `marionette/jquery-dom-api`, `Radio`, build formats, `underscore@^1.13.0`, events, and lifecycle; rows link to existing docs or issue #75.
  - Updated `upgradeGuide.md` to reference the ledger and note that ordered steps will be expanded in #75.

<sup>Written for commit 9d27dd9b741b26ea48a725f1825d770b8f0673c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a v4→v5 compatibility ledger detailing status legend, package/import changes, dependency optionality, API contract differences, lifecycle/customization points, and high‑impact migration boundaries.
  * Updated the upgrade guide to link to the compatibility ledger and note that the ordered migration procedure will be expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->