### PR TITLE
perf(build): enforce monotonic resource baselines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /.github/workflows/docs-pages.yml @paulfalgout @marionettejs/marionette-core
 /config/performance.json @paulfalgout @marionettejs/marionette-core
 /config/bundle-size.mjs @paulfalgout @marionettejs/marionette-core
+/config/performance-resources.mjs @paulfalgout @marionettejs/marionette-core
 /benchmarks/ @paulfalgout @marionettejs/marionette-core
 /test/performance/ @paulfalgout @marionettejs/marionette-core
 /.github/workflows/ci.yml @paulfalgout @marionettejs/marionette-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,21 +149,40 @@ jobs:
       - name: Enforce exact base performance contract
         id: base_authority
         continue-on-error: true
+        env:
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           base_contract='bundle-size-base/config/performance.json'
           authority_script='bundle-size-base/config/bundle-size.mjs'
+          # Each exact-SHA fallback becomes permanently unreachable after its reviewed bootstrap merges.
           if [ ! -f "${base_contract}" ]; then
+            if [ "${PULL_REQUEST_BASE_SHA}" != '31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4' ]; then
+              echo 'Base has no performance contract and is not the reviewed performance bootstrap base.' >&2
+              exit 1
+            fi
             base_contract='config/performance.json'
             authority_script='config/bundle-size.mjs'
-            echo 'Base has no performance contract; using the current contract for this bootstrap PR.'
+            echo 'Using the current contract for the performance bootstrap from exact base 31151c9.'
+          elif [ ! -f 'bundle-size-base/config/performance-resources.mjs' ]; then
+            if [ "${PULL_REQUEST_BASE_SHA}" != '25f3739376d391df396885f3ea1b88fa1ea7a0f0' ]; then
+              echo 'Base has no resource comparator and is not the reviewed bootstrap base.' >&2
+              exit 1
+            fi
+            authority_script='config/bundle-size.mjs'
+            echo 'Using the current validator for the resource bootstrap from exact base 25f3739.'
           fi
           node "${authority_script}" --root bundle-size-base --config "${base_contract}" --json --no-enforce > bundle-size-base.json
           authority_status=0
           node "${authority_script}" --config "${base_contract}" --json > bundle-size-authority.json || authority_status=$?
-          node config/bundle-size.mjs --report bundle-size-base.json bundle-size-authority.json > bundle-size-report.md
+          candidate_status=0
+          node "${authority_script}" --validate-resource-contract "${base_contract}" config/performance.json || candidate_status=$?
+          report_status=0
+          node "${authority_script}" --report bundle-size-base.json bundle-size-authority.json > bundle-size-report.md || report_status=$?
           cat bundle-size-report.md >> "${GITHUB_STEP_SUMMARY}"
-          exit "${authority_status}"
+          if [ "${authority_status}" -ne 0 ] || [ "${candidate_status}" -ne 0 ] || [ "${report_status}" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Upload bundle-size report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -6,6 +6,12 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { brotliCompress, constants } from 'node:zlib';
 import { rollup } from 'rollup';
+import {
+  compareResources,
+  measureResources,
+  resourceReportRows,
+  validateCandidateResourceContract,
+} from './performance-resources.mjs';
 
 const compress = promisify(brotliCompress);
 
@@ -318,7 +324,11 @@ async function measureArtifact(root, quality, artifact) {
   }
 }
 
-export async function measure({ root = '.', configPath = 'config/performance.json', checkToolchain = true } = {}) {
+export async function measure({
+  root = '.',
+  configPath = 'config/performance.json',
+  checkToolchain = true,
+} = {}) {
   const resolvedRoot = resolve(root);
   const resolvedConfigPath = resolve(configPath);
   const contract = await readJson(resolvedConfigPath);
@@ -392,6 +402,19 @@ export async function measure({ root = '.', configPath = 'config/performance.jso
     }
   }
 
+  let resources = null;
+  if (contract.deterministicResources) {
+    try {
+      resources = await measureResources({
+        root: resolvedRoot,
+        attachDetachCycles: contract.deterministicResources.attachDetachCycles,
+        mountDestroyCycles: contract.deterministicResources.mountDestroyCycles,
+      });
+    } catch (error) {
+      violations.push(`Unable to measure deterministic resources: ${error.message}`);
+    }
+  }
+
   return {
     schemaVersion: 1,
     contractPath: normalizePath(relative(resolvedRoot, resolvedConfigPath)),
@@ -405,6 +428,8 @@ export async function measure({ root = '.', configPath = 'config/performance.jso
       absoluteCeiling: contract.baseline.absoluteCeilingBytes,
     },
     graphs,
+    resourcesRequired: Boolean(contract.deterministicResources),
+    resources,
     violations,
   };
 }
@@ -426,6 +451,32 @@ function graphChange(baseGraph, currentGraph) {
   if (externalAdded.length) { changes.push(`external +${externalAdded.join(', +')}`); }
   if (externalRemoved.length) { changes.push(`external -${externalRemoved.join(', -')}`); }
   return changes.join('; ') || 'No change';
+}
+
+function compareResourceReports(base, current) {
+  if (!base.resources && !current.resources) {
+    if (base.resourcesRequired || current.resourcesRequired) {
+      return {
+        changes: [],
+        violations: ['Required resource measurements are missing from both reports'],
+      };
+    }
+    return { changes: [], violations: [], unavailable: true };
+  }
+  if (!base.resources) {
+    return {
+      changes: [],
+      violations: ['Exact base resource measurement is missing'],
+    };
+  }
+  if (!current.resources) {
+    return {
+      changes: [],
+      violations: ['Pull request resource measurement is missing'],
+    };
+  }
+
+  return compareResources(base.resources, current.resources);
 }
 
 export async function createReport(baseFile, currentFile) {
@@ -455,6 +506,19 @@ export async function createReport(baseFile, currentFile) {
   });
   const cumulativeGrowth = formatChange(base.cumulative.size, current.cumulative.size);
   const phase0Growth = formatChange(current.cumulative.baselineSize, current.cumulative.size);
+  const resourceComparison = compareResourceReports(base, current);
+  const resourceSection = resourceComparison.unavailable ? [] : [
+    '',
+    '## Deterministic allocation and retention',
+    '',
+    '| Structural proxy | Base | PR | Result |',
+    '| --- | --- | --- | --- |',
+    ...resourceReportRows(resourceComparison),
+    '',
+    resourceComparison.violations.length ?
+      `Resource regressions: ${resourceComparison.violations.join('; ')}` :
+      'No eager allocation or retained-resource proxy increased from the exact pull request base.',
+  ];
 
   return [
     '<!-- bundle-size-report -->',
@@ -473,8 +537,9 @@ export async function createReport(baseFile, currentFile) {
     current.violations.length ?
       `Contract violations: ${current.violations.join('; ')}` :
       'All deterministic size and production-graph checks passed against the base authority contract.',
+    ...resourceSection,
     '',
-    'The exact-head approval protocol for growth above 1% and new subpaths is intentionally deferred to #127 PR B; this report does not treat that threshold as an enforceable approval yet.'
+    'The exact-head approval protocol for growth above 1% and new subpaths remains a separate #127 follow-up; this report does not treat that threshold as enforceable approval yet.'
   ].join('\n');
 }
 
@@ -491,12 +556,38 @@ function writeMeasurement(result, json) {
   for (const graph of result.graphs) {
     console.log(`${graph.subpath}: ${graph.status === 'measured' ? `${graph.modules.length} internal modules, ${graph.externalImports.length} external imports` : graph.error}`);
   }
+  if (result.resources) {
+    console.log(`Resources: ${Object.keys(result.resources.allocations).length} unused instance shapes; ${result.resources.workload.attachDetachCycles} detach cycles; ${result.resources.workload.mountDestroyCycles} mount/destroy cycles`);
+  }
 }
 
 export async function main(args = process.argv.slice(2)) {
+  const candidateIndex = args.indexOf('--validate-resource-contract');
+  if (candidateIndex !== -1) {
+    const [authority, candidate] = await Promise.all([
+      readJson(args[candidateIndex + 1]),
+      readJson(args[candidateIndex + 2]),
+    ]);
+    const violations = validateCandidateResourceContract(authority, candidate);
+    for (const violation of violations) {
+      console.error(`Performance contract violation: ${violation}`);
+    }
+    if (violations.length) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   const reportIndex = args.indexOf('--report');
   if (reportIndex !== -1) {
-    console.log(await createReport(args[reportIndex + 1], args[reportIndex + 2]));
+    const baseFile = args[reportIndex + 1];
+    const currentFile = args[reportIndex + 2];
+    console.log(await createReport(baseFile, currentFile));
+    const [base, current] = await Promise.all([readJson(baseFile), readJson(currentFile)]);
+    const comparison = compareResourceReports(base, current);
+    if (comparison.violations.length) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -557,16 +557,26 @@ function writeMeasurement(result, json) {
     console.log(`${graph.subpath}: ${graph.status === 'measured' ? `${graph.modules.length} internal modules, ${graph.externalImports.length} external imports` : graph.error}`);
   }
   if (result.resources) {
-    console.log(`Resources: ${Object.keys(result.resources.allocations).length} unused instance shapes; ${result.resources.workload.attachDetachCycles} detach cycles; ${result.resources.workload.mountDestroyCycles} mount/destroy cycles`);
+    console.log(`Resources: ${Object.keys(result.resources.allocations).length} measured instance shapes; ${result.resources.workload.attachDetachCycles} detach cycles; ${result.resources.workload.mountDestroyCycles} mount/destroy cycles`);
   }
+}
+
+function positionalPaths(args, index, count, name) {
+  const paths = args.slice(index + 1, index + count + 1);
+  if (paths.length !== count || paths.some(path => !path || path.startsWith('--'))) {
+    throw new Error(`Missing paths for ${name}`);
+  }
+
+  return paths;
 }
 
 export async function main(args = process.argv.slice(2)) {
   const candidateIndex = args.indexOf('--validate-resource-contract');
   if (candidateIndex !== -1) {
+    const paths = positionalPaths(args, candidateIndex, 2, '--validate-resource-contract');
     const [authority, candidate] = await Promise.all([
-      readJson(args[candidateIndex + 1]),
-      readJson(args[candidateIndex + 2]),
+      readJson(paths[0]),
+      readJson(paths[1]),
     ]);
     const violations = validateCandidateResourceContract(authority, candidate);
     for (const violation of violations) {
@@ -580,8 +590,7 @@ export async function main(args = process.argv.slice(2)) {
 
   const reportIndex = args.indexOf('--report');
   if (reportIndex !== -1) {
-    const baseFile = args[reportIndex + 1];
-    const currentFile = args[reportIndex + 2];
+    const [baseFile, currentFile] = positionalPaths(args, reportIndex, 2, '--report');
     console.log(await createReport(baseFile, currentFile));
     const [base, current] = await Promise.all([readJson(baseFile), readJson(currentFile)]);
     const comparison = compareResourceReports(base, current);

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -479,7 +479,7 @@ function compareResourceReports(base, current) {
   return compareResources(base.resources, current.resources);
 }
 
-export async function createReport(baseFile, currentFile) {
+async function buildReport(baseFile, currentFile) {
   const base = await readJson(baseFile);
   const current = await readJson(currentFile);
   const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
@@ -520,7 +520,7 @@ export async function createReport(baseFile, currentFile) {
       'No eager allocation or retained-resource proxy increased from the exact pull request base.',
   ];
 
-  return [
+  const markdown = [
     '<!-- bundle-size-report -->',
     '## Production performance contract 📦',
     '',
@@ -541,6 +541,12 @@ export async function createReport(baseFile, currentFile) {
     '',
     'The exact-head approval protocol for growth above 1% and new subpaths remains a separate #127 follow-up; this report does not treat that threshold as enforceable approval yet.'
   ].join('\n');
+
+  return { markdown, resourceComparison };
+}
+
+export async function createReport(baseFile, currentFile) {
+  return (await buildReport(baseFile, currentFile)).markdown;
 }
 
 function writeMeasurement(result, json) {
@@ -591,10 +597,9 @@ export async function main(args = process.argv.slice(2)) {
   const reportIndex = args.indexOf('--report');
   if (reportIndex !== -1) {
     const [baseFile, currentFile] = positionalPaths(args, reportIndex, 2, '--report');
-    console.log(await createReport(baseFile, currentFile));
-    const [base, current] = await Promise.all([readJson(baseFile), readJson(currentFile)]);
-    const comparison = compareResourceReports(base, current);
-    if (comparison.violations.length) {
+    const report = await buildReport(baseFile, currentFile);
+    console.log(report.markdown);
+    if (report.resourceComparison.violations.length) {
       process.exitCode = 1;
     }
     return;

--- a/config/performance-resources.mjs
+++ b/config/performance-resources.mjs
@@ -2,6 +2,8 @@ import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+let runtimeLoaded = false;
+
 function registrations(eventMap, owner) {
   return Object.values(eventMap || {})
     .flat()
@@ -89,6 +91,11 @@ function restoreGlobal(name, descriptor) {
 }
 
 async function loadRuntime(root) {
+  if (runtimeLoaded) {
+    throw new Error('Resource measurement supports one built runtime per process');
+  }
+  runtimeLoaded = true;
+
   const requireFromRoot = createRequire(resolve(root, 'package.json'));
   const { JSDOM } = requireFromRoot('jsdom');
   const dom = new JSDOM('<!doctype html><html><body></body></html>');

--- a/config/performance-resources.mjs
+++ b/config/performance-resources.mjs
@@ -96,21 +96,22 @@ async function loadRuntime(root) {
   }
   runtimeLoaded = true;
 
-  const requireFromRoot = createRequire(resolve(root, 'package.json'));
-  const { JSDOM } = requireFromRoot('jsdom');
-  const dom = new JSDOM('<!doctype html><html><body></body></html>');
-  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
-  const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
-  globalThis.window = dom.window;
-  globalThis.document = dom.window.document;
-
-  const cleanup = () => {
-    restoreGlobal('window', previousWindow);
-    restoreGlobal('document', previousDocument);
-    dom.window.close();
-  };
+  let cleanup;
 
   try {
+    const requireFromRoot = createRequire(resolve(root, 'package.json'));
+    const { JSDOM } = requireFromRoot('jsdom');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    cleanup = () => {
+      restoreGlobal('window', previousWindow);
+      restoreGlobal('document', previousDocument);
+      dom.window.close();
+    };
+
     const backboneUrl = pathToFileURL(resolve(root, 'dist/backbone.js'));
     const runtimeUrl = pathToFileURL(resolve(root, 'dist/marionette.js'));
     const [{ default: Backbone }, Marionette] = await Promise.all([
@@ -120,7 +121,8 @@ async function loadRuntime(root) {
 
     return { Backbone, Marionette, cleanup };
   } catch (error) {
-    cleanup();
+    runtimeLoaded = false;
+    cleanup?.();
     throw error;
   }
 }

--- a/config/performance-resources.mjs
+++ b/config/performance-resources.mjs
@@ -34,6 +34,22 @@ function maxValue(target, key, ...values) {
   target[key] = Math.max(target[key], ...values);
 }
 
+const workloadFields = ['attachDetachCycles', 'mountDestroyCycles'];
+
+function validCycleCount(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+function validateWorkload(workload, label) {
+  if (!workload || typeof workload !== 'object') {
+    return [`${label} is missing`];
+  }
+
+  return workloadFields
+    .filter(field => !validCycleCount(workload[field]))
+    .map(field => `${label} ${field} must be a positive integer; received ${workload[field]}`);
+}
+
 function instanceMeasurement(instance, { Region }) {
   const ownProperties = Object.keys(instance).sort();
   const entries = ownProperties.map(property => [property, instance[property]]);
@@ -103,6 +119,12 @@ async function loadRuntime(root) {
 }
 
 export async function measureResources({ root = '.', attachDetachCycles, mountDestroyCycles }) {
+  const workload = { attachDetachCycles, mountDestroyCycles };
+  const workloadViolations = validateWorkload(workload, 'Resource measurement workload');
+  if (workloadViolations.length) {
+    throw new Error(workloadViolations.join('; '));
+  }
+
   const resolvedRoot = resolve(root);
   const runtime = await loadRuntime(resolvedRoot);
   const { Backbone, Marionette } = runtime;
@@ -190,7 +212,11 @@ export async function measureResources({ root = '.', attachDetachCycles, mountDe
     for (let index = 0; index < mountDestroyCycles; index += 1) {
       const regionEl = document.createElement('div');
       document.body.appendChild(regionEl);
-      const cycleRegion = new Region({ el: regionEl });
+      const regionHost = new PlainView();
+      const cycleRegion = regionHost.addRegion('resource', { el: regionEl });
+      if (cycleRegion._parentView !== regionHost) {
+        throw new Error('Region resource scenario did not establish parent ownership');
+      }
       const regionView = new PlainView();
       cycleRegion.show(regionView);
       cycleRegion.empty();
@@ -264,17 +290,14 @@ export async function measureResources({ root = '.', attachDetachCycles, mountDe
       retention.destroyedBehaviorRetainsHostReference ||= mountedBehavior.view === behaviorView;
       maxValue(retention, 'destroyedHostRetainsBehaviorCount', behaviorView._behaviors.length);
 
-      cycleRegion.destroy();
+      regionHost.destroy();
       maxValue(retention, 'regionParentReferencesAfterDestroy', Number(cycleRegion._parentView != null));
       regionEl.remove();
     }
 
     return {
       schemaVersion: 1,
-      workload: {
-        attachDetachCycles,
-        mountDestroyCycles,
-      },
+      workload,
       allocations,
       retention,
     };
@@ -348,10 +371,17 @@ export function compareResources(base, current) {
   const changes = [];
   const violations = [];
 
-  if (base.schemaVersion !== current.schemaVersion) {
-    violations.push(`Resource schema changed from ${base.schemaVersion} to ${current.schemaVersion}`);
+  if (base.schemaVersion !== 1) {
+    violations.push(`Exact-base resource schemaVersion must be 1; received ${base.schemaVersion}`);
   }
-  if (JSON.stringify(base.workload) !== JSON.stringify(current.workload)) {
+  if (current.schemaVersion !== 1) {
+    violations.push(`Pull request resource schemaVersion must be 1; received ${current.schemaVersion}`);
+  }
+  const baseWorkloadViolations = validateWorkload(base.workload, 'Exact-base resource workload');
+  const currentWorkloadViolations = validateWorkload(current.workload, 'Pull request resource workload');
+  violations.push(...baseWorkloadViolations, ...currentWorkloadViolations);
+  if (!baseWorkloadViolations.length && !currentWorkloadViolations.length &&
+      JSON.stringify(base.workload) !== JSON.stringify(current.workload)) {
     violations.push('Resource measurement workload does not match the exact base');
   }
 
@@ -377,8 +407,14 @@ export function validateCandidateResourceContract(authorityContract, candidateCo
   }
 
   const violations = [];
-  for (const field of ['attachDetachCycles', 'mountDestroyCycles']) {
-    if (!Number.isInteger(candidate[field]) || candidate[field] < authority[field]) {
+  for (const field of workloadFields) {
+    if (!validCycleCount(authority[field])) {
+      violations.push(`Exact-base authority ${field} must be a positive integer; received ${authority[field]}`);
+      continue;
+    }
+    if (!validCycleCount(candidate[field])) {
+      violations.push(`Candidate ${field} must be a positive integer; received ${candidate[field]}`);
+    } else if (candidate[field] < authority[field]) {
       violations.push(`Candidate ${field} ${candidate[field]} is below the exact-base authority ${authority[field]}`);
     }
   }
@@ -388,7 +424,9 @@ export function validateCandidateResourceContract(authorityContract, candidateCo
 
 export function resourceReportRows(comparison) {
   if (!comparison.changes.length) {
-    return ['| None | No change | No change | Pass |'];
+    return comparison.violations.length ?
+      ['| Contract validation | Not comparable | Not comparable | Review required |'] :
+      ['| None | No change | No change | Pass |'];
   }
 
   return comparison.changes.map(change => {

--- a/config/performance-resources.mjs
+++ b/config/performance-resources.mjs
@@ -1,0 +1,397 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function registrations(eventMap, owner) {
+  return Object.values(eventMap || {})
+    .flat()
+    .filter(event => !owner || event.context === owner || event.ctx === owner || event.listener === owner)
+    .length;
+}
+
+function marionetteRegistrations(emitter, owner) {
+  return registrations(emitter._rdEvents, owner);
+}
+
+function backboneRegistrations(emitter, owner) {
+  return registrations(emitter._events, owner);
+}
+
+function ledgerEntries(ledger) {
+  return Object.keys(ledger || {}).length;
+}
+
+function childContainerEntries(container) {
+  return Math.max(
+    container.length,
+    container._views.length,
+    ledgerEntries(container._viewsByCid),
+    ledgerEntries(container._indexByModel)
+  );
+}
+
+function maxValue(target, key, ...values) {
+  target[key] = Math.max(target[key], ...values);
+}
+
+function instanceMeasurement(instance, { Region }) {
+  const ownProperties = Object.keys(instance).sort();
+  const entries = ownProperties.map(property => [property, instance[property]]);
+  const arrays = entries.filter(([, value]) => Array.isArray(value));
+  const plainObjects = entries.filter(([, value]) => value?.constructor === Object);
+  const childViewContainers = entries.filter(([, value]) => Array.isArray(value?._views) &&
+    value?._viewsByCid && value?._indexByModel);
+  const regions = entries.filter(([, value]) => value instanceof Region);
+  const references = entries.filter(([, value]) =>
+    value !== null && (typeof value === 'object' || typeof value === 'function'));
+
+  return {
+    ownProperties,
+    ownReferences: references.map(([property]) => property),
+    uniqueOwnReferences: new Set(references.map(([, value]) => value)).size,
+    arrays: arrays.map(([property]) => property),
+    arrayEntries: arrays.reduce((total, [, value]) => total + value.length, 0),
+    plainObjects: plainObjects.map(([property]) => property),
+    plainObjectEntries: plainObjects.reduce((total, [, value]) => total + Object.keys(value).length, 0),
+    childViewContainers: childViewContainers.map(([property]) => property),
+    childViewContainerEntries: childViewContainers.reduce((total, [, value]) => {
+      return total + childContainerEntries(value);
+    }, 0),
+    regions: regions.map(([property]) => property),
+    regionsWithViews: regions.filter(([, value]) => value.hasView()).length,
+    marionetteEventRegistrations: marionetteRegistrations(instance),
+    listeningContainers: ledgerEntries(instance._rdListeningTo),
+  };
+}
+
+function restoreGlobal(name, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete globalThis[name];
+  }
+}
+
+async function loadRuntime(root) {
+  const requireFromRoot = createRequire(resolve(root, 'package.json'));
+  const { JSDOM } = requireFromRoot('jsdom');
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+
+  const cleanup = () => {
+    restoreGlobal('window', previousWindow);
+    restoreGlobal('document', previousDocument);
+    dom.window.close();
+  };
+
+  try {
+    const backboneUrl = pathToFileURL(resolve(root, 'dist/backbone.js'));
+    const runtimeUrl = pathToFileURL(resolve(root, 'dist/marionette.js'));
+    const [{ default: Backbone }, Marionette] = await Promise.all([
+      import(backboneUrl.href),
+      import(runtimeUrl.href),
+    ]);
+
+    return { Backbone, Marionette, cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+}
+
+export async function measureResources({ root = '.', attachDetachCycles, mountDestroyCycles }) {
+  const resolvedRoot = resolve(root);
+  const runtime = await loadRuntime(resolvedRoot);
+  const { Backbone, Marionette } = runtime;
+  const { Behavior, CollectionView, Region, View } = Marionette;
+  const PlainView = View.extend({ template: false });
+  const ChildView = View.extend({ template: false });
+  const ListeningBehavior = Behavior.extend({
+    modelEvents: {
+      change: 'onModelChange'
+    },
+    onModelChange() {
+      this.modelChanges = (this.modelChanges || 0) + 1;
+    }
+  });
+  const BehaviorView = View.extend({
+    behaviors: [ListeningBehavior],
+    template: false,
+  });
+
+  try {
+    const view = new View();
+    const region = new Region({ el: document.createElement('div') });
+    const behaviorHost = new View();
+    const behavior = new Behavior({}, behaviorHost);
+    const collectionView = new CollectionView({
+      childView: ChildView,
+      collection: new Backbone.Collection(),
+    });
+    const allocations = {
+      View: instanceMeasurement(view, Marionette),
+      Region: instanceMeasurement(region, Marionette),
+      Behavior: instanceMeasurement(behavior, Marionette),
+      CollectionView: instanceMeasurement(collectionView, Marionette),
+    };
+
+    behavior.destroy();
+    behaviorHost.destroy();
+    view.destroy();
+    region.destroy();
+    collectionView.destroy();
+
+    const retention = {
+      regionRegistrationsWhileShown: 0,
+      collectionRegistrationsWhileMounted: 0,
+      modelRegistrationsWhileMounted: 0,
+      externalListenerOwnersWhileMounted: 0,
+      collectionViewListeningToWhileMounted: 0,
+      behaviorListeningToWhileMounted: 0,
+      destroyedBehaviorRetainsHostReference: false,
+      destroyedHostRetainsBehaviorCount: 0,
+      externalRegistrationsAfterDestroy: 0,
+      externalListenerOwnersAfterDestroy: 0,
+      frameworkListeningToAfterDestroy: 0,
+      childContainerEntriesAfterDestroy: 0,
+      managedDomChildrenAfterEmpty: 0,
+      managedRootsConnectedAfterDestroy: 0,
+      regionParentReferencesAfterDestroy: 0,
+    };
+    const detachRegionEl = document.createElement('div');
+    document.body.appendChild(detachRegionEl);
+    const detachRegion = new Region({ el: detachRegionEl });
+    const detachView = new PlainView();
+
+    for (let index = 0; index < attachDetachCycles; index += 1) {
+      detachRegion.show(detachView);
+      if (!detachRegion.hasView() || detachRegion.currentView !== detachView) {
+        throw new Error('Region resource scenario did not show its view');
+      }
+      maxValue(retention, 'regionRegistrationsWhileShown', marionetteRegistrations(detachView, detachRegion));
+      detachRegion.detachView();
+      if (detachRegion.hasView()) {
+        throw new Error('Region resource scenario did not detach its view');
+      }
+      maxValue(retention, 'externalRegistrationsAfterDestroy', marionetteRegistrations(detachView, detachRegion));
+      maxValue(retention, 'managedDomChildrenAfterEmpty', detachRegionEl.childNodes.length);
+    }
+
+    detachView.destroy();
+    detachRegion.destroy();
+    detachRegionEl.remove();
+
+    const collection = new Backbone.Collection([{ id: 1 }]);
+    const model = new Backbone.Model();
+
+    for (let index = 0; index < mountDestroyCycles; index += 1) {
+      const regionEl = document.createElement('div');
+      document.body.appendChild(regionEl);
+      const cycleRegion = new Region({ el: regionEl });
+      const regionView = new PlainView();
+      cycleRegion.show(regionView);
+      cycleRegion.empty();
+      maxValue(retention, 'externalRegistrationsAfterDestroy', marionetteRegistrations(regionView, cycleRegion));
+      maxValue(retention, 'managedDomChildrenAfterEmpty', regionEl.childNodes.length);
+
+      const mountedCollectionView = new CollectionView({
+        childView: ChildView,
+        collection,
+      });
+      document.body.appendChild(mountedCollectionView.el);
+      mountedCollectionView.render();
+      if (mountedCollectionView.children.length !== collection.length) {
+        throw new Error('CollectionView resource scenario did not render its collection');
+      }
+      maxValue(
+        retention,
+        'collectionRegistrationsWhileMounted',
+        backboneRegistrations(collection, mountedCollectionView),
+        marionetteRegistrations(collection, mountedCollectionView)
+      );
+      maxValue(retention, 'externalListenerOwnersWhileMounted', ledgerEntries(collection._rdListeners));
+      maxValue(retention, 'collectionViewListeningToWhileMounted', ledgerEntries(mountedCollectionView._rdListeningTo));
+      mountedCollectionView.destroy();
+
+      maxValue(
+        retention,
+        'childContainerEntriesAfterDestroy',
+        childContainerEntries(mountedCollectionView._children),
+        childContainerEntries(mountedCollectionView.children)
+      );
+      maxValue(
+        retention,
+        'externalRegistrationsAfterDestroy',
+        backboneRegistrations(collection, mountedCollectionView),
+        marionetteRegistrations(collection, mountedCollectionView)
+      );
+      maxValue(retention, 'externalListenerOwnersAfterDestroy', ledgerEntries(collection._rdListeners));
+      maxValue(retention, 'frameworkListeningToAfterDestroy', ledgerEntries(mountedCollectionView._rdListeningTo));
+      maxValue(retention, 'managedDomChildrenAfterEmpty', mountedCollectionView.el.childNodes.length);
+      maxValue(retention, 'managedRootsConnectedAfterDestroy', Number(mountedCollectionView.el.isConnected));
+
+      const behaviorView = new BehaviorView({ model });
+      const mountedBehavior = behaviorView._behaviors[0];
+      document.body.appendChild(behaviorView.el);
+      model.set('resourceCycle', index);
+      if (mountedBehavior.modelChanges !== 1) {
+        throw new Error('Behavior resource scenario did not receive its model event');
+      }
+      maxValue(
+        retention,
+        'modelRegistrationsWhileMounted',
+        backboneRegistrations(model, mountedBehavior),
+        marionetteRegistrations(model, mountedBehavior)
+      );
+      maxValue(retention, 'externalListenerOwnersWhileMounted', ledgerEntries(model._rdListeners));
+      maxValue(retention, 'behaviorListeningToWhileMounted', ledgerEntries(mountedBehavior._rdListeningTo));
+      behaviorView.destroy();
+
+      maxValue(
+        retention,
+        'externalRegistrationsAfterDestroy',
+        backboneRegistrations(model, behaviorView),
+        backboneRegistrations(model, mountedBehavior),
+        marionetteRegistrations(model, mountedBehavior)
+      );
+      maxValue(retention, 'externalListenerOwnersAfterDestroy', ledgerEntries(model._rdListeners));
+      maxValue(retention, 'frameworkListeningToAfterDestroy', ledgerEntries(mountedBehavior._rdListeningTo));
+      maxValue(retention, 'managedDomChildrenAfterEmpty', behaviorView.el.childNodes.length);
+      maxValue(retention, 'managedRootsConnectedAfterDestroy', Number(behaviorView.el.isConnected));
+      retention.destroyedBehaviorRetainsHostReference ||= mountedBehavior.view === behaviorView;
+      maxValue(retention, 'destroyedHostRetainsBehaviorCount', behaviorView._behaviors.length);
+
+      cycleRegion.destroy();
+      maxValue(retention, 'regionParentReferencesAfterDestroy', Number(cycleRegion._parentView != null));
+      regionEl.remove();
+    }
+
+    return {
+      schemaVersion: 1,
+      workload: {
+        attachDetachCycles,
+        mountDestroyCycles,
+      },
+      allocations,
+      retention,
+    };
+  } finally {
+    document.body.textContent = '';
+    runtime.cleanup();
+  }
+}
+
+function displayValue(value) {
+  return Array.isArray(value) ? value.join(', ') || 'None' : String(value);
+}
+
+function compareValues(base, current, path, changes, violations) {
+  if (Array.isArray(base)) {
+    if (!Array.isArray(current)) {
+      violations.push(`${path} changed measurement type`);
+      return;
+    }
+    const added = current.filter(value => !base.includes(value));
+    const removed = base.filter(value => !current.includes(value));
+    if (added.length || removed.length) {
+      const status = added.length ? 'regression' : 'improvement';
+      changes.push({ path, base, current, status });
+    }
+    if (added.length) {
+      violations.push(`${path} added ${added.join(', ')}`);
+    }
+    return;
+  }
+
+  if (typeof base === 'number' || typeof base === 'boolean') {
+    if (typeof current !== typeof base) {
+      violations.push(`${path} changed measurement type`);
+      return;
+    }
+    const baseValue = Number(base);
+    const currentValue = Number(current);
+    if (currentValue !== baseValue) {
+      const status = currentValue > baseValue ? 'regression' : 'improvement';
+      changes.push({ path, base, current, status });
+      if (status === 'regression') {
+        violations.push(`${path} increased from ${displayValue(base)} to ${displayValue(current)}`);
+      }
+    }
+    return;
+  }
+
+  if (!base || typeof base !== 'object' || !current || typeof current !== 'object') {
+    violations.push(`${path} has unsupported measurement values`);
+    return;
+  }
+
+  const baseKeys = Object.keys(base).sort();
+  const currentKeys = Object.keys(current).sort();
+  const missing = baseKeys.filter(key => !currentKeys.includes(key));
+  const unknown = currentKeys.filter(key => !baseKeys.includes(key));
+  if (missing.length) {
+    violations.push(`${path} is missing metrics: ${missing.join(', ')}`);
+  }
+  if (unknown.length) {
+    violations.push(`${path} has unknown metrics: ${unknown.join(', ')}`);
+  }
+
+  for (const metric of baseKeys.filter(key => currentKeys.includes(key))) {
+    compareValues(base[metric], current[metric], `${path}.${metric}`, changes, violations);
+  }
+}
+
+export function compareResources(base, current) {
+  const changes = [];
+  const violations = [];
+
+  if (base.schemaVersion !== current.schemaVersion) {
+    violations.push(`Resource schema changed from ${base.schemaVersion} to ${current.schemaVersion}`);
+  }
+  if (JSON.stringify(base.workload) !== JSON.stringify(current.workload)) {
+    violations.push('Resource measurement workload does not match the exact base');
+  }
+
+  compareValues(
+    { allocations: base.allocations, retention: base.retention },
+    { allocations: current.allocations, retention: current.retention },
+    'resources',
+    changes,
+    violations
+  );
+
+  return { changes, violations };
+}
+
+export function validateCandidateResourceContract(authorityContract, candidateContract) {
+  const authority = authorityContract.deterministicResources;
+  const candidate = candidateContract.deterministicResources;
+  if (!authority) {
+    return ['Exact-base performance contract is missing deterministicResources'];
+  }
+  if (!candidate) {
+    return ['Candidate performance contract is missing deterministicResources'];
+  }
+
+  const violations = [];
+  for (const field of ['attachDetachCycles', 'mountDestroyCycles']) {
+    if (!Number.isInteger(candidate[field]) || candidate[field] < authority[field]) {
+      violations.push(`Candidate ${field} ${candidate[field]} is below the exact-base authority ${authority[field]}`);
+    }
+  }
+
+  return violations;
+}
+
+export function resourceReportRows(comparison) {
+  if (!comparison.changes.length) {
+    return ['| None | No change | No change | Pass |'];
+  }
+
+  return comparison.changes.map(change => {
+    return `| \`${change.path}\` | ${displayValue(change.base)} | ${displayValue(change.current)} | ${change.status === 'regression' ? 'Regression' : 'Improvement'} |`;
+  });
+}

--- a/config/performance-resources.mjs
+++ b/config/performance-resources.mjs
@@ -104,13 +104,13 @@ async function loadRuntime(root) {
     const dom = new JSDOM('<!doctype html><html><body></body></html>');
     const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
     const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
-    globalThis.window = dom.window;
-    globalThis.document = dom.window.document;
     cleanup = () => {
       restoreGlobal('window', previousWindow);
       restoreGlobal('document', previousDocument);
       dom.window.close();
     };
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
 
     const backboneUrl = pathToFileURL(resolve(root, 'dist/backbone.js'));
     const runtimeUrl = pathToFileURL(resolve(root, 'dist/marionette.js'));

--- a/config/performance.json
+++ b/config/performance.json
@@ -245,6 +245,7 @@
         ],
         "emptyObjects": [
           "_regions",
+          "options",
           "regions"
         ],
         "marionetteEventRegistrations": 6
@@ -254,6 +255,7 @@
           "_domEvents"
         ],
         "emptyObjects": [
+          "options",
           "ui"
         ],
         "listeningContainers": 1
@@ -284,7 +286,9 @@
       "externalListenerOwnersAfterDestroy": 0,
       "frameworkListeningToAfterDestroy": 0,
       "childContainerEntriesAfterDestroy": 0,
-      "managedDomChildrenAfterEmpty": 0
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
     }
   },
   "timing": {

--- a/config/performance.json
+++ b/config/performance.json
@@ -177,6 +177,7 @@
   ],
   "forbiddenProductionModules": [
     "config/bundle-size.mjs",
+    "config/performance-resources.mjs",
     "config/performance.json",
     "config/release-profile.json",
     "config/release-promotion.json"

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -15,6 +15,11 @@ npm ci
 npm run size
 ```
 
+That single-checkout command validates the current artifacts, lifecycle scenarios,
+and absolute budgets, but it cannot reproduce a base-relative resource regression by
+itself. Use the pull request report or the exact base/current sequence in
+`.github/workflows/ci.yml` when debugging a monotonic-comparison failure.
+
 The check builds the package and measures every shipped runtime JavaScript artifact
 with Brotli quality 11. The Phase 0 total is 49,500 bytes and the fixed cumulative
 ceiling is 51,975 bytes, exactly five percent above that baseline. Package entrypoints

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -27,19 +27,17 @@ documentation, benchmark, release, or diagnostic tooling enters a production gra
 The Phase 0 module lists remain fixed evidence; ordinary source-module refactors are
 reported rather than prohibited when the resulting graph remains clean.
 
-Unit tests record both the own-property shape and the current eager allocation
-categories of unused View, Region, Behavior, and CollectionView instances. That
-baseline includes the empty arrays, objects, ChildViewContainers, event maps, and
-CollectionView empty Region that v5 currently creates; it records the current cost
-without pretending those allocations are already pay-for-play. Repeated lifecycle
-checks prove that Region registrations are removed after 100 detach cycles and that
-long-lived DOM, model, and collection owners return to their original event counts
-after every one of 1,000 mount/destroy cycles. A destroyed Behavior and its destroyed
-host currently retain each other inside the otherwise released graph; the baseline
-records that collectible internal cycle instead of falsely claiming those two
-objects are emptied. These allocation and retention shapes are structural ownership
-proxies. They detect known eager containers, listener ownership, and managed DOM
-cleanup deterministically; they are not heap-size, reachability, leak-detector, or
+The same command measures the built runtime's own-property and reference shapes for
+unused View, Region, Behavior, and CollectionView instances. It records eager arrays,
+plain objects, ChildViewContainers, Regions, event registrations, and listening
+ledgers without pretending those allocations are already pay-for-play. Repeated
+lifecycle scenarios prove public behavior while recording Region detach cleanup and
+1,000 CollectionView and Behavior mount/destroy cycles. A destroyed Behavior and its
+destroyed host currently retain each other inside the otherwise released graph; the
+baseline records that collectible internal cycle instead of falsely claiming those
+two objects are emptied. These measurements are structural ownership proxies. They
+detect eager containers, listener ownership, managed DOM cleanup, and known internal
+cycles deterministically; they are not heap-size, reachability, leak-detector, or
 garbage-collector proof.
 
 ## Pull request comparison
@@ -56,12 +54,24 @@ contract. After the bootstrap merges, the fallback is unreachable for ordinary
 descendant pull requests. Reports call out missing artifacts, untracked `.js`,
 `.cjs`, or `.mjs` files, and new or unmeasurable subpaths explicitly.
 
-Structural allocation and retention shapes are recorded and checked for internal
-consistency in PR A, but they are not yet compared with the base contract. A literal
-base-shape equality gate would also reject desired improvements that remove eager
-containers or retained references. PR B must add a monotonic comparator: newly eager
-or more-retained ownership fails without approval, while removals and lower retention
-remain allowed and visible.
+Allocation and retention observations are compared monotonically with the exact pull
+request base. New own properties, reference-backed storage, containers, registrations,
+listener owners, managed DOM, or retained framework entries fail the existing required
+`Bundle size` check. Removed storage and lower retention pass and remain visible as
+improvements in the report. Missing metrics, unknown metrics, incompatible schemas,
+and reduced lifecycle workloads fail closed. The validator also verifies the public
+Region, CollectionView, and Behavior scenarios so a broken or vacuous all-zero probe
+cannot appear to be an improvement.
+
+This comparator has one explicit bootstrap exception: its immediate base contains the
+recorded resource shapes but predates the comparator module. CI therefore uses the
+reviewed pull request validator to measure both exact builds only when the pull request
+base is the pinned resource-bootstrap commit `25f3739`. The earlier performance-
+contract bootstrap is likewise pinned to its reviewed base `31151c9`; any other base
+missing either authority fails closed. Every descendant uses the exact base revision
+of both the validator and resource probe. The active strict required-status-check
+policy prevents a stale pre-bootstrap branch from merging without updating to the
+protected base.
 
 The current contract is also validated independently so intentional contract and
 toolchain edits remain internally coherent. Its pinned release profile records Node
@@ -71,10 +81,10 @@ checks. CI posts artifact, cumulative-size, and production-graph changes through
 the repository's read-only workflow plus the separate comment workflow.
 
 The roadmap also requires explicit issue approval and evidence for growth above one
-percent versus the pull request base and for every new production subpath. This PR A
-does not invent a weak convention that agents could satisfy themselves. PR B must
-define an exact-head, maintainer-authored approval record and make the check validate
-that record before these cases can merge.
+percent versus the pull request base and for every new production subpath. The
+resource comparator does not invent a weak convention that agents could satisfy
+themselves. A separate follow-up must define an exact-head, maintainer-authored
+approval record and make the check validate that record before these cases can merge.
 
 ## Hosted timing
 
@@ -92,12 +102,12 @@ CI runs the base and pull request on the same Ubuntu hosted worker and reports m
 and p95 changes. A change above ten percent is a warning only because shared-runner
 timing is noisy.
 
-Hosted results never decide merge or release eligibility. PR B must name the
-controlled machine, pin its CPU, operating system and kernel, architecture, power
-state, isolation policy, and harness revision, record the initial timing baseline,
-and enforce the roadmap's independently repeated five-percent median and ten-percent
-p95 release limits. Immutable release evidence must consume that exact-source report;
-until then `controlledRunner.status` remains `pending-pr-b`.
+Hosted results never decide merge or release eligibility. A separate follow-up must
+name the controlled machine, pin its CPU, operating system and kernel, architecture,
+power state, isolation policy, and harness revision, record the initial timing
+baseline, and enforce the roadmap's independently repeated five-percent median and
+ten-percent p95 release limits. Immutable release evidence must consume that
+exact-source report; until then `controlledRunner.status` remains `pending-pr-b`.
 
 ## Runtime boundary
 
@@ -107,9 +117,9 @@ zero-runtime-overhead boundary executable.
 
 ## Ownership and enforcement
 
-CODEOWNERS assigns the contract, harness, focused tests, and performance workflows
-to the project maintainer and core team. Current live repository rules do not require
-a CODEOWNER approval, so ownership is review routing rather than an automated merge
-gate. The exact-base authority contract is the automated anti-relaxation guard after
-this bootstrap; PR B remains responsible only for the separate greater-than-one-
-percent approval protocol and controlled timing runner.
+CODEOWNERS assigns the contract, resource probe, harness, focused tests, and
+performance workflows to the project maintainer and core team. Current live repository
+rules do not require a CODEOWNER approval, so ownership is review routing rather than
+an automated merge gate. The exact-base authority contract is the automated
+anti-relaxation guard after this bootstrap; the greater-than-one-percent approval
+protocol and controlled timing runner remain separate follow-ups.

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -173,6 +174,64 @@ describe('performance contract validation', () => {
         writeFile(currentReport, JSON.stringify(result)),
       ]);
       assert.match(await createReport(baseReport, currentReport), /\| `\.` \| 1 \| None \| No change \|/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects forbidden modules from the measured production graph', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-forbidden-'));
+    const contract = contractFor();
+    contract.productionGraphs = [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/index.mjs',
+      baselineModules: ['index.js'],
+      baselineExternalImports: [],
+    }];
+    contract.forbiddenProductionModules = ['forbidden.js'];
+    const packageJson = {
+      type: 'module',
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+
+    try {
+      await mkdir(join(fixtureRoot, 'dist'));
+      await writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(packageJson));
+      await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
+      await writeFile(
+        join(fixtureRoot, 'index.js'),
+        'import { forbidden } from \'./forbidden.js\';\nexport const value = forbidden;\n'
+      );
+      await writeFile(join(fixtureRoot, 'forbidden.js'), 'export const forbidden = true;\n');
+      await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
+      await writeFile(
+        join(fixtureRoot, 'rollup.config.mjs'),
+        'export default [{ input: \'index.js\', output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
+      );
+
+      const result = await measure({
+        root: fixtureRoot,
+        configPath: join(fixtureRoot, 'performance.json'),
+        checkToolchain: false,
+      });
+
+      assert.deepEqual(result.graphs[0].forbiddenModules, ['forbidden.js']);
+      assert.ok(result.violations.includes('. includes forbidden production modules: forbidden.js'));
+
+      const enforced = spawnSync(
+        process.execPath,
+        [
+          join(root, 'config/bundle-size.mjs'),
+          '--root', fixtureRoot,
+          '--config', join(fixtureRoot, 'performance.json'),
+          '--artifact-graph-only',
+          '--json',
+        ],
+        { encoding: 'utf8' }
+      );
+      assert.equal(enforced.status, 1);
+      assert.match(enforced.stderr, /includes forbidden production modules: forbidden\.js/);
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -216,5 +216,9 @@ describe('performance contract validation', () => {
     assert.ok(
       contract.forbiddenProductionModules.includes('config/performance-resources.mjs')
     );
+    assert.deepEqual(
+      findForbiddenModules(['index.js', 'config/performance-resources.mjs'], contract),
+      ['config/performance-resources.mjs']
+    );
   });
 });

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -213,5 +213,8 @@ describe('performance contract validation', () => {
     const contract = JSON.parse(await readFile(new URL('../../config/performance.json', import.meta.url)));
 
     assert.deepEqual(await validateToolchain(contract, root), []);
+    assert.ok(
+      contract.forbiddenProductionModules.includes('config/performance-resources.mjs')
+    );
   });
 });

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -275,6 +275,27 @@ describe('deterministic resource comparison', () => {
     await assert.rejects(
       measureResources({ root: '/missing', attachDetachCycles: 1, mountDestroyCycles: 1 })
     );
+    const lockedDocumentDescriptor = {
+      configurable: true,
+      enumerable: true,
+      value: {},
+      writable: false,
+    };
+    Object.defineProperty(globalThis, 'document', lockedDocumentDescriptor);
+    await assert.rejects(
+      measureResources({ root, attachDetachCycles: 1, mountDestroyCycles: 1 }),
+      /Cannot assign to read only property 'document'/
+    );
+    assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'window'), windowDescriptor);
+    assert.deepEqual(
+      Object.getOwnPropertyDescriptor(globalThis, 'document'),
+      lockedDocumentDescriptor
+    );
+    if (documentDescriptor) {
+      Object.defineProperty(globalThis, 'document', documentDescriptor);
+    } else {
+      delete globalThis.document;
+    }
     const measurement = await measureResources({
       root,
       attachDetachCycles: 1,

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -282,19 +282,22 @@ describe('deterministic resource comparison', () => {
       writable: false,
     };
     Object.defineProperty(globalThis, 'document', lockedDocumentDescriptor);
-    await assert.rejects(
-      measureResources({ root, attachDetachCycles: 1, mountDestroyCycles: 1 }),
-      /Cannot assign to read only property 'document'/
-    );
-    assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'window'), windowDescriptor);
-    assert.deepEqual(
-      Object.getOwnPropertyDescriptor(globalThis, 'document'),
-      lockedDocumentDescriptor
-    );
-    if (documentDescriptor) {
-      Object.defineProperty(globalThis, 'document', documentDescriptor);
-    } else {
-      delete globalThis.document;
+    try {
+      await assert.rejects(
+        measureResources({ root, attachDetachCycles: 1, mountDestroyCycles: 1 }),
+        /Cannot assign to read only property 'document'/
+      );
+      assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'window'), windowDescriptor);
+      assert.deepEqual(
+        Object.getOwnPropertyDescriptor(globalThis, 'document'),
+        lockedDocumentDescriptor
+      );
+    } finally {
+      if (documentDescriptor) {
+        Object.defineProperty(globalThis, 'document', documentDescriptor);
+      } else {
+        delete globalThis.document;
+      }
     }
     const measurement = await measureResources({
       root,

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import {
+  compareResources,
+  measureResources,
+  resourceReportRows,
+  validateCandidateResourceContract,
+} from '../../config/performance-resources.mjs';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+
+function report() {
+  return {
+    schemaVersion: 1,
+    workload: {
+      attachDetachCycles: 100,
+      mountDestroyCycles: 1000,
+    },
+    allocations: {
+      View: {
+        ownProperties: ['cid'],
+        ownReferences: ['_behaviors'],
+        uniqueOwnReferences: 1,
+        arrays: ['_behaviors'],
+        arrayEntries: 0,
+        plainObjects: [],
+        plainObjectEntries: 0,
+        childViewContainers: [],
+        childViewContainerEntries: 0,
+        regions: [],
+        regionsWithViews: 0,
+        marionetteEventRegistrations: 6,
+        listeningContainers: 0,
+      },
+    },
+    retention: {
+      externalRegistrationsAfterDestroy: 0,
+      destroyedHostRetainsBehaviorCount: 1,
+    },
+  };
+}
+
+function bundleReport(resources, resourcesRequired = resources != null) {
+  return {
+    brotliQuality: 11,
+    thresholds: { pullRequestApprovalPercent: 1 },
+    artifacts: [],
+    cumulative: {
+      size: 0,
+      baselineSize: 0,
+      absoluteCeiling: 0,
+    },
+    graphs: [],
+    resourcesRequired,
+    resources,
+    violations: [],
+  };
+}
+
+describe('deterministic resource comparison', () => {
+  test('rejects added eager storage and increased retention despite head claims', () => {
+    const base = report();
+    const current = structuredClone(base);
+    current.claimedBaseline = {
+      allocations: current.allocations,
+      retention: current.retention,
+    };
+    current.allocations.View.arrays.push('_domEvents');
+    current.allocations.View.uniqueOwnReferences = 2;
+    current.retention.destroyedHostRetainsBehaviorCount = 2;
+
+    const comparison = compareResources(base, current);
+
+    assert.deepEqual(comparison.violations, [
+      'resources.allocations.View.arrays added _domEvents',
+      'resources.allocations.View.uniqueOwnReferences increased from 1 to 2',
+      'resources.retention.destroyedHostRetainsBehaviorCount increased from 1 to 2',
+    ]);
+    assert.match(resourceReportRows(comparison).join('\n'), /Regression/);
+  });
+
+  test('allows and reports removed allocations and lower retention', () => {
+    const base = report();
+    const current = structuredClone(base);
+    current.allocations.View.arrays = [];
+    current.allocations.View.ownReferences = [];
+    current.allocations.View.uniqueOwnReferences = 0;
+    current.allocations.View.marionetteEventRegistrations = 5;
+    current.retention.destroyedHostRetainsBehaviorCount = 0;
+
+    const comparison = compareResources(base, current);
+
+    assert.deepEqual(comparison.violations, []);
+    assert.equal(comparison.changes.length, 5);
+    assert.ok(comparison.changes.every(change => change.status === 'improvement'));
+    assert.match(resourceReportRows(comparison).join('\n'), /Improvement/);
+  });
+
+  test('fails closed for missing, unknown, or incompatible measurements', () => {
+    const base = report();
+    const current = structuredClone(base);
+    delete current.allocations.View.plainObjects;
+    current.allocations.View.unknownLedger = 0;
+    current.workload.mountDestroyCycles = 1;
+
+    const comparison = compareResources(base, current);
+
+    assert.ok(comparison.violations.includes('Resource measurement workload does not match the exact base'));
+    assert.ok(comparison.violations.includes('resources.allocations.View is missing metrics: plainObjects'));
+    assert.ok(comparison.violations.includes('resources.allocations.View has unknown metrics: unknownLedger'));
+  });
+
+  test('rejects candidate contracts that reduce or remove authority workloads', () => {
+    const authority = {
+      deterministicResources: report().workload,
+    };
+    const reduced = structuredClone(authority);
+    reduced.deterministicResources.mountDestroyCycles = 1;
+
+    assert.deepEqual(validateCandidateResourceContract(authority, reduced), [
+      'Candidate mountDestroyCycles 1 is below the exact-base authority 1000',
+    ]);
+    assert.deepEqual(validateCandidateResourceContract(authority, {}), [
+      'Candidate performance contract is missing deterministicResources',
+    ]);
+    assert.deepEqual(validateCandidateResourceContract({}, authority), [
+      'Exact-base performance contract is missing deterministicResources',
+    ]);
+  });
+
+  test('enforces the resource contract and report CLI exit paths', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-resource-cli-'));
+    const authorityContract = join(fixtureRoot, 'authority-contract.json');
+    const missingAuthorityContract = join(fixtureRoot, 'missing-authority-contract.json');
+    const candidateContract = join(fixtureRoot, 'candidate-contract.json');
+    const baseReport = join(fixtureRoot, 'base-report.json');
+    const currentReport = join(fixtureRoot, 'current-report.json');
+    const missingReport = join(fixtureRoot, 'missing-report.json');
+    const requiredMissingReport = join(fixtureRoot, 'required-missing-report.json');
+    const cli = join(root, 'config/bundle-size.mjs');
+    const authority = { deterministicResources: report().workload };
+    const candidate = structuredClone(authority);
+    const baseResources = report();
+    const currentResources = structuredClone(baseResources);
+    candidate.deterministicResources.mountDestroyCycles = 1;
+    currentResources.retention.destroyedHostRetainsBehaviorCount = 2;
+
+    try {
+      await Promise.all([
+        writeFile(authorityContract, JSON.stringify(authority)),
+        writeFile(missingAuthorityContract, '{}'),
+        writeFile(candidateContract, JSON.stringify(candidate)),
+        writeFile(baseReport, JSON.stringify(bundleReport(baseResources))),
+        writeFile(currentReport, JSON.stringify(bundleReport(currentResources))),
+        writeFile(missingReport, JSON.stringify(bundleReport(null))),
+        writeFile(requiredMissingReport, JSON.stringify(bundleReport(null, true))),
+      ]);
+
+      const contractResult = spawnSync(process.execPath, [
+        cli,
+        '--validate-resource-contract',
+        authorityContract,
+        candidateContract,
+      ], { encoding: 'utf8' });
+      assert.equal(contractResult.status, 1);
+      assert.match(contractResult.stderr, /mountDestroyCycles 1 is below/);
+
+      const missingAuthorityResult = spawnSync(process.execPath, [
+        cli,
+        '--validate-resource-contract',
+        missingAuthorityContract,
+        authorityContract,
+      ], { encoding: 'utf8' });
+      assert.equal(missingAuthorityResult.status, 1);
+      assert.match(missingAuthorityResult.stderr, /Exact-base performance contract is missing/);
+
+      const reportResult = spawnSync(process.execPath, [
+        cli,
+        '--report',
+        baseReport,
+        currentReport,
+      ], { encoding: 'utf8' });
+      assert.equal(reportResult.status, 1);
+      assert.match(reportResult.stdout, /Resource regressions: .* increased from 1 to 2/);
+
+      const cleanReportResult = spawnSync(process.execPath, [
+        cli,
+        '--report',
+        baseReport,
+        baseReport,
+      ], { encoding: 'utf8' });
+      assert.equal(cleanReportResult.status, 0);
+      assert.match(cleanReportResult.stdout, /No eager allocation or retained-resource proxy increased/);
+
+      const asymmetricResult = spawnSync(process.execPath, [
+        cli,
+        '--report',
+        baseReport,
+        missingReport,
+      ], { encoding: 'utf8' });
+      assert.equal(asymmetricResult.status, 1);
+      assert.match(asymmetricResult.stdout, /Pull request resource measurement is missing/);
+
+      const requiredMissingResult = spawnSync(process.execPath, [
+        cli,
+        '--report',
+        requiredMissingReport,
+        requiredMissingReport,
+      ], { encoding: 'utf8' });
+      assert.equal(requiredMissingResult.status, 1);
+      assert.match(requiredMissingResult.stdout, /Required resource measurements are missing/);
+
+      const unavailableResult = spawnSync(process.execPath, [
+        cli,
+        '--report',
+        missingReport,
+        missingReport,
+      ], { encoding: 'utf8' });
+      assert.equal(unavailableResult.status, 0);
+      assert.doesNotMatch(unavailableResult.stdout, /Deterministic allocation and retention/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('measures the built runtime and restores DOM globals', async() => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    const measurement = await measureResources({
+      root,
+      attachDetachCycles: 1,
+      mountDestroyCycles: 1,
+    });
+
+    assert.deepEqual(measurement.allocations.View.arrays, ['_behaviors', '_domEvents']);
+    assert.deepEqual(
+      measurement.allocations.CollectionView.childViewContainers,
+      ['_children', 'children']
+    );
+    assert.equal(measurement.retention.externalRegistrationsAfterDestroy, 0);
+    assert.equal(measurement.retention.destroyedBehaviorRetainsHostReference, true);
+    assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'window'), windowDescriptor);
+    assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'document'), documentDescriptor);
+  });
+});

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -272,6 +272,9 @@ describe('deterministic resource comparison', () => {
   test('measures the built runtime and restores DOM globals', async() => {
     const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
     const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    await assert.rejects(
+      measureResources({ root: '/missing', attachDetachCycles: 1, mountDestroyCycles: 1 })
+    );
     const measurement = await measureResources({
       root,
       attachDetachCycles: 1,

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -115,6 +115,25 @@ describe('deterministic resource comparison', () => {
     assert.ok(comparison.violations.includes('resources.allocations.View has unknown metrics: unknownLedger'));
   });
 
+  test('rejects missing measurement schema and workloads on both sides', () => {
+    const base = report();
+    const current = report();
+    delete base.schemaVersion;
+    delete current.schemaVersion;
+    delete base.workload;
+    delete current.workload;
+
+    const comparison = compareResources(base, current);
+
+    assert.ok(comparison.violations.includes('Exact-base resource schemaVersion must be 1; received undefined'));
+    assert.ok(comparison.violations.includes('Pull request resource schemaVersion must be 1; received undefined'));
+    assert.ok(comparison.violations.includes('Exact-base resource workload is missing'));
+    assert.ok(comparison.violations.includes('Pull request resource workload is missing'));
+    assert.deepEqual(resourceReportRows(comparison), [
+      '| Contract validation | Not comparable | Not comparable | Review required |',
+    ]);
+  });
+
   test('rejects candidate contracts that reduce or remove authority workloads', () => {
     const authority = {
       deterministicResources: report().workload,
@@ -130,6 +149,11 @@ describe('deterministic resource comparison', () => {
     ]);
     assert.deepEqual(validateCandidateResourceContract({}, authority), [
       'Exact-base performance contract is missing deterministicResources',
+    ]);
+    const malformedAuthority = structuredClone(authority);
+    delete malformedAuthority.deterministicResources.mountDestroyCycles;
+    assert.deepEqual(validateCandidateResourceContract(malformedAuthority, authority), [
+      'Exact-base authority mountDestroyCycles must be a positive integer; received undefined',
     ]);
   });
 
@@ -179,6 +203,15 @@ describe('deterministic resource comparison', () => {
       assert.equal(missingAuthorityResult.status, 1);
       assert.match(missingAuthorityResult.stderr, /Exact-base performance contract is missing/);
 
+      const missingPathResult = spawnSync(process.execPath, [
+        cli,
+        '--validate-resource-contract',
+        authorityContract,
+        '--report',
+      ], { encoding: 'utf8' });
+      assert.equal(missingPathResult.status, 1);
+      assert.match(missingPathResult.stderr, /Missing paths for --validate-resource-contract/);
+
       const reportResult = spawnSync(process.execPath, [
         cli,
         '--report',
@@ -196,6 +229,14 @@ describe('deterministic resource comparison', () => {
       ], { encoding: 'utf8' });
       assert.equal(cleanReportResult.status, 0);
       assert.match(cleanReportResult.stdout, /No eager allocation or retained-resource proxy increased/);
+
+      const missingReportPathResult = spawnSync(process.execPath, [
+        cli,
+        '--report',
+        baseReport,
+      ], { encoding: 'utf8' });
+      assert.equal(missingReportPathResult.status, 1);
+      assert.match(missingReportPathResult.stderr, /Missing paths for --report/);
 
       const asymmetricResult = spawnSync(process.execPath, [
         cli,
@@ -243,8 +284,16 @@ describe('deterministic resource comparison', () => {
       ['_children', 'children']
     );
     assert.equal(measurement.retention.externalRegistrationsAfterDestroy, 0);
+    assert.equal(measurement.retention.regionParentReferencesAfterDestroy, 0);
     assert.equal(measurement.retention.destroyedBehaviorRetainsHostReference, true);
     assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'window'), windowDescriptor);
     assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'document'), documentDescriptor);
+  });
+
+  test('rejects invalid lifecycle workloads before loading the runtime', async() => {
+    await assert.rejects(
+      measureResources({ root: '/missing', attachDetachCycles: 0 }),
+      /attachDetachCycles must be a positive integer.*mountDestroyCycles must be a positive integer/
+    );
   });
 });

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -288,6 +288,10 @@ describe('deterministic resource comparison', () => {
     assert.equal(measurement.retention.destroyedBehaviorRetainsHostReference, true);
     assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'window'), windowDescriptor);
     assert.deepEqual(Object.getOwnPropertyDescriptor(globalThis, 'document'), documentDescriptor);
+    await assert.rejects(
+      measureResources({ root, attachDetachCycles: 1, mountDestroyCycles: 1 }),
+      /one built runtime per process/
+    );
   });
 
   test('rejects invalid lifecycle workloads before loading the runtime', async() => {

--- a/test/performance/resources.test.mjs
+++ b/test/performance/resources.test.mjs
@@ -106,7 +106,7 @@ describe('deterministic resource comparison', () => {
     const current = structuredClone(base);
     delete current.allocations.View.plainObjects;
     current.allocations.View.unknownLedger = 0;
-    current.workload.mountDestroyCycles = 1;
+    current.workload.mountDestroyCycles = 2000;
 
     const comparison = compareResources(base, current);
 
@@ -132,6 +132,14 @@ describe('deterministic resource comparison', () => {
     assert.deepEqual(resourceReportRows(comparison), [
       '| Contract validation | Not comparable | Not comparable | Review required |',
     ]);
+
+    const incompatible = report();
+    incompatible.schemaVersion = 2;
+    assert.ok(
+      compareResources(report(), incompatible).violations.includes(
+        'Pull request resource schemaVersion must be 1; received 2'
+      )
+    );
   });
 
   test('rejects candidate contracts that reduce or remove authority workloads', () => {

--- a/test/unit/performance.resources.spec.js
+++ b/test/unit/performance.resources.spec.js
@@ -149,7 +149,9 @@ describe('Phase 0 deterministic resource baselines', function() {
     for (let index = 0; index < resources.mountDestroyCycles; index += 1) {
       const regionEl = document.createElement('div');
       document.body.appendChild(regionEl);
-      const region = new Region({ el: regionEl });
+      const regionHost = new PlainView();
+      const region = regionHost.addRegion('resource', { el: regionEl });
+      expect(region._parentView).to.equal(regionHost);
       const regionView = new PlainView();
       region.show(regionView);
       region.empty();
@@ -227,7 +229,7 @@ describe('Phase 0 deterministic resource baselines', function() {
         shapes.destroyedHostRetainsBehaviorCount > 0
       );
 
-      region.destroy();
+      regionHost.destroy();
       expect(region.isDestroyed()).to.equal(true);
       expect(region._parentView).to.equal(undefined);
       expect(Number(region._parentView != null))

--- a/test/unit/performance.resources.spec.js
+++ b/test/unit/performance.resources.spec.js
@@ -187,6 +187,8 @@ describe('Phase 0 deterministic resource baselines', function() {
         .to.equal(shapes.frameworkListeningToAfterDestroy);
       expect(backboneRegistrations(collection)).to.equal(collectionBaseline);
       expect(collectionView.el.isConnected).to.equal(false);
+      expect(Number(collectionView.el.isConnected))
+        .to.equal(shapes.managedRootsConnectedAfterDestroy);
       expect(collectionView.el.childNodes).to.have.lengthOf(resources.retentionShapes.managedDomChildrenAfterEmpty);
 
       const behaviorView = new BehaviorView({ model });
@@ -214,6 +216,8 @@ describe('Phase 0 deterministic resource baselines', function() {
         .to.equal(shapes.frameworkListeningToAfterDestroy);
       expect(backboneRegistrations(model)).to.equal(modelBaseline);
       expect(behaviorView.el.isConnected).to.equal(false);
+      expect(Number(behaviorView.el.isConnected))
+        .to.equal(shapes.managedRootsConnectedAfterDestroy);
       expect(behavior.view === behaviorView)
         .to.equal(resources.retentionShapes.destroyedBehaviorRetainsHostReference);
       expect(behaviorView._behaviors).to.have.lengthOf(
@@ -226,6 +230,8 @@ describe('Phase 0 deterministic resource baselines', function() {
       region.destroy();
       expect(region.isDestroyed()).to.equal(true);
       expect(region._parentView).to.equal(undefined);
+      expect(Number(region._parentView != null))
+        .to.equal(shapes.regionParentReferencesAfterDestroy);
       expect(regionEl.isConnected).to.equal(true);
       expect(regionEl.childNodes).to.have.lengthOf(resources.retentionShapes.managedDomChildrenAfterEmpty);
       regionEl.remove();


### PR DESCRIPTION
Related #127

## What

- Measure deterministic View, Region, Behavior, and CollectionView allocation and retention proxies from the built runtime.
- Compare exact-base and pull-request observations monotonically in the existing required Bundle size gate; regressions, missing metrics, schema drift, and reduced workloads fail while improvements remain visible.
- Pin both performance bootstrap exceptions to their exact reviewed base commits and document the structural-proxy boundary.

## Why

Phase 0 recorded resource shapes, but pull requests could not yet prove that they avoided new eager allocations or retained framework ownership. Agent-authored runtime changes need a base-authoritative, non-relaxable cost signal without adding a production inspection API or runtime overhead.

## Scope

- Impacts performance validation, CI reporting, CODEOWNERS, focused tests, and performance-baseline documentation.
- Corrects the recorded empty options-object and post-destroy DOM/Region baselines.
- Does not change runtime source, package exports, generated dist artifacts, public APIs, timing enforcement, the greater-than-one-percent approval protocol, npm publication, GitHub releases, or the website.

## Deployment Impact

No application or website deployment is required. No npm package, release tag, or production artifact is published. The existing required Bundle size check gains deterministic resource enforcement for subsequent pull requests.

## Testing

- npm test -- --coverage.enabled=false (61 files, 1,120 tests)
- npm run test:performance (26 tests, including subprocess CLI pass/fail paths)
- npm run lint:ci
- npm run size
- npm run test:dist
- npm run test:fixtures
- npm run check:dist
- npm run docs:check
- Exact-base/current authority simulation against commit 25f3739 produced a clean resource report and candidate-contract result.
- git diff --exit-code origin/master -- dist version.js confirmed production artifacts are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces monotonic resource baselines in the required `Bundle size` check so pull requests that add eager allocations or retain framework ownership fail while improvements remain visible. This is the resource enforcement phase of #127; it does not change runtime source, package exports, or public APIs.

**What changed**
- Measures allocation and retention proxies for View, Region, Behavior, and CollectionView from the built runtime in a temporary jsdom, comparing against the exact base observation; DOM globals are restored even when setup or measurement fails.
- Fails closed on missing or unknown metrics, schema drift, reduced lifecycle workloads, malformed reports, failed runtime loads, and missing CLI paths; report and resource-contract commands exit nonzero on regressions.
- Validates candidate lifecycle workloads against the exact base authority so they cannot be reduced.
- Pins both performance bootstrap exceptions to their exact reviewed base commits and forbids the resource probe from production graphs, with a focused test locking that boundary.
- Corrects the recorded empty options-object and post-destroy DOM/Region baselines.
- Clarifies that `npm run size` validates current state but cannot reproduce a base-relative regression; use the PR report or CI sequence to debug.

**Verification**
- Unit, performance, lint, size, dist, fixture, and docs checks pass, including a new test proving the CLI rejects forbidden graph imports.
- Production dist artifacts are unchanged; no deployment or publication is required.

<sup>Written for commit 50884ff2950a878d66e8a4ab1697abc2f2cab090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic performance-resource measurements for allocation, retention, event registrations, regions, and lifecycle workloads.
  * Bundle-size reports now include resource counts and highlight regressions or improvements.
  * Added candidate contract validation and resource comparison commands.

* **Bug Fixes**
  * Performance checks now fail reliably for invalid, missing, incompatible, or regressed measurements.
  * Improved cleanup verification for destroyed views, behaviors, and regions.
  * Runtime loading and workload validation are now more consistent.

* **Documentation**
  * Updated performance baseline guidance, comparison rules, ownership, and enforcement details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
