### PR TITLE
fix(ci): run required docs check for every PR

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -18,19 +18,6 @@ on:
       - 'package-lock.json'
       - 'package.json'
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.nvmrc'
-      - 'config/check-release-profile.mjs'
-      - 'config/check-diagnostic-catalog.mjs'
-      - 'config/diagnostics/**'
-      - 'config/docs/**'
-      - 'config/release-profile.json'
-      - 'docs/**'
-      - 'docs-site/**'
-      - 'upgradeGuide.md'
-      - 'package-lock.json'
-      - 'package.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What
- Run the `Build and validate` documentation job for every pull request.
- Keep the existing path filter for `master` pushes, so documentation publishing work is not broadened.

## Why
The default-branch ruleset requires `Build and validate`, but the workflow previously existed only for pull requests touching documentation-related paths. Non-documentation PRs therefore could pass every available check while remaining permanently blocked because the required check was never created.

## Scope
- Documentation workflow trigger behavior only.
- Documentation build commands, deployment guards, runtime source, package artifacts, and release behavior are unchanged.
- Website deployment remains disabled unless the existing `DOCS_PAGES_ENABLED` variable and `master` push conditions are satisfied.

## Deployment Impact
No application, package, form, or website deployment is performed by this PR. Pull requests will run one additional required documentation validation job.

## Testing
- Parsed `.github/workflows/docs-pages.yml` with Ruby YAML
- `npm ci`
- `npm run docs:check` — 29 documentation pages, 30 HTML files, 288 internal links
- `git diff --check`
- The PR itself must produce the required `Build and validate` check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the required `Build and validate` docs check for every pull request. Previously, the check only ran when PRs touched documentation-related paths, so non-documentation PRs could fail to meet the branch ruleset because the required check never ran. The path filter is removed only for `pull_request` events; `master` pushes keep the existing filter, so deployment behavior is unchanged.

<sup>Written for commit 9359bbe6b6de78d18f431a539e615ad3638c1a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

