### PR TITLE
docs(governance): align documentation code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-/docs/ @paulfalgout
-/docs-site/ @paulfalgout
-/config/docs/ @paulfalgout
-/config/diagnostics/ @paulfalgout
-/config/check-diagnostic-catalog.mjs @paulfalgout
-/.github/workflows/docs-pages.yml @paulfalgout
+/docs/ @paulfalgout @marionettejs/marionette-core
+/docs-site/ @paulfalgout @marionettejs/marionette-core
+/config/docs/ @paulfalgout @marionettejs/marionette-core
+/config/diagnostics/ @paulfalgout @marionettejs/marionette-core
+/config/check-diagnostic-catalog.mjs @paulfalgout @marionettejs/marionette-core
+/.github/workflows/docs-pages.yml @paulfalgout @marionettejs/marionette-core


### PR DESCRIPTION
## Linked issue

- Related #153

## What

- Add `@marionettejs/marionette-core` to all six existing documentation, documentation-tooling, diagnostic-catalog, and documentation-workflow ownership rules.
- Retain `@paulfalgout` on every existing rule.

## Why

The documentation publication contract names the Marionette core team as the repository owner. The current CODEOWNERS file names only one individual, so review ownership does not match that contract.

## Agent-development failure addressed

- Documentation and diagnostic changes now expose the durable team-level review owner directly in repository metadata instead of requiring agents to infer an individual maintainer.

## Public behavior contract

- Canonical behavior after this PR: matching pull requests request review from both the existing individual owner and `@marionettejs/marionette-core`.
- Superseded behavior removed, if any: individual-only ownership for these paths.
- Compatibility exception and removal condition, if any: N/A; retaining the individual owner provides explicit additional coverage and does not preserve obsolete behavior.

## Runtime cost

- [x] Static or documentation only
- [ ] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: 0 B across every reported bundle in CI.
- Startup/hot path: none; CODEOWNERS is GitHub metadata.
- Allocations/retention: none.

## Scope

- Changes only `.github/CODEOWNERS`.
- Does not change documentation content, diagnostics, workflows, Pages settings, DNS, HTTPS, runtime code, package contents, or generated artifacts.

## Deployment Impact

No application, package, documentation, or form deployment is required.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
git diff --check
# passed

# Validated all six non-comment rules contain one path and both expected owner tokens.
# Verified @marionettejs/marionette-core exists and has repository admin permission through the GitHub API.
```

CI also passed Node 24, Node 26 advisory, macOS arm64 and Windows x64 package smoke, CodeQL, and bundle-size checks at exact head `9ac5cbcd6dd95c045a3ffe4bd99018e5c45bcaed`.

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: none.
- Production/dev/test module-graph impact: none.

## Rollback or deprecation

Revert the CODEOWNERS-only commit if GitHub cannot resolve the team owner. The team currently exists and has repository administration permission.

## Review notes

- GitHub Pages, DNS, HTTPS, and the `DOCS_PAGES_ENABLED` deployment gate remain intentionally unchanged and externally blocked under #153.
