### PR TITLE
fix(build): move artifact validation out of install

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "test": "vitest run",
     "test:dist": "node test/dist/validate.mjs",
     "test:fixtures": "node test/fixtures/run.mjs",
-    "prepare": "npm run check:dist && npm run test:dist"
+    "prepack": "npm run build && npm run test:dist"
   },
   "bugs": {
     "url": "https://github.com/marionettejs/marionette/issues"


### PR DESCRIPTION
Closes #151

## What

- Replace the root `prepare` hook with `prepack`.
- Build and validate distributable entry points before packing or publishing Marionette.
- Keep committed-artifact drift enforcement in the explicit CI-only `check:dist` command.

## Why

`prepare` runs during ordinary `npm ci` and local installs. That made a clean bootstrap run Rollup and fail whenever source and committed artifacts differed, even though artifact drift is already a dedicated CI policy. Packaging still needs fresh, validated distributables, which is the lifecycle boundary `prepack` provides.

## Scope

- Package lifecycle configuration only.
- No runtime source, generated artifact, dependency, lockfile, public API, browser contract, or bundle change.
- `check:dist` remains unchanged and continues to enforce committed artifacts in CI.

## Deployment Impact

No application redeploy or runtime deployment is required. The change affects contributor installs and future package preparation only; normal package publication will run the new `prepack` gate.

## Agent-development failure addressed

- A source-first agent checkout can now complete `npm ci` even while its intended source edit makes committed artifacts stale.
- The same stale state still fails the explicit CI artifact check, preserving release integrity without adding install-time work.

## Public behavior contract

- Canonical behavior after this PR: installs bootstrap dependencies without building Marionette; package creation and publication build and validate distributable entry points.
- Git and tag consumers use the committed `dist` projection enforced by the #153 release profile and explicit CI drift check. Under npm 11.17.0, the tested Git dependency path does not run `prepack`; a source-only stale commit is invalid and must be rejected by CI rather than repaired during consumer installation.
- Superseded behavior removed, if any: ordinary installs no longer invoke `prepare`, Rollup, `check:dist`, or `test:dist` for the root package.
- Compatibility exception and removal condition, if any: none.

## Runtime cost

- [ ] Static or documentation only
- [x] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: unchanged; `npm run size` reports ES module 19.83/20.83 kB, CommonJS 20.00/21.00 kB, minified UMD 10.03/10.53 kB, and Backbone shim 121/128 B.
- Startup/hot path: unchanged; no production module was edited.
- Allocations/retention: unchanged; no runtime code was edited.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm ci --foreground-scripts --no-audit --no-fund
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm run check:release-profile -- --host macos-arm64 --runner macos-15
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm run check:dist
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm run test:fixtures
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm pack --dry-run
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm run lint:ci
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm run coverage -- --reporter=dot
npx --yes --package=node@24.19.0 --package=npm@11.17.0 npm run size
```

Additional acceptance evidence:

- Exact-profile clean install completed without any root `prepare`, Rollup, or `check:dist` invocation.
- In a disposable detached worktree, a source-only URL change left committed artifacts stale: exact-profile `npm ci` passed, then explicit `npm run check:dist` exited 1 and identified all six changed distributable files.
- A disposable local Git consumer installed valid committed artifacts from commit `6650dec` and passed CommonJS and ESM import/version/error-path smoke checks.
- A separate stale-Git proof confirmed npm 11.17.0 did not run `prepack` and consumed the old committed artifacts; this is intentionally rejected at the producer CI boundary rather than rebuilt during consumer installation.
- Coverage: 60 files and 1,096 tests passed; statements, branches, functions, and lines remained at 100%.

## Testing

Unit coverage, package fixtures, dry-run packaging, clean bootstrap, stale-artifact rejection, valid local Git dependency CJS/ESM/error paths, lint, release-profile verification, and bundle-size budgets all passed under the pinned Node/npm profile. No browser test was run because the lifecycle-only change does not alter browser behavior.

## Package and browser impact

- Entry points or install fixtures affected: packaging lifecycle timing only; Git/tag consumers continue to use CI-verified committed artifacts, and all existing fixture entry points passed.
- Browser contracts affected: none.
- Production/dev/test module-graph impact: production graph unchanged; root install omits the former build/check hook, while `prepack` adds build plus distributable validation at package preparation.

## Rollback or deprecation

Revert this commit to restore the prior `prepare` lifecycle. No data migration or deprecation period applies.

## Review notes

The Claude monitor review is an explicit external merge gate. Do not merge solely on normal CI/reviewer success until that gate reports approval.
