### PR TITLE
docs(v5): replace upgradeGuide placeholder with v4-to-v5 migration guide

### DIFF
--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -213,6 +213,8 @@ import Mn from 'backbone.marionette';
 //   npm install jquery
 import { setDomApi } from 'marionette';
 import JQueryDomApi from 'marionette/jquery-dom-api';
+
+setDomApi(JQueryDomApi);
 ```
 
 ## Optional jQuery DomApi adapter
@@ -392,15 +394,14 @@ plugins that read or write those private fields directly will not find them.
 
 This is private API. Use the public `on`, `off`, `listenTo`, `listenToOnce`,
 and `stopListening` methods instead. See [Events docs](docs/events.md) for the
-public surface.
+public surface. There is no public replacement for counting or inspecting
+registered handlers; redesign plugins that depend on that private state.
 
 ```js
 // v4 (before) — reaching into private Backbone event fields
 const count = Object.keys(obj._events || {}).length;
 
-// v5 (after) — use the public API; do not read private `_rd*` fields
-obj.on('some:event', handler);
-obj.stopListening();
+// v5 (after) — no public equivalent; remove private-field introspection
 ```
 
 ## Removed or not-restored APIs
@@ -423,5 +424,3 @@ obj.stopListening();
 For the complete per-area status table (Preserved / Changed / Removed /
 Optional / Renamed / Documented) and the precise public behavior boundary, see
 the [v4-to-v5 compatibility ledger](docs/migration-from-v4.md).
-</content>
-</invoke>

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -1,15 +1,262 @@
-## From backbone.marionette.js
+# Upgrading from Marionette v4 to v5
 
-See the [v4-to-v5 compatibility ledger](docs/migration-from-v4.md) for the
-current public behavior boundary. The ordered migration procedure will be
-expanded in [issue #75](https://github.com/marionettejs/marionette/issues/75).
+This is the ordered, procedural guide for moving an application from Marionette
+v4 (`backbone.marionette`) to Marionette v5 (`marionette`). It complements the
+[v4-to-v5 compatibility ledger](docs/migration-from-v4.md), which is the
+authoritative reference for the public behavior boundary. Where this guide
+gives steps and before/after examples, the ledger gives the per-area status
+(Preserved, Changed, Removed, Optional, Renamed, Documented).
+
+Older upgrade notes remain available:
+
+- [Upgrading from v3 to v4](docs/upgrade-v3-v4.md)
+- [Upgrading from v2 to v3](docs/upgrade-v2-v3.md)
+
+## Contents
+
+- [Overview](#overview)
+- [Install and package name](#install-and-package-name)
+- [Named imports instead of a default namespace import](#named-imports-instead-of-a-default-namespace-import)
+- [`Mn.Object` / `Object` alias becomes `MnObject`](#mnobject--object-alias-becomes-mnobject)
+- [Backbone is optional](#backbone-is-optional)
+- [Explicit Backbone shim and import order](#explicit-backbone-shim-and-import-order)
+- [Peer dependency requirements](#peer-dependency-requirements)
+- [jQuery is optional](#jquery-is-optional)
+- [Optional jQuery DomApi adapter](#optional-jquery-domapi-adapter)
+- [Native DomApi customization](#native-domapi-customization)
+- [View `el` is element-only](#view-el-is-element-only)
+- [Region `el` policy](#region-el-policy)
+- [jQuery DOM compatibility](#jquery-dom-compatibility)
+- [`detachContents` policy](#detachcontents-policy)
+- [Radio is now built in](#radio-is-now-built-in)
+- [Event bookkeeping rename for plugin authors](#event-bookkeeping-rename-for-plugin-authors)
+- [Removed or not-restored APIs](#removed-or-not-restored-apis)
+- [Compatibility ledger](#compatibility-ledger)
+
+## Overview
+
+v5 is primarily a packaging and dependency change. The class APIs you use day
+to day — `Application`, `View`, `CollectionView`, `Region`, `Behavior`,
+`MnObject` — keep their public contracts. What changes is how Marionette is
+named, imported, and wired to Backbone, jQuery, and the DOM.
+
+Migrate in this order. Earlier steps are mechanical and unblock the rest:
+
+1. Update the package name and install command.
+2. Replace the default namespace import with named imports.
+3. Replace `Mn.Object` usage with the `MnObject` named export.
+4. Decide whether you still need Backbone and jQuery, and opt in explicitly.
+5. Resolve `View`/`CollectionView` selector-string `el` at the call site.
+6. Audit `$el`, `view.$(selector)`, and detach-and-reinsert code.
+7. Adopt the built-in `Radio` and stop reaching into private event fields.
+
+Each section below ends with a small before/after example. All v5 examples use
+named imports. The full per-area status table lives in the
+[compatibility ledger](docs/migration-from-v4.md).
+
+## Install and package name
+
+v5 publishes under the name `marionette` (not `backbone.marionette`). Underscore
+is a required peer; Backbone and jQuery are optional peers you install only when
+you use them. See [Installing Marionette](docs/installation.md#install) and
+[peer dependencies](docs/installation.md#peer-dependencies).
+
+```sh
+# v4 (before)
+npm install backbone.marionette
+
+# v5 (after)
+npm install marionette underscore
+```
+
+## Named imports instead of a default namespace import
+
+v5 ships **named exports only**. There is no default namespace export, so the
+`import Mn from 'backbone.marionette'` pattern no longer resolves to an object
+you can dot into. Import exactly what you use from `marionette`. UMD script
+builds keep the `Marionette` global with the same named properties, so global
+consumers read `Marionette.View` instead of a default import.
+
+```js
+// v4 (before)
+import Mn from 'backbone.marionette';
+
+const RootView = Mn.View.extend({ /* ... */ });
+const region = new Mn.Region({ el: someEl });
+
+// v5 (after)
+import { Application, View, Region, MnObject } from 'marionette';
+
+const RootView = View.extend({ /* ... */ });
+const region = new Region({ el: someEl });
+```
+
+Do not reintroduce a namespace object as a v5 recommendation — neither
+`import Mn from 'marionette'` nor `Backbone.Marionette`. If you previously read
+classes off the `Backbone.Marionette` global, read them off the `Marionette`
+global instead:
+
+```js
+// v4 (before) — global/UMD usage
+const view = new Backbone.Marionette.View();
+
+// v5 (after) — UMD still exposes the `Marionette` global with named properties
+const view = new Marionette.View();
+```
+
+## `Mn.Object` / `Object` alias becomes `MnObject`
+
+v4's default namespace exposed an `Object` alias (`Mn.Object`) for the Marionette
+object class. v5 does not restore that alias
+([#59](https://github.com/marionettejs/marionette/issues/59) is closed as not
+planned). Use the `MnObject` named export, which has always been the canonical
+name for this class.
+
+```js
+// v4 (before)
+const Controller = Mn.Object.extend({
+  initialize() { /* ... */ }
+});
+
+// v5 (after)
+import { MnObject } from 'marionette';
+
+const Controller = MnObject.extend({
+  initialize() { /* ... */ }
+});
+```
+
+See [MnObject](docs/marionette.mnobject.md) for the class reference.
+
+## Backbone is optional
+
+Marionette core no longer imports Backbone. Install Backbone only when your app
+actually uses Backbone models, collections, or views. Marionette's own
+`View`, `CollectionView`, `Region`, and `MnObject` work without it. See
+[Optional Backbone](docs/optional-backbone.md).
+
+```js
+// v4 (before) — Backbone was always present as a hard dependency
+import Mn from 'backbone.marionette';
+
+// v5 (after) — install and import Backbone only where you use it
+//   npm install backbone
+import { Model, Collection } from 'backbone';
+import { View } from 'marionette';
+
+const list = new Collection();
+const ListView = View.extend({ /* ... */ });
+```
+
+## Explicit Backbone shim and import order
+
+In v4, Marionette's relationship with Backbone meant Backbone constructors were
+patched as part of loading Marionette. In v5 that patching is explicit and opt-in
+through the `marionette/backbone` subpath, which extends
+`Backbone.Model`, `Backbone.Collection`, `Backbone.View`, and `Backbone.Router`
+prototypes with Marionette's `Events` (so `triggerMethod`, Marionette-style
+`listenTo`, etc. are available on Backbone objects).
+
+**Import order matters.** Run the shim at your application entry point, before
+any module that constructs Backbone objects expecting the Marionette event
+helpers. Because Backbone is a singleton module, importing the shim once patches
+every later `import Backbone from 'backbone'`. See
+[Using the bundled Backbone shim](docs/optional-backbone.md#using-the-bundled-backbone-shim).
+
+```js
+// v4 (before) — Backbone was patched implicitly
+import Mn from 'backbone.marionette';
+
+// v5 (after) — patch Backbone explicitly, first, at the app entry point
+import 'marionette/backbone';        // side-effect: patch Backbone prototypes
+import './app';                      // modules here can rely on patched Backbone
+```
+
+`marionette/backbone` also default-exports the patched `Backbone`, so you can
+import the shimmed constructor directly where that reads more clearly:
+
+```js
+// v5 (after)
+import Backbone from 'marionette/backbone';
+
+const model = new Backbone.Model();  // has Marionette's Events mixed in
+```
 
 ## Peer dependency requirements
 
-- Underscore must be `1.13.0` or later. Marionette v5 publishes named ESM imports
-  from `underscore`, and Underscore versions before 1.13 are CJS-only with no
-  package `exports` map, so modern Node and bundler ESM resolution cannot satisfy
-  the named imports.
+- Underscore must be `1.13.0` or later; the supported peer range is
+  `underscore@^1.13.0`. v5 publishes named ESM imports from `underscore`, and
+  Underscore versions before 1.13 are CJS-only with no package `exports` map, so
+  modern Node and bundler ESM resolution cannot satisfy the named imports.
+  Upgrade Underscore before installing v5.
+
+```sh
+# v4 (before) — Underscore 1.11 / 1.12 were acceptable
+npm install underscore@^1.11.0
+
+# v5 (after)
+npm install underscore@^1.13.0
+```
+
+## jQuery is optional
+
+Marionette core does not import jQuery and does not create `view.$el`. jQuery is
+an optional peer used **only** through the `marionette/jquery-dom-api` subpath.
+Install jQuery solely when you opt into that adapter. See
+[jQuery DOM adapter is optional](docs/installation.md#jquery-dom-adapter-is-optional).
+
+```js
+// v4 (before) — jQuery commonly backed view/DOM behavior implicitly
+import Mn from 'backbone.marionette';
+
+// v5 (after) — install jQuery only if you opt into the adapter
+//   npm install jquery
+import { setDomApi } from 'marionette';
+import JQueryDomApi from 'marionette/jquery-dom-api';
+```
+
+## Optional jQuery DomApi adapter
+
+If you depend on jQuery-backed DOM operations (for example, `view.$(selector)`
+returning a jQuery collection, or jQuery's listener-preserving detach), opt into
+the adapter once at app boot with `setDomApi`. The adapter is the default export
+of `marionette/jquery-dom-api`.
+
+```js
+// v5 (after) — at app boot, before constructing views
+import { setDomApi } from 'marionette';
+import JQueryDomApi from 'marionette/jquery-dom-api';
+
+setDomApi(JQueryDomApi);
+```
+
+This configures the DomApi globally for `View`, `CollectionView`, and `Region`.
+
+## Native DomApi customization
+
+The native DOM API is the default in v5 — no jQuery required. It remains
+customizable. `setDomApi` **merges** your overrides over the native defaults, so
+you can override only the methods you need, globally or per class. See
+[Providing Your Own DOM API](docs/dom.api.md#providing-your-own-dom-api).
+
+```js
+// v4 (before) — DOM operations were jQuery-backed by default
+import Mn from 'backbone.marionette';
+
+// v5 (after) — native by default; override individual methods as needed
+import { setDomApi, View } from 'marionette';
+
+// Globally, merged over the native defaults:
+setDomApi({
+  setContents(el, html) { el.innerHTML = html; }
+});
+
+// Or per class, leaving other classes on the native default:
+const CustomView = View.extend({});
+CustomView.setDomApi({
+  appendContents(el, contents) { el.appendChild(contents); }
+});
+```
 
 ## View `el` is element-only
 
@@ -18,77 +265,163 @@ expanded in [issue #75](https://github.com/marionettejs/marionette/issues/75).
 - v4 inherited string-`el` resolution from `Backbone.View._ensureElement`, which
   used jQuery to look up the selector. v5 drops `Backbone.View` inheritance and
   the default jQuery dependency, so the string-resolution path goes with them.
-- v5 now throws a `ViewError` with a migration hint on construction (or
-  `setElement`) when a string is passed, instead of silently storing the raw
-  string as `view.el` and failing later in DOM code.
-- Migration: resolve at the call site.
+- v5 throws a `ViewError` with a migration hint on construction (or
+  `setElement`/`CollectionView#setElement`) when a string is passed, instead of
+  silently storing the raw string as `view.el` and failing later in DOM code.
+- Migration: resolve the selector at the call site.
 
-  ```js
-  // v4
-  new View({ el: '#root' });
+```js
+// v4 (before)
+new View({ el: '#app' });
 
-  // v5
-  new View({ el: document.querySelector('#root') });
-  ```
+// v5 (after)
+new View({ el: document.querySelector('#app') });
+```
 
-- `Region` continues to accept selector strings. That API is Marionette-native
-  (the Region abstraction has always been "where to mount"), not inherited from
-  Backbone, so it is preserved.
+The same rule applies to `CollectionView#setElement`:
+
+```js
+// v4 (before)
+collectionView.setElement('#list');
+
+// v5 (after)
+collectionView.setElement(document.querySelector('#list'));
+```
+
+## Region `el` policy
+
+`Region` continues to accept **selector strings or DOM elements**. The Region
+abstraction is Marionette-native ("where to mount"), not inherited from
+Backbone, so its string-`el` support is preserved. No change is required.
+
+```js
+// v4 (before)
+new Region({ el: '#region' });
+
+// v5 (after) — still supported, unchanged
+new Region({ el: '#region' });
+```
 
 ## jQuery DOM compatibility
 
-- v5 core does not depend on jQuery and does not create `view.$el`.
-- Apps that want Marionette DOM operations such as `view.$(selector)` to return
-  jQuery collections can opt into the `marionette/jquery-dom-api` adapter:
+- v5 core does not create `view.$el`.
+- `view.$(selector)` delegates to `DomApi.findEl`, which returns a native
+  `NodeList` by default (`el.querySelectorAll(selector)`), or a jQuery collection
+  when you opt into `marionette/jquery-dom-api`.
+- Prefer native collection APIs, or opt into the adapter (see
+  [Optional jQuery DomApi adapter](#optional-jquery-domapi-adapter)).
 
-  ```js
-  import { setDomApi } from 'marionette';
-  import JQueryDomApi from 'marionette/jquery-dom-api';
+```js
+// v4 (before) — jQuery collection by default
+view.$('.item').addClass('active');
+view.$el.attr('id', 'root');
 
-  setDomApi(JQueryDomApi);
-  ```
+// v5 (after) — native NodeList by default
+view.$('.item').forEach(el => el.classList.add('active'));
+view.el.setAttribute('id', 'root');
+```
 
-- The adapter imports `jquery`, so jQuery is an optional peer dependency only for
-  consumers that opt into this subpath.
-- The adapter intentionally does not add `$el`. If legacy app code still expects
-  `view.$el`, set it in your own view layer:
+The optional adapter intentionally does **not** add `$el`. If legacy code still
+expects `view.$el`, set it in your own view layer:
 
-  ```js
-  import $ from 'jquery';
-  import { View } from 'marionette';
+```js
+// v5 (after) — restore $el in an app-specific base view if you truly need it
+import $ from 'jquery';
+import { View } from 'marionette';
 
-  const LegacyView = View.extend({
-    initialize() {
-      this.$el = $(this.el);
-    }
-  });
-  ```
+const LegacyView = View.extend({
+  initialize() {
+    this.$el = $(this.el);
+  }
+});
+```
 
 ## `detachContents` policy
 
 - The default native DomApi `detachContents(el)` clears the element via
-  `el.textContent = ''`. Children are removed from `el` and Marionette no
-  longer holds references to them.
-- v4 used jQuery's `$(el).contents().detach()`, which is jQuery's documented
-  detach-for-reinsertion path. It removes children from `el` while preserving
-  jQuery's internal handler/data bookkeeping on those elements.
-- For most apps the user-visible difference is small — `Region.empty()`
-  discards the detached content in both cases, and DOM event listeners
-  attached via `addEventListener` remain on referenced child elements either
-  way. The difference matters for apps that detach-then-reinsert children
-  externally and rely on jQuery's `.on()` handlers, `.data()` cache, or other
-  jQuery-internal element bookkeeping surviving that cycle.
-- Legacy code that depends on the v4 jQuery semantics can opt into the
-  optional jQuery DomApi adapter at app boot:
+  `el.textContent = ''`. Children are removed from `el` and Marionette no longer
+  holds references to them.
+- v4 used jQuery's `$(el).contents().detach()`, which removes children from `el`
+  while preserving jQuery's internal handler/data bookkeeping on those elements.
+- For most apps the user-visible difference is small — `Region.empty()` discards
+  the detached content in both cases, and DOM listeners attached via
+  `addEventListener` survive either way. The difference matters for apps that
+  detach-then-reinsert children externally and rely on jQuery's `.on()` handlers,
+  `.data()` cache, or other jQuery-internal element bookkeeping surviving that
+  cycle.
+- Legacy code that depends on the v4 jQuery semantics can opt into the optional
+  jQuery DomApi adapter at app boot; its `detachContents(el)` calls
+  `$(el).contents().detach()`, matching v4.
 
-  ```js
-  import { setDomApi } from 'marionette';
-  import JQueryDomApi from 'marionette/jquery-dom-api';
+```js
+// v4 (before) — jQuery detach preserved .on()/.data() bookkeeping implicitly
 
-  setDomApi(JQueryDomApi);
-  ```
+// v5 (after) — opt back into jQuery detach only if you rely on that bookkeeping
+import { setDomApi } from 'marionette';
+import JQueryDomApi from 'marionette/jquery-dom-api';
 
-  The adapter's `detachContents(el)` calls `$(el).contents().detach()`,
-  matching the v4 behavior.
+setDomApi(JQueryDomApi);
+```
 
-- The native default is also described in [docs/dom.api.md](docs/dom.api.md).
+The native default is also described in [docs/dom.api.md](docs/dom.api.md).
+
+## Radio is now built in
+
+Marionette exports its own `Radio` implementation as a named export. You no
+longer add a separate `backbone.radio` package for Marionette's internal
+request/event channels. See [Backbone.Radio](docs/backbone.radio.md).
+
+```js
+// v4 (before)
+import Radio from 'backbone.radio';
+
+const channel = Radio.channel('app');
+
+// v5 (after)
+import { Radio } from 'marionette';
+
+const channel = Radio.channel('app');
+```
+
+## Event bookkeeping rename for plugin authors
+
+Marionette's built-in `Events` implementation stores its private bookkeeping
+under `_rdEvents`, `_rdListeningTo`, `_rdListeners`, and `_rdListenId` — not the
+Backbone-compatible `_events`, `_listeningTo`, and `_listenId` fields. Code or
+plugins that read or write those private fields directly will not find them.
+
+This is private API. Use the public `on`, `off`, `listenTo`, `listenToOnce`,
+and `stopListening` methods instead. See [Events docs](docs/events.md) for the
+public surface.
+
+```js
+// v4 (before) — reaching into private Backbone event fields
+const count = Object.keys(obj._events || {}).length;
+
+// v5 (after) — use the public API; do not read private `_rd*` fields
+obj.on('some:event', handler);
+obj.stopListening();
+```
+
+## Removed or not-restored APIs
+
+| Removed / not restored | Use instead |
+| --- | --- |
+| Default namespace export (`import Mn from 'marionette'`) | Named imports: `import { View, Region } from 'marionette'` |
+| `Mn.Object` / `Object` alias ([#59](https://github.com/marionettejs/marionette/issues/59), not planned) | `import { MnObject } from 'marionette'` |
+| `Backbone.Marionette` global namespace usage | The `Marionette` UMD global with named properties, or named ESM imports |
+| `view.$el` created by core | Use `view.el`, or set `$el` yourself via the jQuery adapter / a base view |
+| Implicit jQuery-backed DOM | Native DomApi by default; opt into `marionette/jquery-dom-api` |
+| Private `_events` / `_listeningTo` / `_listenId` fields | Public `on`/`off`/`listenTo`/`stopListening` |
+
+`onShow` is **not** removed — the `Region` `show`/`before:show` events and the
+`onShow(region, view, options)` convention are preserved. See
+[Region `show` events](docs/events.class.md#show-and-beforeshow-events).
+
+## Compatibility ledger
+
+For the complete per-area status table (Preserved / Changed / Removed /
+Optional / Renamed / Documented) and the precise public behavior boundary, see
+the [v4-to-v5 compatibility ledger](docs/migration-from-v4.md).
+</content>
+</invoke>

--- a/upgradeGuide.md
+++ b/upgradeGuide.md
@@ -141,9 +141,10 @@ import Mn from 'backbone.marionette';
 
 // v5 (after) — install and import Backbone only where you use it
 //   npm install backbone
-import { Model, Collection } from 'backbone';
+import Backbone from 'backbone';
 import { View } from 'marionette';
 
+const { Model, Collection } = Backbone;
 const list = new Collection();
 const ListView = View.extend({ /* ... */ });
 ```
@@ -332,8 +333,10 @@ import $ from 'jquery';
 import { View } from 'marionette';
 
 const LegacyView = View.extend({
-  initialize() {
+  setElement(element) {
+    View.prototype.setElement.call(this, element);
     this.$el = $(this.el);
+    return this;
   }
 });
 ```
@@ -357,6 +360,10 @@ const LegacyView = View.extend({
 
 ```js
 // v4 (before) — jQuery detach preserved .on()/.data() bookkeeping implicitly
+const $widget = view.$('.legacy-widget');
+$widget.on('refresh', refreshWidget).data('state', widgetState);
+view.getRegion('content').empty();
+view.el.appendChild($widget[0]); // handler and data still exist
 
 // v5 (after) — opt back into jQuery detach only if you rely on that bookkeeping
 import { setDomApi } from 'marionette';


### PR DESCRIPTION
## Linked issue

Closes #75

## Summary

Replaces the placeholder `upgradeGuide.md` (which only pointed forward to this
issue) with the ordered, procedural v4-to-v5 migration guide. The guide gives
step-by-step migration instructions and a small before/after example per
section, and defers the per-area status table to the
[compatibility ledger](docs/migration-from-v4.md). Docs-only change.

## Public behavior boundary

No runtime source or tests were changed — documentation only. The guide
describes the existing v5 public boundary already established in the ledger and
the v5 packaging/runtime PRs; it does not introduce or assert any new behavior.
All v5 examples use named imports from `marionette`; no example recommends a
default namespace import, `Backbone.Marionette`, or `Mn.Object`.

To avoid breaking inbound links, the guide preserves the four heading anchors
the ledger links into: `#peer-dependency-requirements`,
`#view-el-is-element-only`, `#jquery-dom-compatibility`, and
`#detachcontents-policy`.

## Sections added

Overview · Install and package name · Named imports (no default namespace) ·
`Mn.Object`/`Object` → `MnObject` · Backbone is optional · Explicit
`marionette/backbone` shim and import order · Peer dependency requirements
(underscore `^1.13.0`) · jQuery is optional · Optional jQuery DomApi adapter ·
Native DomApi customization · View/CollectionView `el` is element-only · Region
`el` policy · jQuery DOM compatibility (`$el`, `view.$(selector)`) ·
`detachContents` policy · Radio is now built in · Event bookkeeping rename for
plugin authors · Removed or not-restored APIs · Compatibility ledger.

## Changed / removed behavior called out

- **Changed**: package name `backbone.marionette` → `marionette`; underscore
  peer floor → `^1.13.0`; default DomApi is native (`view.$()` returns a
  `NodeList`); `detachContents` clears via `textContent` unless the jQuery
  adapter is opted in.
- **Optional**: Backbone, the explicit `marionette/backbone` shim, jQuery, and
  the `marionette/jquery-dom-api` adapter.
- **Removed / not restored**: default namespace export, `Mn.Object`/`Object`
  alias (#59, not planned), core-created `view.$el`, implicit jQuery-backed DOM,
  and private `_events`/`_listeningTo`/`_listenId` fields (renamed to `_rd*`).
- **Preserved (called out explicitly)**: Region selector-string `el`, `onShow`
  and the Region `show`/`before:show` convention, UMD `Marionette` global, and
  CJS+ESM named imports.

## Validation

Markdown is not covered by the project linter (`lint:base` lints JS only;
`upgradeGuide.md` is not in its file list), so no docs-lint command applies.

Spec-required greps were run against `upgradeGuide.md`:

- `rg "Todo|backbone\.marionette|Backbone\.Marionette|import Mn from|Mn\.Object" upgradeGuide.md`
  — every match is a v4 before-example, an explicit "do not use" warning, or a
  row in the removed-APIs table. No match presents a v4 form as recommended v5
  usage.
- `rg "migration-from-v4|MnObject|jquery-dom-api|marionette/backbone|document.querySelector|underscore" upgradeGuide.md`
  — all required migration topics are present.

Additional checks: every TOC anchor resolves to a heading; the four
ledger-referenced anchors are intact; all outbound `docs/*.md` links and their
section anchors exist.

## Scope creep check

Single file changed (`upgradeGuide.md`, +400/-67). No runtime source, tests, or
`logs/` touched. Did not rewrite DOM interactions, Events, or installation docs,
and did not perform the broader docs sweep — those remain with their own issues
(below). Cross-links to existing docs were added but those target files were not
edited.

## Follow-ups

- #76 — Rewrite DOM interactions docs (open). This guide links to
  `docs/dom.api.md` but does not rewrite it.
- #77 — Rewrite events docs (open). This guide links to `docs/events.md` /
  `docs/events.class.md` but does not rewrite them.
- #78 — Rename `backbone.radio` docs to radio docs (open). The Radio section
  links to `docs/backbone.radio.md`; the rename belongs to #78.
- #79 — Fix installation docs (already closed); install/peer cross-links point
  at the updated `docs/installation.md`.
- #81 — Broader README/docs sweep for legacy references (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the placeholder `upgradeGuide.md` with a procedural v4→v5 migration guide with clear before/after examples. It covers the package rename, import changes, optional Backbone/jQuery setup, DOM API configuration, element-only `el` rules, built-in `Radio`, and removed APIs.

- **Migration**
  - Use named imports from `marionette`; no default namespace or `Backbone.Marionette` (UMD `Marionette` global is retained).
  - `Mn.Object` → `MnObject`.
  - Backbone is optional; run the `marionette/backbone` shim first; it also default-exports the patched `Backbone`.
  - jQuery is optional; by default `view.$()` returns a `NodeList` and `$el` is not created; the `marionette/jquery-dom-api` adapter doesn’t add `$el`; customize via `setDomApi` (merged overrides).
  - `View`/`CollectionView` `el` must be a DOM element (throws a helpful error on strings); `Region` still accepts selector strings.
  - `detachContents` clears via `textContent`; the jQuery adapter restores detach-and-reinsert semantics if needed.
  - `Radio` is built in; event bookkeeping fields are now `_rd*` (for plugin authors).
  - Calls out removed/not-restored APIs with alternatives, and notes that `onShow` and Region `show` events are preserved.

- **Dependencies**
  - Package renamed to `marionette`.
  - Requires `underscore@^1.13.0`.
  - `backbone` and `jquery` are optional and only needed when you opt in.

<sup>Written for commit 55fa5564242f74b85be1ab4829cbf596a18a73ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote and expanded the Marionette v4-to-v5 migration guide with step-by-step upgrade instructions.
  * Clarified package imports, Backbone and jQuery integration, peer dependencies, and DOM API configuration.
  * Documented changes to view element handling, selectors, native DOM behavior, and region compatibility.
  * Added guidance on `Radio`, internal event changes, removed APIs, and compatibility tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->