### PR TITLE
refactor(performance): keep timing cases canonical

### DIFF
--- a/benchmarks/performance.mjs
+++ b/benchmarks/performance.mjs
@@ -212,7 +212,6 @@ function createCases({ Backbone, Marionette }) {
 export async function measure({
   root = '.',
   configPath = 'config/performance.json',
-  caseFactory = createCases,
   dependencyRoot = root,
 } = {}) {
   const resolvedRoot = resolve(root);
@@ -223,7 +222,7 @@ export async function measure({
   const results = [];
 
   try {
-    const cases = caseFactory(runtime);
+    const cases = createCases(runtime);
     for (const caseConfig of contract.timing.cases) {
       const run = cases.get(caseConfig.id);
       if (!run) {

--- a/config/performance.json
+++ b/config/performance.json
@@ -289,7 +289,7 @@
   },
   "timing": {
     "harnessSchemaVersion": 1,
-    "harnessRevision": "f22242e13a8af8ee11a57930a6913d77b2ab65f32fa109c917987cdfeadb9145",
+    "harnessRevision": "271128bee00c66b3168424d65220dbe6c5dbea1f336082c21b45a07a344bb1d9",
     "sampleCount": 20,
     "warmupBatches": 5,
     "cases": [

--- a/test/performance/timing.test.mjs
+++ b/test/performance/timing.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -94,21 +94,26 @@ describe('hosted timing report math', () => {
   });
 
   test('restores DOM globals when timing case construction fails', async() => {
-    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-timing-'));
-    const contract = JSON.parse(await readFile(new URL('../../config/performance.json', import.meta.url)));
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-runtime-'));
+    const configPath = fileURLToPath(new URL('../../config/performance.json', import.meta.url));
     const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
     const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
 
     try {
-      const configPath = join(fixtureRoot, 'performance.json');
-      await writeFile(configPath, JSON.stringify(contract));
+      await mkdir(join(fixtureRoot, 'dist'));
+      await writeFile(join(fixtureRoot, 'package.json'), '{"type":"module"}\n');
+      await writeFile(
+        join(fixtureRoot, 'dist/marionette.js'),
+        'export const View = { extend() { throw new Error("Timing case construction failed"); } };\n' +
+        'export const Behavior = {};\n' +
+        'export const CollectionView = {};\n' +
+        'export const Region = {};\n'
+      );
       await assert.rejects(
         measure({
-          root,
+          root: fixtureRoot,
           configPath,
-          caseFactory() {
-            throw new Error('Timing case construction failed');
-          },
+          dependencyRoot: root,
         }),
         /Timing case construction failed/
       );


### PR DESCRIPTION
Related #127

Follow-up to #181 and its late [CodeRabbit review](https://github.com/marionettejs/marionette/pull/181#discussion_r3873599903).

## What
- Remove the exported `caseFactory` override so hosted reports always use the pinned canonical timing cases.
- Preserve the case-construction cleanup regression through a temporary ESM runtime fixture that fails during the real `createCases` path.
- Regenerate the pinned timing-harness SHA-256.

## Why
The test seam added while addressing #181 feedback also allowed programmatic callers to substitute different workloads under canonical configured case IDs. This follow-up restores a single benchmark-definition path without weakening cleanup coverage.

## Scope
- Benchmark tooling, its focused timing test, and the pinned performance contract only.
- Timing case IDs, workloads, thresholds, and hosted-reporting-only policy are unchanged.
- Runtime source, package exports, dependencies, and built artifact bytes are unchanged.
- The separate suggestion to expose private allocation/retention shapes as a public runtime API is intentionally out of scope because those tests are repository-internal structural proxies and the Phase 0 contract requires zero runtime overhead.

## Deployment Impact
No application or form redeploy is required. No npm publication, Git tag, GitHub release, or website publication is involved.

## Testing
- `npm ci`
- `npm run test:performance` — 17/17 passed
- `npm run lint:ci`
- `npm run size` — 49,500 B / 51,975 B; production graphs 40/1/1
- `npm run performance:timing` — all seven canonical cases completed
- `npm run check:dist`
- Independent SHA-256 source/contract equality check
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `caseFactory` override from `measure` so hosted benchmark reports always run the pinned canonical timing cases, and preserves cleanup coverage by failing inside the real `createCases` path through a temporary ESM runtime fixture. Regenerates the timing-harness SHA-256 to match.

The override seam allowed programmatic callers to substitute workloads under canonical case IDs; closing it restores a single benchmark-definition path without weakening cleanup coverage. Timing case IDs, workloads, thresholds, and the hosted-reporting-only policy are unchanged. No runtime, export, dependency, artifact, or rollout changes are involved.

<sup>Written for commit 77000606d5c7b9d10f833dcf4c70d83266db12cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

