### PR TITLE
test(release): pin publication failure paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ on:
       - 'package.json'
       - 'test/dist/**'
       - 'test/fixtures/**'
+      - 'test/release/**'
       - 'version.js'
   workflow_dispatch:
     inputs:
@@ -110,6 +111,9 @@ jobs:
 
       - name: Lint
         run: npm run lint:ci
+
+      - name: Test release failure paths
+        run: npm run test:release-promotion
 
       - name: Run configured coverage
         run: npm run coverage

--- a/config/release/github-release.mjs
+++ b/config/release/github-release.mjs
@@ -1,0 +1,4 @@
+export function publishDraftRelease({ editArgs, ensureTag, run }) {
+  ensureTag();
+  run(editArgs);
+}

--- a/config/release/publish-github.mjs
+++ b/config/release/publish-github.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
+import { publishDraftRelease } from './github-release.mjs';
 
 const root = resolve(import.meta.dirname, '../..');
 const args = process.argv.slice(2);
@@ -270,6 +271,5 @@ if (evidence.release.prerelease) {
 } else {
   editArgs.push('--latest');
 }
-ensureTag();
-run(editArgs);
+publishDraftRelease({ editArgs, ensureTag, run });
 console.log(`Published GitHub release ${evidence.release.tag}.`);

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "test": "vitest run",
     "test:dist": "node test/dist/validate.mjs",
     "test:fixtures": "node test/fixtures/run.mjs",
+    "test:release-promotion": "node --test test/release/promotion.test.mjs",
     "test:source": "node test/source/validate.mjs",
     "prepack": "npm run build && npm run test:dist"
   },

--- a/test/release/promotion.test.mjs
+++ b/test/release/promotion.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { after, test } from 'node:test';
+import { publishDraftRelease } from '../../config/release/github-release.mjs';
+
+const root = resolve(import.meta.dirname, '../..');
+const temporaryDirectories = [];
+
+after(async function() {
+  await Promise.all(temporaryDirectories.map(directory => rm(directory, {
+    force: true,
+    recursive: true,
+  })));
+});
+
+async function createArtifactDirectory(evidence, withChecksum = false) {
+  const directory = await mkdtemp(join(tmpdir(), 'marionette-release-test-'));
+  temporaryDirectories.push(directory);
+  const evidenceText = `${JSON.stringify(evidence, null, 2)}\n`;
+  await writeFile(resolve(directory, 'release-evidence.json'), evidenceText);
+  if (withChecksum) {
+    const checksum = createHash('sha512').update(evidenceText).digest('hex');
+    await writeFile(
+      resolve(directory, 'release-evidence.sha512'),
+      `${checksum}  release-evidence.json\n`,
+    );
+  }
+  return directory;
+}
+
+function runScript(file, args) {
+  return spawnSync(process.execPath, [resolve(root, file), ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  });
+}
+
+test('release artifact verification rejects Windows drive-relative names', async function() {
+  const artifactDirectory = await createArtifactDirectory({
+    schemaVersion: 1,
+    package: {
+      tarball: {
+        file: 'C:evil.tgz',
+      },
+    },
+  }, true);
+
+  const result = runScript('config/release/verify-artifact.mjs', [
+    '--artifact-dir',
+    artifactDirectory,
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Release artifact must use a contained file name: C:evil\.tgz/);
+});
+
+test('GitHub release planning rejects Windows drive-relative names', async function() {
+  const artifactDirectory = await createArtifactDirectory({
+    package: {
+      tarball: {
+        file: 'C:evil.tgz',
+      },
+    },
+    reports: {
+      bundle: {
+        file: 'bundle-report.json',
+      },
+      packageManifest: {
+        file: 'package-manifest.json',
+      },
+    },
+  });
+
+  const result = runScript('config/release/publish-github.mjs', [
+    '--mode',
+    'dry-run',
+    '--artifact-dir',
+    artifactDirectory,
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Release artifact must use a contained file name: C:evil\.tgz/);
+});
+
+test('tag validation failure prevents a draft from becoming public', function() {
+  const tagError = new Error('tag conflict');
+  let editCalled = false;
+
+  assert.throws(() => publishDraftRelease({
+    editArgs: ['release', 'edit', 'v5.0.0'],
+    ensureTag() {
+      throw tagError;
+    },
+    run() {
+      editCalled = true;
+    },
+  }), error => error === tagError);
+  assert.equal(editCalled, false);
+});
+
+test('a verified tag is followed by the public release edit', function() {
+  const calls = [];
+  const editArgs = ['release', 'edit', 'v5.0.0', '--draft=false'];
+
+  publishDraftRelease({
+    editArgs,
+    ensureTag() {
+      calls.push('tag');
+    },
+    run(args) {
+      calls.push(args);
+    },
+  });
+
+  assert.deepEqual(calls, ['tag', editArgs]);
+});

--- a/test/release/promotion.test.mjs
+++ b/test/release/promotion.test.mjs
@@ -119,3 +119,19 @@ test('a verified tag is followed by the public release edit', function() {
 
   assert.deepEqual(calls, ['tag', editArgs]);
 });
+
+test('a failed public release edit propagates after tag validation', function() {
+  const editError = new Error('release edit failed');
+  let tagValidated = false;
+
+  assert.throws(() => publishDraftRelease({
+    editArgs: ['release', 'edit', 'v5.0.0', '--draft=false'],
+    ensureTag() {
+      tagValidated = true;
+    },
+    run() {
+      throw editError;
+    },
+  }), error => error === editError);
+  assert.equal(tagValidated, true);
+});


### PR DESCRIPTION
Closes #179

## What

- add hermetic CLI tests proving Windows drive-relative artifact names are rejected by both release artifact verification and GitHub release planning;
- extract the two-step draft publication boundary and prove tag validation failure prevents the public-release edit;
- run the focused failure-path suite in the release-promotion pull-request workflow.

## Why

The exact-head Claude review of #178 approved the implementation but identified these two negative paths as worthwhile executable regression evidence. Agents should be able to verify fail-closed publication behavior without relying on reviewer code inspection.

## Scope

Release tooling and CI tests only. Runtime source, package exports, bundle code, npm publication state, Git tags, GitHub releases, and website publication are unchanged.

## Deployment Impact

No application or website deployment is needed. This only adds repository tests and a release-script helper; actual publication remains disabled by the checked-in policy.

## Testing

- `npm run test:release-promotion`
- `npm run lint:ci`
- `npm run test:source`
- `/private/tmp/actionlint.2dzED6/actionlint .github/workflows/release.yml`
- `node config/check-dist.mjs`
- built and verified a fresh immutable tarball with `npm run release:artifact` and `npm run release:verify`

The focused suite covers rejection in both CLIs, failure-before-edit ordering, and the successful tag-then-edit order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #179. Adds hermetic tests proving release artifact verification and GitHub release planning reject Windows drive-relative artifact names, that tag validation failure prevents the draft from being made public, and that edit failures propagate after tag validation. Extracts the draft-publication step into a helper so the failure and ordering paths are testable, and runs the new suite in the release-promotion CI workflow. No runtime or publication behavior changes; publication remains disabled by policy.

<sup>Written for commit 049f3f02a1d66fa9b88a64e8d70e2b5fd7e6f4ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation to reject unsafe tarball filenames, including Windows drive-relative paths.
  * Prevented draft release updates when tag verification fails.

* **Tests**
  * Added coverage for release validation, tag verification failures, and successful draft-release promotion.
  * Release checks now run automatically for relevant pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->