### PR TITLE
test(performance): define exact-head growth approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /.github/workflows/docs-pages.yml @paulfalgout @marionettejs/marionette-core
 /config/performance.json @paulfalgout @marionettejs/marionette-core
 /config/bundle-size.mjs @paulfalgout @marionettejs/marionette-core
+/config/performance-growth-approval.mjs @paulfalgout @marionettejs/marionette-core
 /config/performance-resources.mjs @paulfalgout @marionettejs/marionette-core
 /benchmarks/ @paulfalgout @marionettejs/marionette-core
 /test/performance/ @paulfalgout @marionettejs/marionette-core

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { brotliCompress, constants } from 'node:zlib';
 import { rollup } from 'rollup';
+import { validateGrowthApprovalPolicy } from './performance-growth-approval.mjs';
 import {
   compareResources,
   measureResources,
@@ -114,6 +115,8 @@ export function validateContract(contract, packageJson, runtimeFiles) {
   if (contract.schemaVersion !== 1) {
     violations.push(`Unsupported performance schemaVersion ${contract.schemaVersion}`);
   }
+  violations.push(...validateGrowthApprovalPolicy(contract.pullRequestGrowthApproval)
+    .map(({ message }) => message));
 
   const baselineTotal = contract.runtimeArtifacts
     .reduce((total, artifact) => total + artifact.baselineBrotliBytes, 0);

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -735,7 +735,8 @@ export async function main(args = process.argv.slice(2)) {
     const growthApprovalFile = getArgument(args, '--growth-approval');
     const report = await buildReport(baseFile, currentFile, growthApprovalFile);
     console.log(report.markdown);
-    if (report.resourceComparison.violations.length || !report.growthApproval.accepted) {
+    if (report.resourceComparison.violations.length ||
+        (growthApprovalFile && !report.growthApproval.accepted)) {
       process.exitCode = 1;
     }
     return;

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -482,22 +482,154 @@ function compareResourceReports(base, current) {
   return compareResources(base.resources, current.resources);
 }
 
-async function buildReport(baseFile, currentFile) {
+function approvalRequirement(baseResult, currentResult, thresholdPercent) {
+  if (!baseResult || baseResult.size == null || currentResult.size == null) {
+    return null;
+  }
+
+  const deltaBytes = currentResult.size - baseResult.size;
+  if (deltaBytes <= 0 ||
+      (baseResult.size > 0 && deltaBytes * 100 <= baseResult.size * thresholdPercent)) {
+    return null;
+  }
+
+  return {
+    path: currentResult.path,
+    baseBytes: baseResult.size,
+    currentBytes: currentResult.size,
+    deltaBytes,
+    growthBasisPoints: baseResult.size === 0 ? null :
+      Math.round(deltaBytes * 10000 / baseResult.size),
+  };
+}
+
+function sameApprovalRequirements(supplied, expected) {
+  if (!Array.isArray(supplied) || supplied.length !== expected.length) {
+    return false;
+  }
+
+  const normalized = supplied.map(requirement => ({
+    path: requirement?.path,
+    baseBytes: requirement?.baseBytes,
+    currentBytes: requirement?.currentBytes,
+    deltaBytes: requirement?.deltaBytes,
+    growthBasisPoints: requirement?.growthBasisPoints,
+  })).sort((left, right) => String(left.path).localeCompare(String(right.path)));
+
+  return normalized.every((requirement, index) => {
+    const expectedRequirement = expected[index];
+    return requirement.path === expectedRequirement.path &&
+      requirement.baseBytes === expectedRequirement.baseBytes &&
+      requirement.currentBytes === expectedRequirement.currentBytes &&
+      requirement.deltaBytes === expectedRequirement.deltaBytes &&
+      requirement.growthBasisPoints === expectedRequirement.growthBasisPoints;
+  });
+}
+
+function growthApprovalReport(base, current, supplied) {
+  const thresholdPercent = current.thresholds.pullRequestApprovalPercent;
+  const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
+  const required = current.artifacts
+    .map(result => approvalRequirement(baseByPath.get(result.path), result, thresholdPercent))
+    .filter(Boolean)
+    .sort((left, right) => left.path.localeCompare(right.path));
+  const violations = [];
+
+  if (!supplied) {
+    const status = required.length ? 'required' : 'not-required';
+    if (required.length) {
+      violations.push('Existing artifact growth above the approval threshold has no structured approval result');
+    }
+    return { accepted: !required.length, approval: null, diagnostics: [], headSha: null,
+      required, status, thresholdPercent, violations };
+  }
+
+  if (supplied.schemaVersion !== 1 || !Array.isArray(supplied.required) ||
+      !Array.isArray(supplied.diagnostics)) {
+    violations.push('Growth approval result is malformed');
+  }
+  if (supplied.thresholdPercent !== thresholdPercent) {
+    violations.push(`Growth approval threshold ${supplied.thresholdPercent} does not match report threshold ${thresholdPercent}`);
+  }
+  if (typeof supplied.headSha !== 'string' || !/^[a-f\d]{40}$/.test(supplied.headSha)) {
+    violations.push('Growth approval result is missing a lowercase full head SHA');
+  }
+
+  if (!sameApprovalRequirements(supplied.required, required)) {
+    violations.push('Growth approval requirements do not match the exact report comparison');
+  }
+  if (!['approved', 'not-required'].includes(supplied.status)) {
+    violations.push(`Growth approval status ${supplied.status || 'missing'} does not permit this report`);
+  } else if (required.length && supplied.status !== 'approved') {
+    violations.push('Existing artifact growth requires an approved result');
+  } else if (!required.length && supplied.status !== 'not-required') {
+    violations.push('Growth approval result must be not-required when no artifact crosses the threshold');
+  }
+  if (supplied.status === 'approved' && (!supplied.approval || typeof supplied.approval !== 'object')) {
+    violations.push('Approved growth result is missing its approval record');
+  }
+
+  return {
+    ...supplied,
+    accepted: violations.length === 0,
+    required,
+    thresholdPercent,
+    violations,
+  };
+}
+
+function growthApprovalSection(result) {
+  const status = result.accepted && result.status === 'approved' ? 'Approved' :
+    result.accepted ? 'Not required' :
+      result.status === 'invalid' || result.status === 'blocked' ? 'Invalid' : 'Required';
+  const lines = [
+    '',
+    '## Artifact growth approval',
+    '',
+    `Status: **${status}**.`,
+    `Threshold: greater than ${result.thresholdPercent}% versus the exact pull request base.`,
+  ];
+
+  if (result.headSha) {
+    lines.push(`Head: \`${result.headSha}\`.`);
+  }
+  if (result.accepted && result.status === 'approved') {
+    const author = result.approval.authorLogin ? `@${result.approval.authorLogin}` : 'an allowed maintainer';
+    const link = result.approval.commentUrl ? `[${author}](${result.approval.commentUrl})` : author;
+    lines.push(`Approved by ${link} for ${result.required.map(({ path }) => `\`${path}\``).join(', ')}.`);
+  }
+
+  const diagnostics = [
+    ...(Array.isArray(result.diagnostics) ? result.diagnostics
+      .map(entry => entry?.message)
+      .filter(message => typeof message === 'string' && message) : []),
+    ...result.violations,
+  ];
+  if (diagnostics.length) {
+    lines.push(`Approval diagnostics: ${diagnostics.join('; ')}`);
+  }
+
+  return lines;
+}
+
+async function buildReport(baseFile, currentFile, growthApprovalFile) {
   const base = await readJson(baseFile);
   const current = await readJson(currentFile);
+  const suppliedGrowthApproval = growthApprovalFile ? await readJson(growthApprovalFile) : null;
+  const growthApproval = growthApprovalReport(base, current, suppliedGrowthApproval);
   const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
-  const approvalThreshold = current.thresholds.pullRequestApprovalPercent;
+  const approvalRequiredPaths = new Set(growthApproval.required.map(({ path }) => path));
   const rows = current.artifacts.map(result => {
     const baseResult = baseByPath.get(result.path);
     if (!baseResult) {
-      return `| ${result.name} | New | ${formatBytes(result.size)} | New artifact | Required by PR B |`;
+      return `| ${result.name} | New | ${formatBytes(result.size)} | New artifact | Required |`;
     }
     if (result.size == null || baseResult.size == null) {
-      return `| ${result.name} | ${formatBytes(baseResult.size)} | ${formatBytes(result.size)} | Not comparable | Review required |`;
+      return `| ${result.name} | ${formatBytes(baseResult.size)} | ${formatBytes(result.size)} | Not comparable | Required |`;
     }
 
-    const percent = baseResult.size === 0 ? 100 : (result.size - baseResult.size) / baseResult.size * 100;
-    const approval = percent > approvalThreshold ? 'Required by PR B' : 'No';
+    const approval = !approvalRequiredPaths.has(result.path) ? 'Not required' :
+      growthApproval.accepted && growthApproval.status === 'approved' ? 'Approved' : 'Required';
     return `| ${result.name} | ${formatBytes(baseResult.size)} | ${formatBytes(result.size)} | ${formatChange(baseResult.size, result.size)} | ${approval} |`;
   });
   const baseGraphs = new Map(base.graphs.map(graph => [graph.subpath, graph]));
@@ -522,6 +654,7 @@ async function buildReport(baseFile, currentFile) {
       `Resource regressions: ${resourceComparison.violations.join('; ')}` :
       'No eager allocation or retained-resource proxy increased from the exact pull request base.',
   ];
+  const approvalSection = growthApprovalSection(growthApproval);
 
   const markdown = [
     '<!-- bundle-size-report -->',
@@ -541,15 +674,14 @@ async function buildReport(baseFile, currentFile) {
       `Contract violations: ${current.violations.join('; ')}` :
       'All deterministic size and production-graph checks passed against the base authority contract.',
     ...resourceSection,
-    '',
-    'The exact-head approval protocol for growth above 1% and new subpaths remains a separate #127 follow-up; this report does not treat that threshold as enforceable approval yet.'
+    ...approvalSection,
   ].join('\n');
 
-  return { markdown, resourceComparison };
+  return { growthApproval, markdown, resourceComparison };
 }
 
-export async function createReport(baseFile, currentFile) {
-  return (await buildReport(baseFile, currentFile)).markdown;
+export async function createReport(baseFile, currentFile, growthApprovalFile) {
+  return (await buildReport(baseFile, currentFile, growthApprovalFile)).markdown;
 }
 
 function writeMeasurement(result, json) {
@@ -600,9 +732,10 @@ export async function main(args = process.argv.slice(2)) {
   const reportIndex = args.indexOf('--report');
   if (reportIndex !== -1) {
     const [baseFile, currentFile] = positionalPaths(args, reportIndex, 2, '--report');
-    const report = await buildReport(baseFile, currentFile);
+    const growthApprovalFile = getArgument(args, '--growth-approval');
+    const report = await buildReport(baseFile, currentFile, growthApprovalFile);
     console.log(report.markdown);
-    if (report.resourceComparison.violations.length) {
+    if (report.resourceComparison.violations.length || !report.growthApproval.accepted) {
       process.exitCode = 1;
     }
     return;

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -1,12 +1,15 @@
+import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
 const recordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
 const allowedAuthorAssociations = new Set(['COLLABORATOR', 'MEMBER', 'OWNER']);
 const bodyLimit = 16 * 1024;
+const execFileAsync = promisify(execFile);
 const pathLimit = 50;
 const evidenceLimit = 20;
 
@@ -462,6 +465,14 @@ async function readJson(path) {
   return JSON.parse(await readFile(resolve(path), 'utf8'));
 }
 
+async function currentCheckoutHead() {
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+  return stdout.trim();
+}
+
 function parsePullRequestNumber(value) {
   if (!/^[1-9]\d*$/.test(value)) {
     throw new Error('Pull request number must be a positive integer');
@@ -493,6 +504,10 @@ export async function main(args = process.argv.slice(2)) {
   let headSha;
   try {
     headSha = getArgument(args, '--head-sha');
+    const checkoutHeadSha = await currentCheckoutHead();
+    if (headSha !== checkoutHeadSha) {
+      throw new Error(`Requested head SHA ${headSha} does not match checkout ${checkoutHeadSha}`);
+    }
     const pullRequestNumber = parsePullRequestNumber(getArgument(args, '--pull-request'));
     const [contract, baseReport, currentReport, comments, evidenceComments] =
       await Promise.all([

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
 const recordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
+const allowedAuthorAssociations = new Set(['COLLABORATOR', 'MEMBER', 'OWNER']);
 const bodyLimit = 16 * 1024;
 const pathLimit = 50;
 const evidenceLimit = 20;
@@ -365,7 +366,9 @@ export function validateGrowthApproval({
       ));
       continue;
     }
-    if (comment?.user?.type !== 'User' || !allowedLogins.has(authorLogin)) {
+    if (comment?.user?.type !== 'User' ||
+        !allowedAuthorAssociations.has(comment?.author_association) ||
+        !allowedLogins.has(authorLogin)) {
       result.ignored.push({ authorLogin, commentUrl, reason: 'unauthorized-author' });
       continue;
     }

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -1,0 +1,440 @@
+const marker = '<!-- marionette-performance-growth-approval:v1 -->';
+const recordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
+const bodyLimit = 16 * 1024;
+const pathLimit = 50;
+const evidenceLimit = 20;
+
+function diagnostic(code, message, commentUrl) {
+  return commentUrl ? { code, commentUrl, message } : { code, message };
+}
+
+function uniqueSortedStrings(values, limit) {
+  return Array.isArray(values) && values.length > 0 && values.length <= limit &&
+    values.every(value => typeof value === 'string' && value.length > 0) &&
+    new Set(values).size === values.length &&
+    values.every((value, index) => index === 0 || values[index - 1] < value);
+}
+
+function validArtifactPath(path) {
+  return /^dist\/[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:c|m)?js$/.test(path) &&
+    !path.includes('//') && !path.split('/').includes('..');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function issueUrl(repository, value) {
+  return new RegExp(`^https://github\\.com/${escapeRegExp(repository)}/issues/[1-9]\\d*$`)
+    .test(value);
+}
+
+function evidenceUrl(repository, value) {
+  return new RegExp(
+    `^https://github\\.com/${escapeRegExp(repository)}/issues/[1-9]\\d*#issuecomment-[1-9]\\d*$`
+  ).test(value);
+}
+
+function trackingIssueNumber(policy) {
+  return Number(policy.trackingIssueUrl.split('/').at(-1));
+}
+
+function pullRequestCommentUrl(repository, pullRequestNumber, comment) {
+  return Number.isInteger(comment?.id) && comment.id > 0 &&
+    comment.html_url ===
+      `https://github.com/${repository}/pull/${pullRequestNumber}#issuecomment-${comment.id}`;
+}
+
+function evidenceCommentUrl(repository, issueNumber, comment) {
+  return Number.isInteger(comment?.id) && comment.id > 0 &&
+    comment.html_url ===
+      `https://github.com/${repository}/issues/${issueNumber}#issuecomment-${comment.id}`;
+}
+
+function canonicalRecord(record) {
+  return {
+    schemaVersion: record.schemaVersion,
+    headSha: record.headSha,
+    issueUrl: record.issueUrl,
+    approvedPaths: record.approvedPaths,
+    evidenceUrls: record.evidenceUrls,
+  };
+}
+
+export function formatGrowthApprovalComment(record) {
+  return `${marker}\n\`\`\`json\n${JSON.stringify(canonicalRecord(record), null, 2)}\n\`\`\``;
+}
+
+export function validateGrowthApprovalPolicy(policy) {
+  const diagnostics = [];
+  if (policy?.schemaVersion !== 1) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_POLICY_SCHEMA',
+      `Growth approval policy schemaVersion must be 1; received ${policy?.schemaVersion}`
+    ));
+  }
+  if (typeof policy?.repository !== 'string' ||
+      !/^[A-Za-z\d_.-]+\/[A-Za-z\d_.-]+$/.test(policy.repository)) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_POLICY_REPOSITORY',
+      'Growth approval policy repository must be an owner/name slug'
+    ));
+  }
+  if (typeof policy?.trackingIssueUrl !== 'string' ||
+      (typeof policy?.repository === 'string' &&
+        !issueUrl(policy.repository, policy.trackingIssueUrl))) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_POLICY_ISSUE',
+      'Growth approval policy trackingIssueUrl must be a repository issue URL'
+    ));
+  }
+  if (!uniqueSortedStrings(policy?.allowedLogins, 50) ||
+      !policy.allowedLogins.every(login =>
+        /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/.test(login))) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_POLICY_LOGINS',
+      'Growth approval policy allowedLogins must contain sorted, unique lowercase GitHub logins'
+    ));
+  }
+
+  return diagnostics;
+}
+
+function validateRecord(record, policy) {
+  const diagnostics = [];
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return [diagnostic('GROWTH_APPROVAL_RECORD', 'Approval record must be a JSON object')];
+  }
+  const unknownFields = Object.keys(record)
+    .filter(field => !recordFields.includes(field))
+    .sort();
+  const missingFields = recordFields
+    .filter(field => !Object.hasOwn(record, field))
+    .sort();
+  if (unknownFields.length || missingFields.length) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_FIELDS',
+      `Approval fields mismatch; missing: ${missingFields.join(', ') || 'none'}; unknown: ${unknownFields.join(', ') || 'none'}`
+    ));
+  }
+  if (record.schemaVersion !== 1) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_SCHEMA',
+      `Approval schemaVersion must be 1; received ${record.schemaVersion}`
+    ));
+  }
+  if (typeof record.headSha !== 'string' || !/^[a-f\d]{40}$/.test(record.headSha)) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_HEAD',
+      'Approval headSha must be a lowercase full 40-character commit SHA'
+    ));
+  }
+  if (record.issueUrl !== policy.trackingIssueUrl) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_ISSUE',
+      `Approval issueUrl must be ${policy.trackingIssueUrl}`
+    ));
+  }
+  if (!uniqueSortedStrings(record.approvedPaths, pathLimit) ||
+      !record.approvedPaths.every(validArtifactPath)) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_PATHS',
+      'Approval approvedPaths must contain sorted, unique safe runtime artifact paths'
+    ));
+  }
+  if (!uniqueSortedStrings(record.evidenceUrls, evidenceLimit) ||
+      !record.evidenceUrls.every(value => evidenceUrl(policy.repository, value))) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_EVIDENCE',
+      'Approval evidenceUrls must contain sorted, unique repository issue-comment permalinks'
+    ));
+  }
+
+  return diagnostics;
+}
+
+export function parseGrowthApprovalComment(body, policy) {
+  if (typeof body !== 'string' || !body.includes(marker)) {
+    return { matched: false };
+  }
+  const policyDiagnostics = validateGrowthApprovalPolicy(policy);
+  if (policyDiagnostics.length) {
+    return { matched: true, diagnostics: policyDiagnostics };
+  }
+  if (body.length > bodyLimit || body.startsWith('\uFEFF')) {
+    return {
+      matched: true,
+      diagnostics: [diagnostic(
+        'GROWTH_APPROVAL_FORMAT',
+        'Approval comment is oversized or begins with a byte-order mark'
+      )],
+    };
+  }
+  const normalized = body.replaceAll('\r\n', '\n').replace(/\n$/, '');
+  const match = normalized.match(
+    /^<!-- marionette-performance-growth-approval:v1 -->\n```json\n([\s\S]+)\n```$/
+  );
+  if (!match) {
+    return {
+      matched: true,
+      diagnostics: [diagnostic(
+        'GROWTH_APPROVAL_FORMAT',
+        'Approval comment must contain only the canonical marker and JSON fence'
+      )],
+    };
+  }
+
+  let approval;
+  try {
+    approval = JSON.parse(match[1]);
+  } catch {
+    return {
+      matched: true,
+      diagnostics: [diagnostic('GROWTH_APPROVAL_JSON', 'Approval JSON could not be parsed')],
+    };
+  }
+  const diagnostics = validateRecord(approval, policy);
+  if (!diagnostics.length && normalized !== formatGrowthApprovalComment(approval)) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_CANONICAL',
+      'Approval comment does not use the canonical JSON field order and formatting'
+    ));
+  }
+
+  return diagnostics.length ? { matched: true, diagnostics } : { matched: true, approval };
+}
+
+function artifactMap(report, label) {
+  if (!Array.isArray(report?.artifacts)) {
+    throw new Error(`${label} report artifacts must be an array`);
+  }
+  const artifacts = new Map();
+  for (const artifact of report.artifacts) {
+    if (typeof artifact?.path !== 'string' || artifacts.has(artifact.path)) {
+      throw new Error(`${label} report has an invalid or duplicate artifact path ${artifact?.path}`);
+    }
+    artifacts.set(artifact.path, artifact);
+  }
+  return artifacts;
+}
+
+export function requiredArtifactGrowth(baseReport, currentReport, thresholdPercent) {
+  if (!Number.isFinite(thresholdPercent) || thresholdPercent < 0) {
+    throw new Error(`Growth approval threshold must be a non-negative number; received ${thresholdPercent}`);
+  }
+  const baseArtifacts = artifactMap(baseReport, 'Exact-base');
+  const currentArtifacts = artifactMap(currentReport, 'Pull request');
+  const missingPaths = [...baseArtifacts.keys()]
+    .filter(path => !currentArtifacts.has(path))
+    .sort();
+  if (missingPaths.length) {
+    throw new Error(`Pull request report is missing exact-base artifacts: ${missingPaths.join(', ')}`);
+  }
+  const required = [];
+  for (const [path, current] of currentArtifacts) {
+    const base = baseArtifacts.get(path);
+    if (!base) {
+      continue;
+    }
+    if (!Number.isInteger(base.size) || base.size < 0 ||
+        !Number.isInteger(current.size) || current.size < 0) {
+      throw new Error(`Existing artifact ${path} has non-comparable sizes ${base.size} and ${current.size}`);
+    }
+    const deltaBytes = current.size - base.size;
+    if (deltaBytes <= 0 || (base.size > 0 && deltaBytes * 100 <= base.size * thresholdPercent)) {
+      continue;
+    }
+    required.push({
+      baseBytes: base.size,
+      currentBytes: current.size,
+      deltaBytes,
+      growthBasisPoints: base.size === 0 ? null : Math.round(deltaBytes * 10000 / base.size),
+      name: current.name,
+      path,
+    });
+  }
+
+  return required.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function validateGrowthApproval({
+  baseReport,
+  comments,
+  currentReport,
+  evidenceComments,
+  headSha,
+  policy,
+  pullRequestNumber,
+  thresholdPercent,
+}) {
+  let required = [];
+  const diagnostics = validateGrowthApprovalPolicy(policy);
+  try {
+    required = requiredArtifactGrowth(baseReport, currentReport, thresholdPercent);
+  } catch (error) {
+    diagnostics.push(diagnostic('GROWTH_APPROVAL_REPORT', error.message));
+  }
+  const result = {
+    approval: null,
+    diagnostics,
+    headSha,
+    ignored: [],
+    required,
+    schemaVersion: 1,
+    status: 'required',
+    thresholdPercent,
+  };
+  if (!/^[a-f\d]{40}$/.test(headSha || '')) {
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_PULL_REQUEST_HEAD',
+      'Pull request head must be a lowercase full 40-character commit SHA'
+    ));
+  }
+  if (!Number.isInteger(pullRequestNumber) || pullRequestNumber < 1) {
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_PULL_REQUEST_NUMBER',
+      'Pull request number must be a positive integer'
+    ));
+  }
+  if (result.diagnostics.length) {
+    result.status = 'blocked';
+    return result;
+  }
+  if (!required.length) {
+    result.status = 'not-required';
+    return result;
+  }
+  if (comments?.schemaVersion !== 1 || !Array.isArray(comments.comments) ||
+      comments.repository !== policy.repository ||
+      comments.pullRequestNumber !== pullRequestNumber) {
+    result.status = 'blocked';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_COMMENTS',
+      'Approval comment snapshot is missing or malformed'
+    ));
+    return result;
+  }
+  if (comments.status !== 'ok') {
+    result.status = 'blocked';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_COMMENTS_UNAVAILABLE',
+      'Approval comments were unavailable when the exact head was evaluated'
+    ));
+    return result;
+  }
+  const issueNumber = trackingIssueNumber(policy);
+  if (evidenceComments?.schemaVersion !== 1 || !Array.isArray(evidenceComments.comments) ||
+      evidenceComments.repository !== policy.repository ||
+      evidenceComments.issueNumber !== issueNumber) {
+    result.status = 'blocked';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_EVIDENCE_COMMENTS',
+      'Growth evidence comment snapshot is missing or malformed'
+    ));
+    return result;
+  }
+  if (evidenceComments.status !== 'ok') {
+    result.status = 'blocked';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_EVIDENCE_UNAVAILABLE',
+      'Growth evidence comments were unavailable when the exact head was evaluated'
+    ));
+    return result;
+  }
+
+  const allowedLogins = new Set(policy.allowedLogins);
+  const matching = [];
+  for (const comment of comments.comments) {
+    const parsed = parseGrowthApprovalComment(comment?.body, policy);
+    if (!parsed.matched) {
+      continue;
+    }
+    const authorLogin = comment?.user?.login?.toLowerCase();
+    const commentUrl = comment?.html_url;
+    if (!pullRequestCommentUrl(policy.repository, pullRequestNumber, comment)) {
+      result.diagnostics.push(diagnostic(
+        'GROWTH_APPROVAL_COMMENT_IDENTITY',
+        'Marked approval comment is not bound to the expected repository and pull request',
+        commentUrl
+      ));
+      continue;
+    }
+    if (comment?.user?.type !== 'User' || !allowedLogins.has(authorLogin)) {
+      result.ignored.push({ authorLogin, commentUrl, reason: 'unauthorized-author' });
+      continue;
+    }
+    if (parsed.diagnostics) {
+      result.ignored.push({
+        authorLogin,
+        commentUrl,
+        diagnostics: parsed.diagnostics,
+        reason: 'malformed-record',
+      });
+      continue;
+    }
+    if (parsed.approval.headSha !== headSha) {
+      result.ignored.push({ authorLogin, commentUrl, reason: 'stale-head' });
+      continue;
+    }
+    matching.push({
+      approvedPaths: parsed.approval.approvedPaths,
+      authorLogin,
+      commentId: comment.id,
+      commentUrl,
+      evidenceUrls: parsed.approval.evidenceUrls,
+      issueUrl: parsed.approval.issueUrl,
+    });
+  }
+
+  if (result.diagnostics.length) {
+    result.status = 'invalid';
+    return result;
+  }
+  if (!matching.length) {
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_MISSING',
+      `No allowed maintainer approval targets exact head ${headSha}`
+    ));
+    return result;
+  }
+  if (matching.length > 1) {
+    result.status = 'invalid';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_AMBIGUOUS',
+      `Multiple allowed maintainer approvals target exact head ${headSha}`
+    ));
+    return result;
+  }
+
+  result.approval = matching[0];
+  const requiredPaths = required.map(({ path }) => path);
+  const missing = requiredPaths.filter(path => !result.approval.approvedPaths.includes(path));
+  const extra = result.approval.approvedPaths.filter(path => !requiredPaths.includes(path));
+  if (missing.length || extra.length) {
+    result.status = 'invalid';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_PATH_SET_MISMATCH',
+      `Approval paths mismatch; missing: ${missing.join(', ') || 'none'}; extra: ${extra.join(', ') || 'none'}`,
+      result.approval.commentUrl
+    ));
+    return result;
+  }
+
+  const availableEvidence = new Set(evidenceComments.comments
+    .filter(comment => evidenceCommentUrl(policy.repository, issueNumber, comment))
+    .map(comment => comment.html_url));
+  const unresolvedEvidence = result.approval.evidenceUrls
+    .filter(url => !availableEvidence.has(url));
+  if (unresolvedEvidence.length) {
+    result.status = 'invalid';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_EVIDENCE_MISSING',
+      `Approval evidence does not resolve to tracking-issue comments: ${unresolvedEvidence.join(', ')}`,
+      result.approval.commentUrl
+    ));
+    return result;
+  }
+
+  result.status = 'approved';
+  return result;
+}

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -349,7 +349,8 @@ export function validateGrowthApproval({
     if (!parsed.matched) {
       continue;
     }
-    const authorLogin = comment?.user?.login?.toLowerCase();
+    const rawAuthorLogin = comment?.user?.login;
+    const authorLogin = typeof rawAuthorLogin === 'string' ? rawAuthorLogin.toLowerCase() : null;
     const commentUrl = comment?.html_url;
     if (!pullRequestCommentUrl(policy.repository, pullRequestNumber, comment)) {
       result.diagnostics.push(diagnostic(

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -1,3 +1,8 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
 const recordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
 const bodyLimit = 16 * 1024;
@@ -438,4 +443,84 @@ export function validateGrowthApproval({
 
   result.status = 'approved';
   return result;
+}
+
+function getArgument(args, name) {
+  const index = args.indexOf(name);
+  const value = index === -1 ? null : args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${name}`);
+  }
+
+  return value;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(resolve(path), 'utf8'));
+}
+
+function parsePullRequestNumber(value) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error('Pull request number must be a positive integer');
+  }
+
+  const number = Number(value);
+  if (!Number.isSafeInteger(number)) {
+    throw new Error('Pull request number exceeds the safe integer range');
+  }
+
+  return number;
+}
+
+function blockedResult(error, headSha = null) {
+  return {
+    approval: null,
+    diagnostics: [diagnostic('GROWTH_APPROVAL_INPUT', error.message)],
+    headSha,
+    ignored: [],
+    required: [],
+    schemaVersion: 1,
+    status: 'blocked',
+    thresholdPercent: null,
+  };
+}
+
+export async function main(args = process.argv.slice(2)) {
+  let result;
+  let headSha;
+  try {
+    headSha = getArgument(args, '--head-sha');
+    const pullRequestNumber = parsePullRequestNumber(getArgument(args, '--pull-request'));
+    const [contract, baseReport, currentReport, comments, evidenceComments] =
+      await Promise.all([
+        readJson(getArgument(args, '--contract')),
+        readJson(getArgument(args, '--base-report')),
+        readJson(getArgument(args, '--current-report')),
+        readJson(getArgument(args, '--comments')),
+        readJson(getArgument(args, '--evidence-comments')),
+      ]);
+    result = validateGrowthApproval({
+      baseReport,
+      comments,
+      currentReport,
+      evidenceComments,
+      headSha,
+      policy: contract.pullRequestGrowthApproval,
+      pullRequestNumber,
+      thresholdPercent: contract.thresholds?.pullRequestApprovalPercent,
+    });
+  } catch (error) {
+    result = blockedResult(error, headSha);
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+  if (!['approved', 'not-required'].includes(result.status)) {
+    process.exitCode = 1;
+  }
+  return result;
+}
+
+const entryUrl = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (entryUrl === import.meta.url) {
+  main();
 }

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -433,7 +433,9 @@ export function validateGrowthApproval({
   }
 
   const availableEvidence = new Set(evidenceComments.comments
-    .filter(comment => evidenceCommentUrl(policy.repository, issueNumber, comment))
+    .filter(comment => comment?.user?.type === 'User' &&
+      allowedAuthorAssociations.has(comment?.author_association) &&
+      evidenceCommentUrl(policy.repository, issueNumber, comment))
     .map(comment => comment.html_url));
   const unresolvedEvidence = result.approval.evidenceUrls
     .filter(url => !availableEvidence.has(url));

--- a/config/performance.json
+++ b/config/performance.json
@@ -45,6 +45,14 @@
     "controlledMedianRegressionPercent": 5,
     "controlledP95RegressionPercent": 10
   },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
   "runtimeArtifacts": [
     {
       "name": "Main ES module",
@@ -177,6 +185,7 @@
   ],
   "forbiddenProductionModules": [
     "config/bundle-size.mjs",
+    "config/performance-growth-approval.mjs",
     "config/performance.json",
     "config/release-profile.json",
     "config/release-promotion.json"

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -91,8 +91,9 @@ artifact growth now has a versioned, base-owned approval contract in
 `pullRequestGrowthApproval`; new subpaths remain a separate fail-closed case.
 
 An approval is one complete pull request timeline comment. The comment author comes
-from GitHub rather than the JSON body, must appear in the exact-base allowlist, and
-must use this canonical form:
+from GitHub rather than the JSON body, must appear in the exact-base allowlist, must
+have GitHub's `OWNER`, `MEMBER`, or `COLLABORATOR` association, and must use this
+canonical form:
 
 ````markdown
 <!-- marionette-performance-growth-approval:v1 -->

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -118,10 +118,10 @@ greater-than-one-percent threshold. Evidence is limited to durable issue-comment
 permalinks in this repository; Actions artifacts and external mutable pages cannot
 be the sole record. The evaluator binds each marked comment to the expected repository
 and pull request from the API snapshot, and every evidence URL must resolve to a real
-comment in the configured tracking issue snapshot. Unauthorized, stale, and ordinary
-comments do not approve anything. Multiple exact-head approvals, malformed trusted
-records without a valid replacement, missing paths, extra paths, and noncanonical JSON
-fail the evaluator.
+`OWNER`, `MEMBER`, or `COLLABORATOR` comment in the configured tracking issue snapshot.
+Unauthorized, stale, and ordinary comments do not approve anything. Multiple
+exact-head approvals, malformed trusted records without a valid replacement, missing
+paths, extra paths, and noncanonical JSON fail the evaluator.
 
 This change deliberately defines and tests the contract before enforcing it. The
 immediately following pull request will collect the read-only GitHub comment snapshot

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -86,10 +86,49 @@ checks. CI posts artifact, cumulative-size, and production-graph changes through
 the repository's read-only workflow plus the separate comment workflow.
 
 The roadmap also requires explicit issue approval and evidence for growth above one
-percent versus the pull request base and for every new production subpath. The
-resource comparator does not invent a weak convention that agents could satisfy
-themselves. A separate follow-up must define an exact-head, maintainer-authored
-approval record and make the check validate that record before these cases can merge.
+percent versus the pull request base and for every new production subpath. Existing
+artifact growth now has a versioned, base-owned approval contract in
+`pullRequestGrowthApproval`; new subpaths remain a separate fail-closed case.
+
+An approval is one complete pull request timeline comment. The comment author comes
+from GitHub rather than the JSON body, must appear in the exact-base allowlist, and
+must use this canonical form:
+
+````markdown
+<!-- marionette-performance-growth-approval:v1 -->
+```json
+{
+  "schemaVersion": 1,
+  "headSha": "0123456789abcdef0123456789abcdef01234567",
+  "issueUrl": "https://github.com/marionettejs/marionette/issues/127",
+  "approvedPaths": [
+    "dist/marionette.js"
+  ],
+  "evidenceUrls": [
+    "https://github.com/marionettejs/marionette/issues/127#issuecomment-123456789"
+  ]
+}
+```
+````
+
+The full lowercase head SHA prevents an approval from surviving a code change. The
+approved path list must exactly match all existing artifacts above the strict
+greater-than-one-percent threshold. Evidence is limited to durable issue-comment
+permalinks in this repository; Actions artifacts and external mutable pages cannot
+be the sole record. The evaluator binds each marked comment to the expected repository
+and pull request from the API snapshot, and every evidence URL must resolve to a real
+comment in the configured tracking issue snapshot. Unauthorized, stale, and ordinary
+comments do not approve anything. Multiple exact-head approvals, malformed trusted
+records without a valid replacement, missing paths, extra paths, and noncanonical JSON
+fail the evaluator.
+
+This change deliberately defines and tests the contract before enforcing it. The
+immediately following pull request will collect the read-only GitHub comment snapshot
+and invoke this parser from the exact base checkout. Until that wiring lands, the
+existing `Bundle size` report still labels growth above one percent but does not treat
+the comment record as a merge gate. This two-step bootstrap avoids allowing the first
+enforcement change to authorize itself with a parser or allowlist absent from its
+base.
 
 ## Hosted timing
 
@@ -122,9 +161,9 @@ zero-runtime-overhead boundary executable.
 
 ## Ownership and enforcement
 
-CODEOWNERS assigns the contract, resource probe, harness, focused tests, and
-performance workflows to the project maintainer and core team. Current live repository
-rules do not require a CODEOWNER approval, so ownership is review routing rather than
-an automated merge gate. The exact-base authority contract is the automated
-anti-relaxation guard after this bootstrap; the greater-than-one-percent approval
-protocol and controlled timing runner remain separate follow-ups.
+CODEOWNERS assigns the contract, growth-approval parser, resource probe, harness,
+focused tests, and performance workflows to the project maintainer and core team.
+Current live repository rules do not require a CODEOWNER approval, so ownership is
+review routing rather than an automated merge gate. The exact-base authority contract
+is the automated anti-relaxation guard after this bootstrap; growth-approval
+enforcement and the controlled timing runner remain separate follow-ups.

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -225,7 +225,7 @@ describe('performance contract validation', () => {
     }
   });
 
-  test('renders artifact-specific growth approval results and fails closed without one', async() => {
+  test('renders artifact-specific growth approval results before enforcement', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-approval-report-'));
     const baseReport = join(fixtureRoot, 'base.json');
     const currentReport = join(fixtureRoot, 'current.json');
@@ -275,7 +275,7 @@ describe('performance contract validation', () => {
       const missing = spawnSync(process.execPath, [
         cli, '--report', baseReport, currentReport,
       ], { encoding: 'utf8' });
-      assert.equal(missing.status, 1);
+      assert.equal(missing.status, 0);
       assert.match(missing.stdout, /Status: \*\*Required\*\*\./);
 
       const approved = spawnSync(process.execPath, [

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -120,6 +120,20 @@ describe('performance contract validation', () => {
     assert.ok(violations.includes('Shipped runtime artifacts are untracked: dist/untracked.mjs'));
   });
 
+  test('surfaces malformed growth approval policy through contract validation', () => {
+    const contract = contractFor();
+    contract.pullRequestGrowthApproval.allowedLogins = ['zed', 'alpha'];
+    const packageJson = {
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+
+    const violations = validateContract(contract, packageJson, ['index.mjs']);
+
+    assert.ok(violations.includes(
+      'Growth approval policy allowedLogins must contain sorted, unique lowercase GitHub logins'
+    ));
+  });
+
   test('measures malformed artifact and subpath changes without an uncaught error', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-contract-'));
     const contract = contractFor();

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -29,6 +29,12 @@ function contractFor(paths = ['dist/index.mjs']) {
     thresholds: {
       cumulativeGrowthPercent: 0,
     },
+    pullRequestGrowthApproval: {
+      schemaVersion: 1,
+      repository: 'marionettejs/marionette',
+      trackingIssueUrl: 'https://github.com/marionettejs/marionette/issues/127',
+      allowedLogins: ['paulfalgout'],
+    },
     runtimeArtifacts: paths.map(path => ({
       name: path,
       path,

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import {
@@ -43,6 +45,45 @@ function contractFor(paths = ['dist/index.mjs']) {
     productionGraphs: [{ subpath: '.' }],
     forbiddenProductionModulePrefixes: ['test/'],
     forbiddenProductionModules: ['config/performance.json'],
+  };
+}
+
+function bundleReport(size) {
+  return {
+    brotliQuality: 11,
+    thresholds: { pullRequestApprovalPercent: 1 },
+    artifacts: [{ name: 'Main', path: 'dist/main.js', size }],
+    cumulative: {
+      size,
+      baselineSize: 100,
+      absoluteCeiling: 105,
+    },
+    graphs: [],
+    resourcesRequired: false,
+    resources: null,
+    violations: [],
+  };
+}
+
+function growthApproval(status = 'approved') {
+  return {
+    schemaVersion: 1,
+    status,
+    headSha: '1234567890abcdef1234567890abcdef12345678',
+    thresholdPercent: 1,
+    required: [{
+      baseBytes: 100,
+      currentBytes: 102,
+      deltaBytes: 2,
+      growthBasisPoints: 200,
+      name: 'Main',
+      path: 'dist/main.js',
+    }],
+    approval: status === 'approved' ? {
+      authorLogin: 'paulfalgout',
+      commentUrl: 'https://github.com/marionettejs/marionette/pull/1#issuecomment-1',
+    } : null,
+    diagnostics: status === 'approved' ? [] : [{ message: 'Approval is required' }],
   };
 }
 
@@ -179,6 +220,87 @@ describe('performance contract validation', () => {
         writeFile(currentReport, JSON.stringify(result)),
       ]);
       assert.match(await createReport(baseReport, currentReport), /\| `\.` \| 1 \| None \| No change \|/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('renders artifact-specific growth approval results and fails closed without one', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-approval-report-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvalReport = join(fixtureRoot, 'approval.json');
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(bundleReport(100))),
+        writeFile(currentReport, JSON.stringify(bundleReport(102))),
+        writeFile(approvalReport, JSON.stringify(growthApproval())),
+      ]);
+
+      const approved = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(approved, /\| Main \| 100 B \| 102 B \| \+2 B \(\+2\.00%\) 🔺 \| Approved \|/);
+      assert.match(approved, /## Artifact growth approval\n\nStatus: \*\*Approved\*\*\./);
+      assert.match(approved, /Approved by \[@paulfalgout\]/);
+
+      const missing = await createReport(baseReport, currentReport);
+      assert.match(missing, /\| Main .* \| Required \|/);
+      assert.match(missing, /Status: \*\*Required\*\*\./);
+      assert.match(missing, /has no structured approval result/);
+
+      const identical = await createReport(baseReport, baseReport);
+      assert.match(identical, /\| Main .* \| Not required \|/);
+      assert.match(identical, /Status: \*\*Not required\*\*\./);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('enforces growth approval status through the report CLI', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-approval-cli-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvedReport = join(fixtureRoot, 'approved.json');
+    const requiredReport = join(fixtureRoot, 'required.json');
+    const cli = join(root, 'config/bundle-size.mjs');
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(bundleReport(100))),
+        writeFile(currentReport, JSON.stringify(bundleReport(102))),
+        writeFile(approvedReport, JSON.stringify(growthApproval())),
+        writeFile(requiredReport, JSON.stringify(growthApproval('required'))),
+      ]);
+
+      const missing = spawnSync(process.execPath, [
+        cli, '--report', baseReport, currentReport,
+      ], { encoding: 'utf8' });
+      assert.equal(missing.status, 1);
+      assert.match(missing.stdout, /Status: \*\*Required\*\*\./);
+
+      const approved = spawnSync(process.execPath, [
+        cli, '--report', baseReport, currentReport, '--growth-approval', approvedReport,
+      ], { encoding: 'utf8' });
+      assert.equal(approved.status, 0);
+      assert.match(approved.stdout, /Status: \*\*Approved\*\*\./);
+
+      const required = spawnSync(process.execPath, [
+        cli, '--report', baseReport, currentReport, '--growth-approval', requiredReport,
+      ], { encoding: 'utf8' });
+      assert.equal(required.status, 1);
+      assert.match(required.stdout, /Status: \*\*Required\*\*\./);
+
+      const identical = spawnSync(process.execPath, [
+        cli, '--report', baseReport, baseReport,
+      ], { encoding: 'utf8' });
+      assert.equal(identical.status, 0);
+      assert.match(identical.stdout, /Status: \*\*Not required\*\*\./);
+
+      const missingPath = spawnSync(process.execPath, [
+        cli, '--report', baseReport, currentReport, '--growth-approval',
+      ], { encoding: 'utf8' });
+      assert.equal(missingPath.status, 1);
+      assert.match(missingPath.stderr, /Missing value for --growth-approval/);
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -65,12 +65,12 @@ function snapshot(comments, status = 'ok') {
   };
 }
 
-function evidenceComment({ association = 'MEMBER', type = 'User' } = {}) {
+function evidenceComment({ association = 'MEMBER', login = 'evidence-author', type = 'User' } = {}) {
   return {
     id: 123,
     'author_association': association,
     'html_url': evidenceUrl,
-    user: { type },
+    user: { login, type },
   };
 }
 
@@ -270,6 +270,11 @@ describe('exact-head performance growth approval contract', () => {
         .diagnostics[0].code,
       'GROWTH_APPROVAL_POLICY_SCHEMA'
     );
+    assert.deepEqual(
+      validateGrowthApprovalPolicy({ ...policy, allowedLogins: ['zed', 'alpha'] })
+        .map(({ code }) => code),
+      ['GROWTH_APPROVAL_POLICY_LOGINS']
+    );
   });
 
   test('returns a blocked result for malformed reports instead of throwing', () => {
@@ -377,9 +382,23 @@ describe('exact-head performance growth approval contract', () => {
       validation({ comments: [comment(extra)] }).diagnostics[0].code,
       'GROWTH_APPROVAL_PATH_SET_MISMATCH'
     );
+
+    const missing = validation({
+      base: [
+        { name: 'Over', path: 'dist/over.js', size: 100 },
+        { name: 'Second', path: 'dist/second.js', size: 100 },
+      ],
+      comments: [comment(approvalRecord(['dist/over.js']))],
+      current: [
+        { name: 'Over', path: 'dist/over.js', size: 102 },
+        { name: 'Second', path: 'dist/second.js', size: 102 },
+      ],
+    });
+    assert.equal(missing.diagnostics[0].code, 'GROWTH_APPROVAL_PATH_SET_MISMATCH');
+    assert.match(missing.diagnostics[0].message, /missing: dist\/second\.js; extra: none/);
   });
 
-  test('rejects foreign pull request comments and unresolved evidence URLs', () => {
+  test('allows collaborator evidence but rejects foreign comments and unresolved evidence', () => {
     const foreign = comment(approvalRecord(), { pullRequest: 2 });
     assert.equal(
       validation({ comments: [foreign] }).diagnostics[0].code,
@@ -398,6 +417,9 @@ describe('exact-head performance growth approval contract', () => {
     });
     assert.equal(unresolved.status, 'invalid');
     assert.equal(unresolved.diagnostics[0].code, 'GROWTH_APPROVAL_EVIDENCE_MISSING');
+
+    const collaboratorEvidence = validation();
+    assert.equal(collaboratorEvidence.status, 'approved');
 
     const untrustedEvidence = validateGrowthApproval({
       baseReport: report([{ path: 'dist/over.js', size: 100 }]),

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -1,0 +1,340 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  formatGrowthApprovalComment,
+  parseGrowthApprovalComment,
+  requiredArtifactGrowth,
+  validateGrowthApproval,
+  validateGrowthApprovalPolicy,
+} from '../../config/performance-growth-approval.mjs';
+
+const headSha = '1234567890abcdef1234567890abcdef12345678';
+const pullRequestNumber = 1;
+const evidenceUrl =
+  'https://github.com/marionettejs/marionette/issues/127#issuecomment-123';
+const policy = {
+  schemaVersion: 1,
+  repository: 'marionettejs/marionette',
+  trackingIssueUrl: 'https://github.com/marionettejs/marionette/issues/127',
+  allowedLogins: ['paulfalgout'],
+};
+
+function report(artifacts) {
+  return { artifacts };
+}
+
+function approvalRecord(approvedPaths = ['dist/over.js']) {
+  return {
+    schemaVersion: 1,
+    headSha,
+    issueUrl: policy.trackingIssueUrl,
+    approvedPaths,
+    evidenceUrls: [evidenceUrl],
+  };
+}
+
+function comment(record, {
+  id = 1,
+  login = 'paulfalgout',
+  pullRequest = pullRequestNumber,
+  type = 'User',
+} = {}) {
+  return {
+    id,
+    body: formatGrowthApprovalComment(record),
+    'html_url': `https://github.com/marionettejs/marionette/pull/${pullRequest}#issuecomment-${id}`,
+    user: { login, type },
+  };
+}
+
+function snapshot(comments, status = 'ok') {
+  return {
+    schemaVersion: 1,
+    status,
+    repository: policy.repository,
+    pullRequestNumber,
+    comments,
+  };
+}
+
+function evidenceSnapshot(comments = [{ id: 123, 'html_url': evidenceUrl }], status = 'ok') {
+  return {
+    schemaVersion: 1,
+    status,
+    repository: policy.repository,
+    issueNumber: 127,
+    comments,
+  };
+}
+
+function validation({
+  base = [{ name: 'Over', path: 'dist/over.js', size: 100 }],
+  comments = [comment(approvalRecord())],
+  current = [{ name: 'Over', path: 'dist/over.js', size: 102 }],
+  currentHead = headSha,
+  currentPolicy = policy,
+} = {}) {
+  return validateGrowthApproval({
+    baseReport: report(base),
+    comments: snapshot(comments),
+    currentReport: report(current),
+    evidenceComments: evidenceSnapshot(),
+    headSha: currentHead,
+    policy: currentPolicy,
+    pullRequestNumber,
+    thresholdPercent: 1,
+  });
+}
+
+describe('exact-head performance growth approval contract', () => {
+  test('requires only existing artifacts growing strictly above one percent', () => {
+    const base = report([
+      { name: 'Exact', path: 'dist/exact.js', size: 100 },
+      { name: 'Over', path: 'dist/over.js', size: 100 },
+      { name: 'Shrink', path: 'dist/shrink.js', size: 100 },
+      { name: 'Zero', path: 'dist/zero.js', size: 0 },
+    ]);
+    const current = report([
+      { name: 'Exact', path: 'dist/exact.js', size: 101 },
+      { name: 'Over', path: 'dist/over.js', size: 102 },
+      { name: 'Shrink', path: 'dist/shrink.js', size: 99 },
+      { name: 'Zero', path: 'dist/zero.js', size: 1 },
+      { name: 'New', path: 'dist/new.js', size: 10 },
+    ]);
+
+    assert.deepEqual(requiredArtifactGrowth(base, current, 1), [
+      {
+        baseBytes: 100,
+        currentBytes: 102,
+        deltaBytes: 2,
+        growthBasisPoints: 200,
+        name: 'Over',
+        path: 'dist/over.js',
+      },
+      {
+        baseBytes: 0,
+        currentBytes: 1,
+        deltaBytes: 1,
+        growthBasisPoints: null,
+        name: 'Zero',
+        path: 'dist/zero.js',
+      },
+    ]);
+  });
+
+  test('rejects duplicate report paths and malformed thresholds', () => {
+    assert.throws(
+      () => requiredArtifactGrowth(
+        report([{ path: 'dist/a.js', size: 1 }, { path: 'dist/a.js', size: 1 }]),
+        report([]),
+        1
+      ),
+      /duplicate artifact path/
+    );
+    assert.throws(
+      () => requiredArtifactGrowth(report([]), report([]), -1),
+      /non-negative number/
+    );
+    assert.throws(
+      () => requiredArtifactGrowth(
+        report([{ path: 'dist/a.js', size: 100 }]),
+        report([{ path: 'dist/a.js', size: null }]),
+        1
+      ),
+      /non-comparable sizes/
+    );
+    assert.throws(
+      () => requiredArtifactGrowth(
+        report([{ path: 'dist/a.js', size: 100 }]),
+        report([]),
+        1
+      ),
+      /missing exact-base artifacts/
+    );
+  });
+
+  test('formats and parses one canonical approval record', () => {
+    const record = approvalRecord();
+    const body = formatGrowthApprovalComment(record);
+
+    assert.deepEqual(parseGrowthApprovalComment(body, policy), {
+      matched: true,
+      approval: record,
+    });
+    assert.deepEqual(parseGrowthApprovalComment('ordinary comment', policy), { matched: false });
+    assert.equal(body.split('\n')[0], '<!-- marionette-performance-growth-approval:v1 -->');
+  });
+
+  test('rejects ambiguous formatting, fields, paths, and evidence', () => {
+    const record = approvalRecord();
+    const noncanonical = `${formatGrowthApprovalComment(record)}\nextra`;
+    assert.equal(
+      parseGrowthApprovalComment(noncanonical, policy).diagnostics[0].code,
+      'GROWTH_APPROVAL_FORMAT'
+    );
+
+    const invalid = {
+      ...record,
+      approvedPaths: ['../escape.js'],
+      evidenceUrls: ['https://example.com/evidence'],
+      unexpected: true,
+    };
+    const parsed = parseGrowthApprovalComment(formatGrowthApprovalComment(invalid), policy);
+    assert.deepEqual(parsed.diagnostics.map(({ code }) => code), [
+      'GROWTH_APPROVAL_PATHS',
+      'GROWTH_APPROVAL_EVIDENCE',
+    ]);
+
+    const duplicateKey = formatGrowthApprovalComment(record).replace(
+      '  "schemaVersion": 1,',
+      '  "schemaVersion": 1,\n  "schemaVersion": 1,'
+    );
+    assert.equal(
+      parseGrowthApprovalComment(duplicateKey, policy).diagnostics[0].code,
+      'GROWTH_APPROVAL_CANONICAL'
+    );
+  });
+
+  test('validates the base-owned repository, issue, and approver policy', () => {
+    const diagnostics = validateGrowthApprovalPolicy({
+      schemaVersion: 2,
+      repository: 'invalid',
+      trackingIssueUrl: 'https://example.com/127',
+      allowedLogins: ['Uppercase', 'Uppercase'],
+    });
+
+    assert.deepEqual(diagnostics.map(({ code }) => code), [
+      'GROWTH_APPROVAL_POLICY_SCHEMA',
+      'GROWTH_APPROVAL_POLICY_REPOSITORY',
+      'GROWTH_APPROVAL_POLICY_ISSUE',
+      'GROWTH_APPROVAL_POLICY_LOGINS',
+    ]);
+    assert.equal(
+      parseGrowthApprovalComment(formatGrowthApprovalComment(approvalRecord()), {})
+        .diagnostics[0].code,
+      'GROWTH_APPROVAL_POLICY_SCHEMA'
+    );
+  });
+
+  test('returns a blocked result for malformed reports instead of throwing', () => {
+    const result = validateGrowthApproval({
+      baseReport: {},
+      comments: snapshot([]),
+      currentReport: report([]),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.diagnostics[0].code, 'GROWTH_APPROVAL_REPORT');
+  });
+
+  test('accepts one allowed maintainer record for the exact head and path set', () => {
+    const result = validation();
+
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.approval.authorLogin, 'paulfalgout');
+    assert.deepEqual(result.approval.approvedPaths, ['dist/over.js']);
+  });
+
+  test('fails closed for absent, stale, unauthorized, or unavailable approval comments', () => {
+    assert.equal(validation({ comments: [] }).diagnostics[0].code, 'GROWTH_APPROVAL_MISSING');
+
+    const stale = approvalRecord();
+    stale.headSha = 'abcdef1234567890abcdef1234567890abcdef12';
+    assert.equal(
+      validation({ comments: [comment(stale)] }).diagnostics[0].code,
+      'GROWTH_APPROVAL_MISSING'
+    );
+    assert.equal(
+      validation({ comments: [comment(approvalRecord(), { login: 'attacker' })] })
+        .diagnostics[0].code,
+      'GROWTH_APPROVAL_MISSING'
+    );
+
+    const unavailable = validateGrowthApproval({
+      baseReport: report([{ path: 'dist/over.js', size: 100 }]),
+      comments: snapshot([], 'unavailable'),
+      currentReport: report([{ path: 'dist/over.js', size: 102 }]),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(unavailable.status, 'blocked');
+    assert.equal(unavailable.diagnostics[0].code, 'GROWTH_APPROVAL_COMMENTS_UNAVAILABLE');
+  });
+
+  test('ignores malformed and stale records when one exact-head approval is valid', () => {
+    const malformed = comment(approvalRecord());
+    malformed.body = malformed.body.replace('```json', '```');
+    const stale = approvalRecord();
+    stale.headSha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const result = validation({
+      comments: [malformed, comment(stale, { id: 2 }), comment(approvalRecord(), { id: 3 })],
+    });
+
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(result.ignored.map(({ reason }) => reason), [
+      'malformed-record',
+      'stale-head',
+    ]);
+  });
+
+  test('rejects duplicate exact-head approvals and path mismatches', () => {
+
+    assert.equal(
+      validation({ comments: [comment(approvalRecord(), { id: 1 }), comment(approvalRecord(), { id: 2 })] })
+        .diagnostics[0].code,
+      'GROWTH_APPROVAL_AMBIGUOUS'
+    );
+
+    const extra = approvalRecord(['dist/over.js', 'dist/unknown.js']);
+    assert.equal(
+      validation({ comments: [comment(extra)] }).diagnostics[0].code,
+      'GROWTH_APPROVAL_PATH_SET_MISMATCH'
+    );
+  });
+
+  test('rejects foreign pull request comments and unresolved evidence URLs', () => {
+    const foreign = comment(approvalRecord(), { pullRequest: 2 });
+    assert.equal(
+      validation({ comments: [foreign] }).diagnostics[0].code,
+      'GROWTH_APPROVAL_COMMENT_IDENTITY'
+    );
+
+    const unresolved = validateGrowthApproval({
+      baseReport: report([{ path: 'dist/over.js', size: 100 }]),
+      comments: snapshot([comment(approvalRecord())]),
+      currentReport: report([{ path: 'dist/over.js', size: 102 }]),
+      evidenceComments: evidenceSnapshot([]),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(unresolved.status, 'invalid');
+    assert.equal(unresolved.diagnostics[0].code, 'GROWTH_APPROVAL_EVIDENCE_MISSING');
+  });
+
+  test('does not need comment access when no existing artifact crosses the threshold', () => {
+    const result = validateGrowthApproval({
+      baseReport: report([{ path: 'dist/over.js', size: 100 }]),
+      comments: snapshot([], 'unavailable'),
+      currentReport: report([{ path: 'dist/over.js', size: 101 }]),
+      evidenceComments: evidenceSnapshot([], 'unavailable'),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+
+    assert.equal(result.status, 'not-required');
+    assert.deepEqual(result.diagnostics, []);
+  });
+});

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -107,12 +107,14 @@ describe('exact-head performance growth approval contract', () => {
   test('requires only existing artifacts growing strictly above one percent', () => {
     const base = report([
       { name: 'Exact', path: 'dist/exact.js', size: 100 },
+      { name: 'Fractional', path: 'dist/fractional.js', size: 199 },
       { name: 'Over', path: 'dist/over.js', size: 100 },
       { name: 'Shrink', path: 'dist/shrink.js', size: 100 },
       { name: 'Zero', path: 'dist/zero.js', size: 0 },
     ]);
     const current = report([
       { name: 'Exact', path: 'dist/exact.js', size: 101 },
+      { name: 'Fractional', path: 'dist/fractional.js', size: 201 },
       { name: 'Over', path: 'dist/over.js', size: 102 },
       { name: 'Shrink', path: 'dist/shrink.js', size: 99 },
       { name: 'Zero', path: 'dist/zero.js', size: 1 },
@@ -120,6 +122,14 @@ describe('exact-head performance growth approval contract', () => {
     ]);
 
     assert.deepEqual(requiredArtifactGrowth(base, current, 1), [
+      {
+        baseBytes: 199,
+        currentBytes: 201,
+        deltaBytes: 2,
+        growthBasisPoints: 101,
+        name: 'Fractional',
+        path: 'dist/fractional.js',
+      },
       {
         baseBytes: 100,
         currentBytes: 102,
@@ -137,6 +147,17 @@ describe('exact-head performance growth approval contract', () => {
         path: 'dist/zero.js',
       },
     ]);
+  });
+
+  test('rejects a renamed artifact instead of treating its replacement as new', () => {
+    assert.throws(
+      () => requiredArtifactGrowth(
+        report([{ name: 'Old', path: 'dist/old.js', size: 100 }]),
+        report([{ name: 'Replacement', path: 'dist/replacement.js', size: 1000 }]),
+        1
+      ),
+      /missing exact-base artifacts: dist\/old\.js/
+    );
   });
 
   test('rejects duplicate report paths and malformed thresholds', () => {

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -177,13 +177,21 @@ describe('exact-head performance growth approval contract', () => {
       ...record,
       approvedPaths: ['../escape.js'],
       evidenceUrls: ['https://example.com/evidence'],
-      unexpected: true,
     };
     const parsed = parseGrowthApprovalComment(formatGrowthApprovalComment(invalid), policy);
     assert.deepEqual(parsed.diagnostics.map(({ code }) => code), [
       'GROWTH_APPROVAL_PATHS',
       'GROWTH_APPROVAL_EVIDENCE',
     ]);
+
+    const unknownField = formatGrowthApprovalComment(record).replace(
+      '  "schemaVersion": 1,',
+      '  "schemaVersion": 1,\n  "unexpected": true,'
+    );
+    assert.equal(
+      parseGrowthApprovalComment(unknownField, policy).diagnostics[0].code,
+      'GROWTH_APPROVAL_FIELDS'
+    );
 
     const duplicateKey = formatGrowthApprovalComment(record).replace(
       '  "schemaVersion": 1,',
@@ -252,6 +260,11 @@ describe('exact-head performance growth approval contract', () => {
     );
     assert.equal(
       validation({ comments: [comment(approvalRecord(), { login: 'attacker' })] })
+        .diagnostics[0].code,
+      'GROWTH_APPROVAL_MISSING'
+    );
+    assert.equal(
+      validation({ comments: [comment(approvalRecord(), { login: null })] })
         .diagnostics[0].code,
       'GROWTH_APPROVAL_MISSING'
     );

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -160,6 +160,16 @@ describe('exact-head performance growth approval contract', () => {
       ),
       /non-comparable sizes/
     );
+    for (const size of [undefined, -1, Number.NaN]) {
+      assert.throws(
+        () => requiredArtifactGrowth(
+          report([{ path: 'dist/a.js', size: 100 }]),
+          report([{ path: 'dist/a.js', size }]),
+          1
+        ),
+        /non-comparable sizes/
+      );
+    }
     assert.throws(
       () => requiredArtifactGrowth(
         report([{ path: 'dist/a.js', size: 100 }]),
@@ -321,6 +331,18 @@ describe('exact-head performance growth approval contract', () => {
     ]);
   });
 
+  test('ignores forged approvals when one trusted exact-head approval is valid', () => {
+    const result = validation({
+      comments: [
+        comment(approvalRecord(), { association: 'NONE', id: 1 }),
+        comment(approvalRecord(), { id: 2 }),
+      ],
+    });
+
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(result.ignored.map(({ reason }) => reason), ['unauthorized-author']);
+  });
+
   test('rejects duplicate exact-head approvals and path mismatches', () => {
 
     assert.equal(
@@ -370,6 +392,37 @@ describe('exact-head performance growth approval contract', () => {
     assert.equal(
       untrustedEvidence.diagnostics[0].code,
       'GROWTH_APPROVAL_EVIDENCE_MISSING'
+    );
+
+    const missingEvidenceAssociation = validateGrowthApproval({
+      baseReport: report([{ path: 'dist/over.js', size: 100 }]),
+      comments: snapshot([comment(approvalRecord())]),
+      currentReport: report([{ path: 'dist/over.js', size: 102 }]),
+      evidenceComments: evidenceSnapshot([evidenceComment({ association: null })]),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(missingEvidenceAssociation.status, 'invalid');
+    assert.equal(
+      missingEvidenceAssociation.diagnostics[0].code,
+      'GROWTH_APPROVAL_EVIDENCE_MISSING'
+    );
+  });
+
+  test('rejects abbreviated pull request and approval head SHAs', () => {
+    const prefix = headSha.slice(0, 12);
+    assert.equal(
+      validation({ currentHead: prefix }).diagnostics[0].code,
+      'GROWTH_APPROVAL_PULL_REQUEST_HEAD'
+    );
+
+    const abbreviated = approvalRecord();
+    abbreviated.headSha = prefix;
+    assert.equal(
+      validation({ comments: [comment(abbreviated)] }).diagnostics[0].code,
+      'GROWTH_APPROVAL_MISSING'
     );
   });
 
@@ -455,6 +508,10 @@ describe('exact-head performance growth approval contract', () => {
       assert.equal(
         JSON.parse(invalidInput.stdout).diagnostics[0].code,
         'GROWTH_APPROVAL_INPUT'
+      );
+      assert.match(
+        JSON.parse(invalidInput.stdout).diagnostics[0].message,
+        /Missing value for --head-sha/
       );
 
       const invalidPullRequest = spawnSync(process.execPath, [

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -1,4 +1,9 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import {
   formatGrowthApprovalComment,
@@ -10,6 +15,7 @@ import {
 
 const headSha = '1234567890abcdef1234567890abcdef12345678';
 const pullRequestNumber = 1;
+const root = fileURLToPath(new URL('../..', import.meta.url));
 const evidenceUrl =
   'https://github.com/marionettejs/marionette/issues/127#issuecomment-123';
 const policy = {
@@ -349,5 +355,71 @@ describe('exact-head performance growth approval contract', () => {
 
     assert.equal(result.status, 'not-required');
     assert.deepEqual(result.diagnostics, []);
+  });
+
+  test('emits structured JSON and exit status from the offline CLI', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-growth-approval-'));
+    const paths = {
+      base: join(fixtureRoot, 'base.json'),
+      comments: join(fixtureRoot, 'comments.json'),
+      contract: join(fixtureRoot, 'contract.json'),
+      current: join(fixtureRoot, 'current.json'),
+      evidence: join(fixtureRoot, 'evidence.json'),
+    };
+    const cli = join(root, 'config/performance-growth-approval.mjs');
+    const args = [
+      cli,
+      '--contract', paths.contract,
+      '--base-report', paths.base,
+      '--current-report', paths.current,
+      '--comments', paths.comments,
+      '--evidence-comments', paths.evidence,
+      '--head-sha', headSha,
+      '--pull-request', String(pullRequestNumber),
+    ];
+
+    try {
+      await Promise.all([
+        writeFile(paths.contract, JSON.stringify({
+          thresholds: { pullRequestApprovalPercent: 1 },
+          pullRequestGrowthApproval: policy,
+        })),
+        writeFile(paths.base, JSON.stringify(report([
+          { name: 'Over', path: 'dist/over.js', size: 100 },
+        ]))),
+        writeFile(paths.current, JSON.stringify(report([
+          { name: 'Over', path: 'dist/over.js', size: 102 },
+        ]))),
+        writeFile(paths.comments, JSON.stringify(snapshot([comment(approvalRecord())]))),
+        writeFile(paths.evidence, JSON.stringify(evidenceSnapshot())),
+      ]);
+
+      const approved = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      assert.equal(approved.status, 0);
+      assert.equal(JSON.parse(approved.stdout).status, 'approved');
+
+      await writeFile(paths.comments, JSON.stringify(snapshot([])));
+      const missing = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      assert.equal(missing.status, 1);
+      assert.equal(JSON.parse(missing.stdout).diagnostics[0].code, 'GROWTH_APPROVAL_MISSING');
+
+      const invalidInput = spawnSync(process.execPath, [cli], { encoding: 'utf8' });
+      assert.equal(invalidInput.status, 1);
+      assert.equal(
+        JSON.parse(invalidInput.stdout).diagnostics[0].code,
+        'GROWTH_APPROVAL_INPUT'
+      );
+
+      const invalidPullRequest = spawnSync(process.execPath, [
+        ...args.slice(0, -1), '1e2',
+      ], { encoding: 'utf8' });
+      assert.equal(invalidPullRequest.status, 1);
+      assert.match(
+        JSON.parse(invalidPullRequest.stdout).diagnostics[0].message,
+        /positive integer/
+      );
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -40,6 +40,7 @@ function approvalRecord(approvedPaths = ['dist/over.js']) {
 }
 
 function comment(record, {
+  association = 'MEMBER',
   id = 1,
   login = 'paulfalgout',
   pullRequest = pullRequestNumber,
@@ -47,6 +48,7 @@ function comment(record, {
 } = {}) {
   return {
     id,
+    'author_association': association,
     body: formatGrowthApprovalComment(record),
     'html_url': `https://github.com/marionettejs/marionette/pull/${pullRequest}#issuecomment-${id}`,
     user: { login, type },
@@ -271,6 +273,11 @@ describe('exact-head performance growth approval contract', () => {
     );
     assert.equal(
       validation({ comments: [comment(approvalRecord(), { login: null })] })
+        .diagnostics[0].code,
+      'GROWTH_APPROVAL_MISSING'
+    );
+    assert.equal(
+      validation({ comments: [comment(approvalRecord(), { association: 'NONE' })] })
         .diagnostics[0].code,
       'GROWTH_APPROVAL_MISSING'
     );

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -374,6 +374,12 @@ describe('exact-head performance growth approval contract', () => {
       evidence: join(fixtureRoot, 'evidence.json'),
     };
     const cli = join(root, 'config/performance-growth-approval.mjs');
+    const checkoutHead = spawnSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+    }).stdout.trim();
+    const cliApproval = approvalRecord();
+    cliApproval.headSha = checkoutHead;
     const args = [
       cli,
       '--contract', paths.contract,
@@ -381,7 +387,7 @@ describe('exact-head performance growth approval contract', () => {
       '--current-report', paths.current,
       '--comments', paths.comments,
       '--evidence-comments', paths.evidence,
-      '--head-sha', headSha,
+      '--head-sha', checkoutHead,
       '--pull-request', String(pullRequestNumber),
     ];
 
@@ -397,13 +403,22 @@ describe('exact-head performance growth approval contract', () => {
         writeFile(paths.current, JSON.stringify(report([
           { name: 'Over', path: 'dist/over.js', size: 102 },
         ]))),
-        writeFile(paths.comments, JSON.stringify(snapshot([comment(approvalRecord())]))),
+        writeFile(paths.comments, JSON.stringify(snapshot([comment(cliApproval)]))),
         writeFile(paths.evidence, JSON.stringify(evidenceSnapshot())),
       ]);
 
       const approved = spawnSync(process.execPath, args, { encoding: 'utf8' });
       assert.equal(approved.status, 0);
       assert.equal(JSON.parse(approved.stdout).status, 'approved');
+
+      const mismatchedArgs = [...args];
+      mismatchedArgs[mismatchedArgs.indexOf('--head-sha') + 1] = headSha;
+      const mismatchedHead = spawnSync(process.execPath, mismatchedArgs, { encoding: 'utf8' });
+      assert.equal(mismatchedHead.status, 1);
+      assert.match(
+        JSON.parse(mismatchedHead.stdout).diagnostics[0].message,
+        /does not match checkout/
+      );
 
       await writeFile(paths.comments, JSON.stringify(snapshot([])));
       const missing = spawnSync(process.execPath, args, { encoding: 'utf8' });

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -90,12 +90,13 @@ function validation({
   current = [{ name: 'Over', path: 'dist/over.js', size: 102 }],
   currentHead = headSha,
   currentPolicy = policy,
+  evidence = [evidenceComment()],
 } = {}) {
   return validateGrowthApproval({
     baseReport: report(base),
     comments: snapshot(comments),
     currentReport: report(current),
-    evidenceComments: evidenceSnapshot(),
+    evidenceComments: evidenceSnapshot(evidence),
     headSha: currentHead,
     policy: currentPolicy,
     pullRequestNumber,
@@ -418,7 +419,9 @@ describe('exact-head performance growth approval contract', () => {
     assert.equal(unresolved.status, 'invalid');
     assert.equal(unresolved.diagnostics[0].code, 'GROWTH_APPROVAL_EVIDENCE_MISSING');
 
-    const collaboratorEvidence = validation();
+    const collaboratorEvidence = validation({
+      evidence: [evidenceComment({ association: 'COLLABORATOR' })],
+    });
     assert.equal(collaboratorEvidence.status, 'approved');
 
     const untrustedEvidence = validateGrowthApproval({

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -65,7 +65,16 @@ function snapshot(comments, status = 'ok') {
   };
 }
 
-function evidenceSnapshot(comments = [{ id: 123, 'html_url': evidenceUrl }], status = 'ok') {
+function evidenceComment({ association = 'MEMBER', type = 'User' } = {}) {
+  return {
+    id: 123,
+    'author_association': association,
+    'html_url': evidenceUrl,
+    user: { type },
+  };
+}
+
+function evidenceSnapshot(comments = [evidenceComment()], status = 'ok') {
   return {
     schemaVersion: 1,
     status,
@@ -346,6 +355,22 @@ describe('exact-head performance growth approval contract', () => {
     });
     assert.equal(unresolved.status, 'invalid');
     assert.equal(unresolved.diagnostics[0].code, 'GROWTH_APPROVAL_EVIDENCE_MISSING');
+
+    const untrustedEvidence = validateGrowthApproval({
+      baseReport: report([{ path: 'dist/over.js', size: 100 }]),
+      comments: snapshot([comment(approvalRecord())]),
+      currentReport: report([{ path: 'dist/over.js', size: 102 }]),
+      evidenceComments: evidenceSnapshot([evidenceComment({ association: 'NONE' })]),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(untrustedEvidence.status, 'invalid');
+    assert.equal(
+      untrustedEvidence.diagnostics[0].code,
+      'GROWTH_APPROVAL_EVIDENCE_MISSING'
+    );
   });
 
   test('does not need comment access when no existing artifact crosses the threshold', () => {


### PR DESCRIPTION
Related #127

## What

- Add a versioned, base-owned policy for maintainers who may approve existing runtime artifact growth above 1%.
- Add a canonical exact-head approval parser/evaluator and offline CLI that bind records to the repository, pull request, full head SHA, exact artifact path set, and API-resolved tracking-issue evidence.
- Define the report-side approval input and artifact-specific output contract, with adversarial performance tests, documentation, and production-graph ownership protections.

## Why

The current performance report identifies growth above 1% but does not yet have a machine-readable approval contract. Defining and reviewing the parser, allowlist, and report interface before enforcement lets the next PR execute them from its exact base checkout instead of authorizing itself with candidate-owned policy.

## Scope

This Tier 0 contract PR now targets master and includes the merged #184 resource contract. It changes performance configuration, non-production validation tooling, focused tests, CODEOWNERS, and performance documentation.

It intentionally does not collect GitHub comments, change CI enforcement, approve new production subpaths, modify runtime source or package exports, publish documentation, release npm artifacts, or change the website.

## Deployment Impact

No application or form deployment is required. This adds no production runtime code and does not publish a package, release, or website.

## Testing

- `npm run test:performance` - 45 tests passed
- `npm run lint:ci`
- `npm run size` - cumulative Brotli size remains 49.50 kB; resource scenarios pass
- `npm run docs:check` - 30 HTML files and 288 internal links validated
- `npm run check:dist`
- Verified `dist/`, `version.js`, `package-lock.json`, runtime source, and package exports are unchanged from the stacked base

