### PR TITLE
ci(performance): enforce exact-head growth approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,6 @@
 /benchmarks/ @paulfalgout @marionettejs/marionette-core
 /test/performance/ @paulfalgout @marionettejs/marionette-core
 /.github/workflows/ci.yml @paulfalgout @marionettejs/marionette-core
+/.github/workflows/performance-approval-refresh.yml @paulfalgout @marionettejs/marionette-core
 /.github/workflows/bundle-size-comment.yml @paulfalgout @marionettejs/marionette-core
 /.github/workflows/release.yml @paulfalgout @marionettejs/marionette-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+run-name: >-
+  ${{ github.event_name == 'pull_request' && format('CI PR #{0} base {1} head {2}', github.event.pull_request.number, github.event.pull_request.base.sha, github.event.pull_request.head.sha) || format('CI {0}', github.ref_name) }}
 
 on:
   push:
@@ -106,6 +108,9 @@ jobs:
     name: Bundle size
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: read
 
     steps:
       - name: Checkout
@@ -128,10 +133,73 @@ jobs:
       - name: Build current branch
         run: npm run build
 
+      - name: Prepare performance workspace
+        id: performance_workspace
+        run: |
+          set -euo pipefail
+          performance_dir="$(mktemp -d "${RUNNER_TEMP}/marionette-growth-approval.XXXXXX")"
+          chmod 700 "${performance_dir}"
+          echo "directory=${performance_dir}" >> "${GITHUB_OUTPUT}"
+
       - name: Check current performance contract
         id: current_contract
         continue-on-error: true
-        run: node config/bundle-size.mjs --json > bundle-size-current.json
+        env:
+          PERFORMANCE_DIR: ${{ steps.performance_workspace.outputs.directory }}
+        run: node config/bundle-size.mjs --json > "${PERFORMANCE_DIR}/bundle-size-current.json"
+
+      - name: Collect performance growth approval records
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PERFORMANCE_DIR: ${{ steps.performance_workspace.outputs.directory }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          TRACKING_ISSUE_NUMBER: 127
+        run: |
+          set -euo pipefail
+          pull_request_status='ok'
+          if ! gh api --paginate --slurp \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/${REPOSITORY}/issues/${PULL_REQUEST_NUMBER}/comments?per_page=100" \
+            > "${PERFORMANCE_DIR}/pull-request-pages.json"; then
+            pull_request_status='unavailable'
+            echo '[]' > "${PERFORMANCE_DIR}/pull-request-pages.json"
+          fi
+          jq -n \
+            --arg repository "${REPOSITORY}" \
+            --arg status "${pull_request_status}" \
+            --argjson pull_request_number "${PULL_REQUEST_NUMBER}" \
+            --slurpfile pages "${PERFORMANCE_DIR}/pull-request-pages.json" \
+            '{
+              schemaVersion: 1,
+              status: $status,
+              repository: $repository,
+              pullRequestNumber: $pull_request_number,
+              comments: ($pages[0] | add // [])
+            }' > "${PERFORMANCE_DIR}/approval-comments.json"
+
+          issue_status='ok'
+          if ! gh api --paginate --slurp \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/${REPOSITORY}/issues/${TRACKING_ISSUE_NUMBER}/comments?per_page=100" \
+            > "${PERFORMANCE_DIR}/tracking-issue-pages.json"; then
+            issue_status='unavailable'
+            echo '[]' > "${PERFORMANCE_DIR}/tracking-issue-pages.json"
+          fi
+          jq -n \
+            --arg repository "${REPOSITORY}" \
+            --arg status "${issue_status}" \
+            --argjson issue_number "${TRACKING_ISSUE_NUMBER}" \
+            --slurpfile pages "${PERFORMANCE_DIR}/tracking-issue-pages.json" \
+            '{
+              schemaVersion: 1,
+              status: $status,
+              repository: $repository,
+              issueNumber: $issue_number,
+              comments: ($pages[0] | add // [])
+            }' > "${PERFORMANCE_DIR}/growth-evidence-comments.json"
 
       - name: Checkout exact pull request base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -150,37 +218,41 @@ jobs:
         id: base_authority
         continue-on-error: true
         env:
-          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PERFORMANCE_DIR: ${{ steps.performance_workspace.outputs.directory }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           base_contract='bundle-size-base/config/performance.json'
           authority_script='bundle-size-base/config/bundle-size.mjs'
-          # Each exact-SHA fallback becomes permanently unreachable after its reviewed bootstrap merges.
-          if [ ! -f "${base_contract}" ]; then
-            if [ "${PULL_REQUEST_BASE_SHA}" != '31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4' ]; then
-              echo 'Base has no performance contract and is not the reviewed performance bootstrap base.' >&2
-              exit 1
-            fi
-            base_contract='config/performance.json'
-            authority_script='config/bundle-size.mjs'
-            echo 'Using the current contract for the performance bootstrap from exact base 31151c9.'
-          elif [ ! -f 'bundle-size-base/config/performance-resources.mjs' ]; then
-            if [ "${PULL_REQUEST_BASE_SHA}" != '25f3739376d391df396885f3ea1b88fa1ea7a0f0' ]; then
-              echo 'Base has no resource comparator and is not the reviewed bootstrap base.' >&2
-              exit 1
-            fi
-            authority_script='config/bundle-size.mjs'
-            echo 'Using the current validator for the resource bootstrap from exact base 25f3739.'
-          fi
-          node "${authority_script}" --root bundle-size-base --config "${base_contract}" --json --no-enforce > bundle-size-base.json
+          approval_script='bundle-size-base/config/performance-growth-approval.mjs'
+          test -f "${base_contract}"
+          test -f "${authority_script}"
+          test -f "${approval_script}"
+
+          node "${authority_script}" --root bundle-size-base --config "${base_contract}" --json --no-enforce > "${PERFORMANCE_DIR}/bundle-size-base.json"
           authority_status=0
-          node "${authority_script}" --config "${base_contract}" --json > bundle-size-authority.json || authority_status=$?
+          node "${authority_script}" --config "${base_contract}" --json > "${PERFORMANCE_DIR}/bundle-size-authority.json" || authority_status=$?
           candidate_status=0
           node "${authority_script}" --validate-resource-contract "${base_contract}" config/performance.json || candidate_status=$?
+          approval_status=0
+          node "${approval_script}" \
+            --contract "${base_contract}" \
+            --base-report "${PERFORMANCE_DIR}/bundle-size-base.json" \
+            --current-report "${PERFORMANCE_DIR}/bundle-size-authority.json" \
+            --comments "${PERFORMANCE_DIR}/approval-comments.json" \
+            --evidence-comments "${PERFORMANCE_DIR}/growth-evidence-comments.json" \
+            --head-sha "${PULL_REQUEST_HEAD_SHA}" \
+            --pull-request "${PULL_REQUEST_NUMBER}" \
+            > "${PERFORMANCE_DIR}/growth-approval.json" || approval_status=$?
           report_status=0
-          node "${authority_script}" --report bundle-size-base.json bundle-size-authority.json > bundle-size-report.md || report_status=$?
-          cat bundle-size-report.md >> "${GITHUB_STEP_SUMMARY}"
-          if [ "${authority_status}" -ne 0 ] || [ "${candidate_status}" -ne 0 ] || [ "${report_status}" -ne 0 ]; then
+          node "${authority_script}" \
+            --report "${PERFORMANCE_DIR}/bundle-size-base.json" "${PERFORMANCE_DIR}/bundle-size-authority.json" \
+            --growth-approval "${PERFORMANCE_DIR}/growth-approval.json" \
+            > "${PERFORMANCE_DIR}/bundle-size-report.md" || report_status=$?
+          cat "${PERFORMANCE_DIR}/bundle-size-report.md" >> "${GITHUB_STEP_SUMMARY}"
+          if [ "${authority_status}" -ne 0 ] || [ "${candidate_status}" -ne 0 ] || \
+              [ "${approval_status}" -ne 0 ] || [ "${report_status}" -ne 0 ]; then
             exit 1
           fi
 
@@ -188,7 +260,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bundle-size-report
-          path: bundle-size-report.md
+          path: ${{ steps.performance_workspace.outputs.directory }}/bundle-size-report.md
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup Node

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -1,0 +1,179 @@
+name: Performance approval refresh
+
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Refresh bundle-size approval
+    if: >-
+      ${{
+        (
+          github.event.issue.pull_request &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          (
+            github.event.action != 'created' ||
+            contains(github.event.comment.body, '<!-- marionette-performance-growth-approval:v1 -->')
+          )
+        ) ||
+        (
+          !github.event.issue.pull_request &&
+          github.event.issue.number == 127 &&
+          github.event.action != 'created'
+        )
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    concurrency:
+      group: performance-approval-refresh-${{ github.event.comment.id }}
+      cancel-in-progress: true
+    permissions:
+      actions: write
+      contents: read
+      issues: read
+      pull-requests: read
+
+    steps:
+      - name: Re-run exact-head bundle-size checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_COMMENT_URL: ${{ github.event.comment.html_url }}
+          IS_PULL_REQUEST: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pull_requests="$(mktemp "${RUNNER_TEMP}/marionette-growth-prs.XXXXXX")"
+          refresh_failed=0
+
+          if [ "${IS_PULL_REQUEST}" = 'true' ]; then
+            printf '%s\n' "${ISSUE_NUMBER}" > "${pull_requests}"
+          else
+            open_pull_requests="$(mktemp "${RUNNER_TEMP}/marionette-open-prs.XXXXXX")"
+            comment_pages="$(mktemp "${RUNNER_TEMP}/marionette-pr-comments.XXXXXX")"
+            gh api --paginate \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${REPOSITORY}/pulls?state=open&per_page=100" \
+              --jq '.[].number' > "${open_pull_requests}"
+
+            while IFS= read -r open_pull_request; do
+              if ! [[ "${open_pull_request}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Invalid open pull request number: ${open_pull_request}" >&2
+                refresh_failed=1
+                continue
+              fi
+              if ! gh api --paginate --slurp \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "repos/${REPOSITORY}/issues/${open_pull_request}/comments?per_page=100" \
+                > "${comment_pages}"; then
+                echo "Comments unavailable for pull request ${open_pull_request}." >&2
+                refresh_failed=1
+                continue
+              fi
+              if jq -e \
+                  --arg evidence_url "${EVENT_COMMENT_URL}" \
+                  --arg marker '<!-- marionette-performance-growth-approval:v1 -->' \
+                  'add // [] | any(.[];
+                    . as $comment |
+                    (($comment.body // "") | contains($marker)) and
+                    (($comment.body // "") | contains($evidence_url)) and
+                    (["OWNER", "MEMBER", "COLLABORATOR"] |
+                      index($comment.author_association) != null)
+                  )' \
+                  "${comment_pages}" > /dev/null; then
+                printf '%s\n' "${open_pull_request}" >> "${pull_requests}"
+              fi
+            done < "${open_pull_requests}"
+          fi
+
+          while IFS= read -r pull_request_number; do
+            if ! [[ "${pull_request_number}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Invalid pull request number: ${pull_request_number}" >&2
+              refresh_failed=1
+              continue
+            fi
+
+            pull_request_data="$(mktemp "${RUNNER_TEMP}/marionette-pr.XXXXXX")"
+            if ! gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${REPOSITORY}/pulls/${pull_request_number}" \
+              > "${pull_request_data}"; then
+              echo "Pull request ${pull_request_number} is unavailable." >&2
+              refresh_failed=1
+              continue
+            fi
+            head_sha="$(jq -r '.head.sha' "${pull_request_data}")"
+            base_sha="$(jq -r '.base.sha' "${pull_request_data}")"
+            if ! [[ "${head_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid head SHA for pull request ${pull_request_number}." >&2
+              refresh_failed=1
+              continue
+            fi
+            if ! [[ "${base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid base SHA for pull request ${pull_request_number}." >&2
+              refresh_failed=1
+              continue
+            fi
+
+            workflow_runs="$(mktemp "${RUNNER_TEMP}/marionette-ci-runs.XXXXXX")"
+            expected_run_name="CI PR #${pull_request_number} base ${base_sha} head ${head_sha}"
+            run_id=''
+            lookup_failed=0
+            for attempt in {1..24}; do
+              if ! gh api \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?event=pull_request&head_sha=${head_sha}&per_page=100" \
+                > "${workflow_runs}"; then
+                lookup_failed=1
+                break
+              fi
+              run_id="$(jq -r --arg expected_run_name "${expected_run_name}" \
+                '.workflow_runs |
+                 map(select(.display_title == $expected_run_name)) |
+                 sort_by(.created_at) | last | .id // empty' \
+                "${workflow_runs}")"
+              if [ -n "${run_id}" ]; then
+                break
+              fi
+              sleep 5
+            done
+            if [ "${lookup_failed}" -ne 0 ] || ! [[ "${run_id}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "No CI run found for pull request ${pull_request_number} at ${head_sha}." >&2
+              refresh_failed=1
+              continue
+            fi
+
+            gh run watch "${run_id}" --repo "${REPOSITORY}" --exit-status || true
+            if ! bundle_job_id="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${REPOSITORY}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
+              --jq '.jobs[] | select(.name == "Bundle size") | .id')"; then
+              echo "Jobs unavailable for CI run ${run_id}." >&2
+              refresh_failed=1
+              continue
+            fi
+            if ! [[ "${bundle_job_id}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "No Bundle size job found for CI run ${run_id}." >&2
+              refresh_failed=1
+              continue
+            fi
+
+            if ! gh api --method POST \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${REPOSITORY}/actions/jobs/${bundle_job_id}/rerun"; then
+              echo "Could not re-run Bundle size job ${bundle_job_id}." >&2
+              refresh_failed=1
+            fi
+          done < "${pull_requests}"
+
+          exit "${refresh_failed}"

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -84,6 +84,7 @@ jobs:
                   'add // [] | any(.[];
                     . as $comment |
                     (($comment.body // "") |
+                      gsub("\r\n"; "\n") |
                       capture("(?s)^<!-- marionette-performance-growth-approval:v1 -->\\n```json\\n(?<record>.+)\\n```\\n?$")? |
                       .record | fromjson?) as $approval |
                     (($approval.evidenceUrls? | type) == "array") and

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -16,7 +16,10 @@ jobs:
           github.event.issue.pull_request &&
           github.event.comment.user.type == 'User' &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-          contains(github.event.comment.body, '<!-- marionette-performance-growth-approval:v1 -->')
+          (
+            contains(github.event.comment.body, '<!-- marionette-performance-growth-approval:v1 -->') ||
+            contains(github.event.changes.body.from, '<!-- marionette-performance-growth-approval:v1 -->')
+          )
         ) ||
         (
           !github.event.issue.pull_request &&

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -14,15 +14,14 @@ jobs:
       ${{
         (
           github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-          (
-            github.event.action != 'created' ||
-            contains(github.event.comment.body, '<!-- marionette-performance-growth-approval:v1 -->')
-          )
+          contains(github.event.comment.body, '<!-- marionette-performance-growth-approval:v1 -->')
         ) ||
         (
           !github.event.issue.pull_request &&
           github.event.issue.number == 127 &&
+          github.event.comment.user.type == 'User' &&
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
           github.event.action != 'created'
         )
@@ -79,11 +78,14 @@ jobs:
               fi
               if jq -e \
                   --arg evidence_url "${EVENT_COMMENT_URL}" \
-                  --arg marker '<!-- marionette-performance-growth-approval:v1 -->' \
                   'add // [] | any(.[];
                     . as $comment |
-                    (($comment.body // "") | contains($marker)) and
-                    (($comment.body // "") | contains($evidence_url)) and
+                    (($comment.body // "") |
+                      capture("(?s)^<!-- marionette-performance-growth-approval:v1 -->\\n```json\\n(?<record>.+)\\n```\\n?$")? |
+                      .record | fromjson?) as $approval |
+                    (($approval.evidenceUrls? | type) == "array") and
+                    ($approval.evidenceUrls | index($evidence_url) != null) and
+                    ($comment.user.type == "User") and
                     (["OWNER", "MEMBER", "COLLABORATOR"] |
                       index($comment.author_association) != null)
                   )' \

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -23,6 +23,7 @@ jobs:
         (
           !github.event.issue.pull_request &&
           github.event.issue.number == 127 &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
           github.event.action != 'created'
         )
       }}

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -141,6 +141,11 @@ collection is unavailable when approval is required, the job fails closed; a pul
 request with no existing artifact above the threshold does not require comment
 availability.
 
+The refresh workflow selects only a CI run whose immutable run name records the
+current pull request number, base SHA, and head SHA. If the base advances, it refuses
+to replay an older comparison. The default-branch rules require strict up-to-date
+status checks, so merge remains blocked until CI records the new exact base.
+
 ## Hosted timing
 
 Run the reporting harness with:

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -123,13 +123,23 @@ comments do not approve anything. Multiple exact-head approvals, malformed trust
 records without a valid replacement, missing paths, extra paths, and noncanonical JSON
 fail the evaluator.
 
-This change deliberately defines and tests the contract before enforcing it. The
-immediately following pull request will collect the read-only GitHub comment snapshot
-and invoke this parser from the exact base checkout. Until that wiring lands, the
-existing `Bundle size` report still labels growth above one percent but does not treat
-the comment record as a merge gate. This two-step bootstrap avoids allowing the first
-enforcement change to authorize itself with a parser or allowlist absent from its
-base.
+The required `Bundle size` job collects read-only snapshots of the pull request
+timeline and issue #127 comments. It then invokes the approval evaluator from the
+exact base checkout with the exact-base threshold and allowlist. The evaluator emits
+one structured result that drives both the report and exit status, so candidate edits
+cannot lower the threshold, add an approver, replace the parser, or make output disagree
+with enforcement. GitHub comment bodies remain JSON data and are never evaluated or
+interpolated by the shell.
+
+Approval comment creation, editing, and deletion automatically queues a re-run of the
+completed exact-head `Bundle size` job. Changes to evidence comments on issue #127 do
+the same for every open pull request whose approval references the changed comment.
+GitHub delivers comment events asynchronously, so do not merge until the `Performance
+approval refresh` workflow and resulting `Bundle size` re-run finish. A code push
+changes the head SHA and invalidates the previous approval automatically. If comment
+collection is unavailable when approval is required, the job fails closed; a pull
+request with no existing artifact above the threshold does not require comment
+availability.
 
 ## Hosted timing
 
@@ -166,5 +176,5 @@ CODEOWNERS assigns the contract, growth-approval parser, resource probe, harness
 focused tests, and performance workflows to the project maintainer and core team.
 Current live repository rules do not require a CODEOWNER approval, so ownership is
 review routing rather than an automated merge gate. The exact-base authority contract
-is the automated anti-relaxation guard after this bootstrap; growth-approval
-enforcement and the controlled timing runner remain separate follow-ups.
+is the automated anti-relaxation guard. Approved new-subpath adoption and the
+controlled timing runner remain separate follow-ups.


### PR DESCRIPTION
Related #127

## What

- Enforce existing-artifact growth approvals in the required `Bundle size` job using the parser, policy, and reporter from the exact pull request base checkout.
- Explicitly check out the pull request head SHA, collect pull request and issue #127 comments as read-only JSON snapshots in a private runner-temporary directory, and fail closed when required approval or evidence is unavailable or invalid.
- Re-run the exact PR/base/head `Bundle size` job after trusted approval comments or referenced evidence comments are edited or deleted; refuse to replay a stale-base run.

## Why

#185 defines the versioned approval contract but intentionally leaves it non-enforcing. This stacked PR activates that reviewed contract without allowing candidate-owned code or configuration to authorize its own artifact growth, and keeps approval changes from silently leaving an obsolete check result.

## Scope

This PR now targets master and includes the merged #185 approval contract. It changes CI workflows, CODEOWNERS routing, and performance documentation only.

It does not modify runtime source, package exports, dependencies, built artifacts, release behavior, website publication, new-subpath approval, or hosted timing enforcement. GitHub delivers comment events asynchronously; maintainers must wait for the `Performance approval refresh` workflow and resulting `Bundle size` rerun before merging after an approval or evidence edit/deletion. If the base advances, strict up-to-date required checks keep merge blocked until CI records the new exact base.

## Deployment Impact

No application or form deployment is required. This adds no production runtime code and does not publish an npm package, GitHub release, or website.

## Testing

- `npm run test:performance` - 45 tests passed
- `npm run lint:ci`
- `npm run size` - cumulative Brotli size remains 49.50 kB; resource scenarios pass
- `npm run docs:check` - 30 HTML files and 288 internal links validated
- `npm run check:dist`
- Parsed all workflow files as YAML and verified the refresh shell program with `bash -n`
- Validated all workflow YAML and extracted shell syntax for the exact-base and refresh jobs
- Queried live workflow-run and job APIs read-only to verify exact head/run/job discovery shapes
- Verified current master, including merged #185, is an ancestor of this branch and the working tree is clean
