### PR TITLE
chore(ci): pin first-party actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         run: npm run test:fixtures
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: coverage-node-24
@@ -68,12 +68,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -94,12 +94,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -119,7 +119,7 @@ jobs:
         run: node config/bundle-size.mjs --json > bundle-size-current.json
 
       - name: Checkout base branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.base_ref }}
           path: bundle-size-base
@@ -138,7 +138,7 @@ jobs:
           cat bundle-size-report.md >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload bundle-size report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bundle-size-report
           path: bundle-size-report.md

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/node-current.yml
+++ b/.github/workflows/node-current.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 26
           cache: npm


### PR DESCRIPTION
Related #130

## What

- Pin every `actions/checkout` use to v7.0.1's immutable commit.
- Pin every `actions/setup-node` use to v7.0.0's immutable commit.
- Pin every `actions/upload-artifact` use to v7.0.1's immutable commit.

## Why

GitHub warns that the previous pinned releases use the deprecated Node 20 action runtime and are being forced onto Node 24. The selected first-party releases declare `runs.using: node24`, removing that compatibility warning while retaining immutable SHA pins.

## Scope

This changes the action runtime pins in CI, Documentation, and Node-current workflows. Workflow triggers, jobs, permissions, runner labels, inputs, cache settings, artifact names and paths, package source, and generated distribution files are intentionally unchanged.

## Deployment Impact

No package or application redeploy is required. The change applies to future GitHub Actions workflow runs only and does not alter the documentation deployment conditions.

## Testing

- `git diff --check`
- Parsed every `.github/workflows/*.yml` file with Ruby YAML.
- Compared each workflow to `8e88038b9cce9ef90b17c33aebe73e74150e5590` after normalizing only the three action pin lines; no other behavior changed.
- `npx --yes --package=node@24.19.0 --package=npm@11.17.0 --call 'node --version && npm --version && npm run check:release-profile'`
- `npm run docs:check`

`actionlint` was not available locally; GitHub Actions provides the execution validation for the updated action versions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins first-party GitHub Actions to v7 releases that run on Node 24, removing GitHub's deprecated Node 20 runtime warning from CI flows.

- Updates `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` to immutable SHAs in the CI, Docs, and Node-current workflows.
- Workflow triggers, jobs, permissions, inputs, cache settings, artifact names/paths, and generated files are unchanged.
- No package or app redeploy is needed; the change only affects future workflow runs and doesn't alter documentation deployment conditions.

<sup>Written for commit a7526bc71368515be4058c3b7097b634f2db641b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

