### PR TITLE
test(events): cover EventDelegator edge cases

### DIFF
--- a/test/unit/config/event-delegator.spec.js
+++ b/test/unit/config/event-delegator.spec.js
@@ -2,6 +2,7 @@ import { JSDOM } from 'jsdom';
 import { vi } from 'vitest';
 
 import EventDelegator from '../../../config/event-delegator';
+import View from '../../../modules/view';
 
 describe('EventDelegator', function() {
   let dom;
@@ -31,6 +32,21 @@ describe('EventDelegator', function() {
   function dispatchClick(node) {
     node.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
   }
+
+  it('handles delegated clicks on matching elements and their descendants', function() {
+    const handler = vi.fn();
+
+    rootEl.innerHTML = '<button class="foo"><span>click</span></button>';
+    delegate('click', '.foo', handler);
+
+    const button = rootEl.querySelector('.foo');
+    dispatchClick(button);
+    dispatchClick(button.querySelector('span'));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[0][0].delegateTarget).to.equal(button);
+    expect(handler.mock.calls[1][0].delegateTarget).to.equal(button);
+  });
 
   it('handles delegated events with text-node targets', function() {
     const handler = vi.fn();
@@ -65,5 +81,47 @@ describe('EventDelegator', function() {
     rootEl.querySelector('input').dispatchEvent(new dom.window.FocusEvent('focus'));
 
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates blur events during capture', function() {
+    const handler = vi.fn();
+
+    rootEl.innerHTML = '<input class="foo">';
+    delegate('blur', '.foo', handler);
+
+    rootEl.querySelector('input').dispatchEvent(new dom.window.FocusEvent('blur'));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes handlers without leaks across setElement swaps', function() {
+    const handler = vi.fn();
+
+    rootEl.innerHTML = '<button class="foo">first</button>';
+    const otherEl = dom.window.document.createElement('div');
+    otherEl.innerHTML = '<button class="foo">second</button>';
+
+    const view = new View({
+      el: rootEl,
+      events: {
+        'click .foo': handler
+      }
+    });
+
+    view.setElement(otherEl);
+    dispatchClick(rootEl.querySelector('.foo'));
+    dispatchClick(otherEl.querySelector('.foo'));
+
+    view.setElement(rootEl);
+    dispatchClick(otherEl.querySelector('.foo'));
+    dispatchClick(rootEl.querySelector('.foo'));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    view._undelegateViewEvents();
+    dispatchClick(rootEl.querySelector('.foo'));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(view._domEvents).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
Closes #70

## What
- Add direct delegated-click coverage for matching elements and their descendants.
- Verify both focus and blur delegation through capture.
- Exercise view event teardown across repeated setElement swaps and explicit undelegation.

## Why
EventDelegator lacked explicit coverage for several acceptance criteria in issue #70, especially descendant clicks, blur capture, and leak-free handler teardown when a view changes elements.

## Scope
- Changes only test/unit/config/event-delegator.spec.js.
- Does not change EventDelegator or other runtime behavior.

## Deployment Impact
No deployment or redeploy is required; this is a test-only change.

## Testing
- npx vitest run test/unit/config/event-delegator.spec.js --reporter=dot (6 tests passed)
- npx eslint test/unit/config/event-delegator.spec.js --max-warnings=0
- npm test -- --reporter=dot (58 files and 1,082 tests passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for `EventDelegator` edge cases: delegated clicks on elements and descendants, blur delegation via capture, and leak-free teardown across View `setElement` swaps and explicit undelegation.

This is a test-only change in `test/unit/config/event-delegator.spec.js`; no runtime or deploy impact.

<sup>Written for commit b3e3d0315923bb4c62304069ed732a661b1e7e09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

