### PR TITLE
test(events): add Backbone parity coverage

### DIFF
--- a/test/unit/events-parity.spec.js
+++ b/test/unit/events-parity.spec.js
@@ -1,0 +1,163 @@
+import { createRequire } from 'module';
+import _ from 'underscore';
+
+import EventsMixin from '../../mixins/events';
+
+const require = createRequire(import.meta.url);
+const Backbone = require('backbone');
+
+const createEmitter = Events => _.extend({}, Events);
+
+const runFor = (Events, scenario) => scenario(createEmitter(Events));
+
+const expectParity = scenario => {
+  const backboneResult = runFor(Backbone.Events, scenario);
+  const marionetteResult = runFor(EventsMixin, scenario);
+
+  expect(marionetteResult).to.eql(backboneResult);
+};
+
+describe('Events parity with Backbone.Events', function() {
+  it('dispatches each object-form trigger entry with its mapped value', function() {
+    const emitter = createEmitter(EventsMixin);
+    const calls = [];
+
+    emitter.on('alpha', value => calls.push(['alpha', value]));
+    emitter.on('beta', value => calls.push(['beta', value]));
+
+    // Backbone event-map dispatch:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L95-L113
+    // Marionette extends that shape by passing each mapped value to its handler.
+    emitter.trigger({ alpha: 1, beta: 2 });
+
+    expect(calls).to.eql([
+      ['alpha', 1],
+      ['beta', 2]
+    ]);
+  });
+
+  it('preserves arguments and order for space-separated event names', function() {
+    // Backbone eventsApi space-separated dispatch:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L103-L107
+    expectParity(Events => {
+      const calls = [];
+
+      Events.on('alpha beta', function(...args) {
+        calls.push([this === Events, ...args]);
+      });
+      Events.trigger('alpha beta', 1, 2);
+
+      return calls;
+    });
+  });
+
+  it('removes a once handler before a reentrant trigger', function() {
+    // Backbone once wrappers remove themselves before invoking the callback:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L270-L299
+    expectParity(Events => {
+      const calls = [];
+
+      Events.once('alpha', function(value) {
+        calls.push(value);
+        Events.trigger('alpha', 'reentrant');
+      });
+      Events.trigger('alpha', 'outer');
+
+      return calls;
+    });
+  });
+
+  it('cleans up listener bookkeeping as subscriptions are removed', function() {
+    // Backbone listener cleanup after the final callback is removed:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L220-L268
+    const emitter = createEmitter(EventsMixin);
+    const listener = createEmitter(EventsMixin);
+    const calls = [];
+
+    listener.listenTo(emitter, 'alpha beta', name => calls.push(name));
+    emitter.off('alpha');
+    emitter.trigger('alpha', 'alpha');
+    emitter.trigger('beta', 'beta');
+
+    expect(calls).to.eql(['beta']);
+    expect(Object.keys(listener._rdListeningTo)).to.have.lengthOf(1);
+
+    emitter.off('beta');
+
+    expect(Object.keys(listener._rdListeningTo)).to.have.lengthOf(0);
+    expect(Object.keys(emitter._rdListeners)).to.have.lengthOf(0);
+  });
+
+  it('passes the event name before trigger arguments to all listeners', function() {
+    // Backbone all-listener argument construction:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L301-L325
+    expectParity(Events => {
+      const calls = [];
+
+      Events.on('all', (...args) => calls.push(args));
+      Events.trigger('alpha', 1, { value: 2 });
+
+      return calls;
+    });
+  });
+
+  it('propagates handler errors and stops the current dispatch', function() {
+    // Backbone invokes event callbacks directly without catching handler errors:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L328-L340
+    expectParity(Events => {
+      const calls = [];
+      const error = new Error('handler failed');
+      let thrown;
+
+      Events.on('alpha', () => {
+        calls.push('first');
+        throw error;
+      });
+      Events.on('alpha', () => calls.push('second'));
+
+      try {
+        Events.trigger('alpha');
+      } catch (triggerError) {
+        thrown = triggerError;
+      }
+
+      return {
+        calls,
+        propagatedOriginalError: thrown === error
+      };
+    });
+  });
+
+  it('uses the current handler snapshot during reentrant dispatch', function() {
+    // Backbone captures the current handler-array length before dispatch:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L328-L340
+    expectParity(Events => {
+      const calls = [];
+      let isOuterDispatch = true;
+
+      Events.on('alpha', () => {
+        calls.push(isOuterDispatch ? 'first:outer' : 'first:inner');
+        if (isOuterDispatch) {
+          isOuterDispatch = false;
+          Events.trigger('alpha');
+        }
+      });
+      Events.on('alpha', () => {
+        calls.push(isOuterDispatch ? 'second:outer' : 'second:inner');
+      });
+
+      Events.trigger('alpha');
+
+      return calls;
+    });
+  });
+
+  it('preserves the Backbone.Events object when loading the shim', async function() {
+    // Backbone exposes one stable Events mixin object on its namespace:
+    // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L71-L84
+    const eventsIdentity = Backbone.Events;
+    const { default: ShimmedBackbone } = await import('../../backbone.js');
+
+    expect(ShimmedBackbone.Events).to.equal(eventsIdentity);
+  });
+});

--- a/test/unit/events-parity.spec.js
+++ b/test/unit/events-parity.spec.js
@@ -133,18 +133,26 @@ describe('Events parity with Backbone.Events', function() {
     // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L328-L340
     expectParity(Events => {
       const calls = [];
-      let isOuterDispatch = true;
+      let isInnerDispatch = false;
+
+      const secondHandler = () => {
+        calls.push(isInnerDispatch ? 'second:inner' : 'second:outer');
+      };
+      const lateHandler = () => {
+        calls.push(isInnerDispatch ? 'late:inner' : 'late:outer');
+      };
 
       Events.on('alpha', () => {
-        calls.push(isOuterDispatch ? 'first:outer' : 'first:inner');
-        if (isOuterDispatch) {
-          isOuterDispatch = false;
+        calls.push(isInnerDispatch ? 'first:inner' : 'first:outer');
+        if (!isInnerDispatch) {
+          Events.off('alpha', secondHandler);
+          Events.on('alpha', lateHandler);
+          isInnerDispatch = true;
           Events.trigger('alpha');
+          isInnerDispatch = false;
         }
       });
-      Events.on('alpha', () => {
-        calls.push(isOuterDispatch ? 'second:outer' : 'second:inner');
-      });
+      Events.on('alpha', secondHandler);
 
       Events.trigger('alpha');
 


### PR DESCRIPTION
Closes #68

## What

- Add `test/unit/events-parity.spec.js` with direct comparisons between Marionette Events and Backbone.Events 1.4.0.
- Cover space-separated names, once and reentrant dispatch semantics, listener cleanup, `all` arguments, and handler error propagation.
- Cover the intentional Marionette object-form trigger value extension and verify that loading the Backbone shim preserves the `Backbone.Events` object identity.

## Why

Marionette v5 owns its Events implementation, but the public listener and dispatch behavior did not have focused parity coverage against Backbone.Events. These tests lock down the compatibility boundary and document the intentional object-form trigger difference.

## Scope

- Tests only: `test/unit/events-parity.spec.js`.
- No runtime, package, build, documentation, or generated distribution changes.
- Backbone source links are included beside the equivalent behavior checks.

## Deployment Impact

No deployment or redeploy is required. This change affects test coverage only.

## Testing

- `npx vitest run test/unit/events-parity.spec.js` — 8 tests passed.
- `npx eslint test/unit/events-parity.spec.js --max-warnings=0` — passed with no warnings.
- `npm test` — 59 files and 1,087 tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `test/unit/events-parity.spec.js` to verify Marionette `Events` matches `Backbone.Events` 1.4.0, including handler snapshot behavior during reentrant dispatch. Also confirms object-form trigger passes mapped values and the Backbone shim preserves the `Backbone.Events` object identity; closes #68.

<sup>Written for commit 58e948c9e42fab56d624fa51e5c425c662886d86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

