### PR TITLE
test(radio): add built-in requests coverage

### DIFF
--- a/test/unit/radio.spec.js
+++ b/test/unit/radio.spec.js
@@ -27,10 +27,49 @@ describe('Radio', function() {
     expect(handler).to.have.been.calledOnce.and.calledWith(1);
   });
 
-  it('proxies requests through the top-level API', function() {
-    Radio.reply('foo', 'bar', 'baz');
+  it('requests channel replies through the top-level API', function() {
+    const handler = this.sinon.stub().returns('baz');
+
+    Radio.channel('foo').reply('bar', handler);
 
     expect(Radio.request('foo', 'bar')).to.equal('baz');
+    expect(handler).to.have.been.calledOnce;
+  });
+
+  it('forwards event and request methods through the top-level API', function() {
+    const channel = Radio.channel('foo');
+    const methods = [
+      'on',
+      'off',
+      'once',
+      'listenTo',
+      'listenToOnce',
+      'stopListening',
+      'trigger',
+      'triggerMethod',
+      'reply',
+      'replyOnce',
+      'stopReplying',
+      'request'
+    ];
+
+    methods.forEach(method => {
+      const forwarded = this.sinon.stub(channel, method).returns(method);
+
+      expect(Radio[method]('foo', 'first', 'second')).to.equal(method);
+      expect(forwarded).to.have.been.calledOnce.and.calledOn(channel).and.calledWithExactly('first', 'second');
+    });
+  });
+
+  it('exposes triggerMethod through Radio', function() {
+    const channel = Radio.channel('foo');
+    const handler = this.sinon.stub();
+    channel.onRequestComplete = this.sinon.stub().returns('complete');
+    channel.on('request:complete', handler);
+
+    expect(Radio.triggerMethod('foo', 'request:complete', 1)).to.equal('complete');
+    expect(channel.onRequestComplete).to.have.been.calledOnce.and.calledOn(channel).and.calledWithExactly(1);
+    expect(handler).to.have.been.calledOnce.and.calledWithExactly(1);
   });
 
   it('debug logs overwritten requests when enabled', function() {
@@ -132,11 +171,11 @@ describe('Radio', function() {
   it('logs tuned in events and requests', function() {
     const log = this.sinon.stub(console, 'log');
 
-    Radio.tuneIn('foo');
+    expect(Radio.tuneIn('foo')).to.equal(Radio);
     Radio.trigger('foo', 'bar', 1);
     Radio.reply('foo', 'baz', 'qux');
     Radio.request('foo', 'baz', 2);
-    Radio.tuneOut('foo');
+    expect(Radio.tuneOut('foo')).to.equal(Radio);
     Radio.trigger('foo', 'bar', 3);
 
     expect(log).to.have.been.calledTwice;
@@ -178,5 +217,11 @@ describe('Radio', function() {
     Radio.reset();
     Radio.trigger('bar', 'event');
     expect(barHandler).to.have.been.calledOnce;
+  });
+
+  it('throws when resetting a missing named channel', function() {
+    expect(function() {
+      Radio.reset('missing');
+    }).to.throw(TypeError);
   });
 });

--- a/test/unit/radio.spec.js
+++ b/test/unit/radio.spec.js
@@ -218,10 +218,4 @@ describe('Radio', function() {
     Radio.trigger('bar', 'event');
     expect(barHandler).to.have.been.calledOnce;
   });
-
-  it('throws when resetting a missing named channel', function() {
-    expect(function() {
-      Radio.reset('missing');
-    }).to.throw(TypeError);
-  });
 });

--- a/test/unit/requests.spec.js
+++ b/test/unit/requests.spec.js
@@ -1,0 +1,52 @@
+import Requests from '../../mixins/requests';
+import { setDebug } from '../../modules/common/radio';
+
+describe('Requests', function() {
+  beforeEach(function() {
+    this.requests = { ...Requests };
+  });
+
+  afterEach(function() {
+    setDebug(false);
+  });
+
+  it('calls reply handlers with the request arguments and context', function() {
+    const context = {};
+    const handler = this.sinon.stub().returns('response');
+
+    this.requests.reply('foo', handler, context);
+
+    expect(this.requests.request('foo', 1, 2)).to.equal('response');
+    expect(handler).to.have.been.calledOnce.and.calledOn(context).and.calledWithExactly(1, 2);
+  });
+
+  it('replaces duplicate replies and logs the overwrite in debug mode', function() {
+    const warn = this.sinon.stub(console, 'warn');
+
+    setDebug();
+    this.requests.reply('foo', 'first');
+    this.requests.reply('foo', 'second');
+
+    expect(this.requests.request('foo')).to.equal('second');
+    expect(warn).to.have.been.calledOnce.and.calledWithExactly('A request was overwritten: "foo"');
+  });
+
+  it('removes replyOnce handlers after the first request', function() {
+    const handler = this.sinon.stub().returns('once');
+
+    this.requests.replyOnce('foo', handler);
+
+    expect(this.requests.request('foo', 1)).to.equal('once');
+    expect(this.requests.request('foo', 2)).to.be.undefined;
+    expect(handler).to.have.been.calledOnce.and.calledWithExactly(1);
+  });
+
+  it('passes the request name and arguments to the default handler', function() {
+    const handler = this.sinon.stub().returns('default');
+
+    this.requests.reply('default', handler);
+
+    expect(this.requests.request('missing', 1, 2)).to.equal('default');
+    expect(handler).to.have.been.calledOnce.and.calledWithExactly('missing', 1, 2);
+  });
+});


### PR DESCRIPTION
Closes #69

## What

- Add focused built-in Radio and Requests coverage independent of the optional backbone.radio adapter.
- Cover named-channel and global reset behavior.
- Deliberately avoid asserting that resetting an unknown channel throws an incidental raw `TypeError`; final unknown-channel diagnostics belong to #82 and #134.

## Why

Core Radio behavior needs direct coverage, but tests must not freeze accidental JavaScript failures as the stable framework contract.

## Scope

Tests only. No runtime code, package export, or production bundle behavior changes.

## Deployment Impact

No deployment or package release is required.

## Testing

- Focused Radio and Requests tests: 23 passed across 2 files.
- Focused ESLint: passed.
- `git diff --check`: passed.
- Full repository CI runs on the updated PR branch.