### PR TITLE
feat(performance): define new subpath approval contract

### DIFF
--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -3,10 +3,13 @@ import { readFile, readdir } from 'node:fs/promises';
 import { relative, resolve } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { promisify } from 'node:util';
+import { isDeepStrictEqual, promisify } from 'node:util';
 import { brotliCompress, constants } from 'node:zlib';
 import { rollup } from 'rollup';
-import { validateGrowthApprovalPolicy } from './performance-growth-approval.mjs';
+import {
+  newProductionReportDelta,
+  validateGrowthApprovalPolicy,
+} from './performance-growth-approval.mjs';
 import {
   compareResources,
   measureResources,
@@ -526,6 +529,21 @@ function sameApprovalRequirements(supplied, expected) {
   });
 }
 
+function sameNewArtifacts(supplied, expected) {
+  if (!Array.isArray(supplied) || supplied.length !== expected.length) {
+    return false;
+  }
+
+  const normalized = supplied.map(artifact => ({
+    path: artifact?.path,
+    size: artifact?.size,
+  })).sort((left, right) => String(left.path) < String(right.path) ? -1 :
+    String(left.path) > String(right.path) ? 1 : 0);
+  return normalized.every((artifact, index) => {
+    return artifact.path === expected[index].path && artifact.size === expected[index].size;
+  });
+}
+
 function growthApprovalReport(base, current, supplied) {
   const thresholdPercent = current.thresholds.pullRequestApprovalPercent;
   const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
@@ -533,6 +551,10 @@ function growthApprovalReport(base, current, supplied) {
     .map(result => approvalRequirement(baseByPath.get(result.path), result, thresholdPercent))
     .filter(Boolean)
     .sort((left, right) => left.path.localeCompare(right.path));
+  const newProduction = newProductionReportDelta(base, current);
+  const newProductionPresent = newProduction.artifacts.length || newProduction.subpaths.length;
+  const newProductionEnforced = supplied?.newProductionEnforced === true;
+  const approvalRequired = required.length || newProductionEnforced && newProductionPresent;
   const violations = [];
 
   if (!supplied) {
@@ -541,7 +563,8 @@ function growthApprovalReport(base, current, supplied) {
       violations.push('Existing artifact growth above the approval threshold has no structured approval result');
     }
     return { accepted: !required.length, approval: null, diagnostics: [], headSha: null,
-      required, status, thresholdPercent, violations };
+      newArtifacts: newProduction.artifacts, newSubpaths: newProduction.subpaths,
+      newProductionEnforced: false, required, status, thresholdPercent, violations };
   }
 
   if (supplied.schemaVersion !== 1 || !Array.isArray(supplied.required) ||
@@ -554,16 +577,23 @@ function growthApprovalReport(base, current, supplied) {
   if (typeof supplied.headSha !== 'string' || !/^[a-f\d]{40}$/.test(supplied.headSha)) {
     violations.push('Growth approval result is missing a lowercase full head SHA');
   }
+  if (newProductionPresent && typeof supplied.newProductionEnforced !== 'boolean') {
+    violations.push('Growth approval result is missing its new-production enforcement state');
+  }
 
   if (!sameApprovalRequirements(supplied.required, required)) {
     violations.push('Growth approval requirements do not match the exact report comparison');
   }
+  if (!sameNewArtifacts(supplied.newArtifacts || [], newProduction.artifacts) ||
+      !isDeepStrictEqual(supplied.newSubpaths || [], newProduction.subpaths)) {
+    violations.push('New-production approval requirements do not match the exact report comparison');
+  }
   if (!['approved', 'not-required'].includes(supplied.status)) {
     violations.push(`Growth approval status ${supplied.status || 'missing'} does not permit this report`);
-  } else if (required.length && supplied.status !== 'approved') {
-    violations.push('Existing artifact growth requires an approved result');
-  } else if (!required.length && supplied.status !== 'not-required') {
-    violations.push('Growth approval result must be not-required when no artifact crosses the threshold');
+  } else if (approvalRequired && supplied.status !== 'approved') {
+    violations.push('Production artifact growth or a new subpath requires an approved result');
+  } else if (!approvalRequired && supplied.status !== 'not-required') {
+    violations.push('Growth approval result must be not-required when no approval condition is present');
   }
   if (supplied.status === 'approved' && (!supplied.approval || typeof supplied.approval !== 'object')) {
     violations.push('Approved growth result is missing its approval record');
@@ -572,6 +602,9 @@ function growthApprovalReport(base, current, supplied) {
   return {
     ...supplied,
     accepted: violations.length === 0,
+    newArtifacts: newProduction.artifacts,
+    newProductionEnforced,
+    newSubpaths: newProduction.subpaths,
     required,
     thresholdPercent,
     violations,
@@ -593,10 +626,30 @@ function growthApprovalSection(result) {
   if (result.headSha) {
     lines.push(`Head: \`${result.headSha}\`.`);
   }
+  if (result.newSubpaths.length && !result.newProductionEnforced) {
+    lines.push('New-subpath approval enforcement: **Reporting only**; activation is pending.');
+    lines.push(`New subpaths: ${result.newSubpaths.map(subpath => `\`${subpath}\``).join(', ')}.`);
+    lines.push(result.newArtifacts.length ?
+      `New artifacts at full Brotli size: ${result.newArtifacts
+        .map(({ path, size }) => `\`${path}\` (${formatBytes(size)})`).join(', ')}.` :
+      'New artifacts: none; the subpath aliases an existing runtime artifact.');
+  }
   if (result.accepted && result.status === 'approved') {
     const author = result.approval.authorLogin ? `@${result.approval.authorLogin}` : 'an allowed maintainer';
     const link = result.approval.commentUrl ? `[${author}](${result.approval.commentUrl})` : author;
-    lines.push(`Approved by ${link} for ${result.required.map(({ path }) => `\`${path}\``).join(', ')}.`);
+    const existingPaths = result.required.map(({ path }) => `\`${path}\``);
+    if (existingPaths.length) {
+      lines.push(`Approved by ${link} for ${existingPaths.join(', ')}.`);
+    } else {
+      lines.push(`Approved by ${link}.`);
+    }
+    if (result.newSubpaths.length) {
+      lines.push(`New subpaths: ${result.newSubpaths.map(subpath => `\`${subpath}\``).join(', ')}.`);
+      lines.push(result.newArtifacts.length ?
+        `New artifacts at full Brotli size: ${result.newArtifacts
+          .map(({ path, size }) => `\`${path}\` (${formatBytes(size)})`).join(', ')}.` :
+        'New artifacts: none; the approved subpath aliases an existing runtime artifact.');
+    }
   }
 
   const diagnostics = [
@@ -619,10 +672,14 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
   const growthApproval = growthApprovalReport(base, current, suppliedGrowthApproval);
   const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
   const approvalRequiredPaths = new Set(growthApproval.required.map(({ path }) => path));
+  const newArtifactPaths = new Set(growthApproval.newArtifacts.map(({ path }) => path));
   const rows = current.artifacts.map(result => {
     const baseResult = baseByPath.get(result.path);
     if (!baseResult) {
-      return `| ${result.name} | New | ${formatBytes(result.size)} | New artifact | Required |`;
+      const approval = !growthApproval.newProductionEnforced ? 'Reporting only' :
+        newArtifactPaths.has(result.path) && growthApproval.accepted &&
+          growthApproval.status === 'approved' ? 'Approved' : 'Required';
+      return `| ${result.name} | New | ${formatBytes(result.size)} | New artifact | ${approval} |`;
     }
     if (result.size == null || baseResult.size == null) {
       return `| ${result.name} | ${formatBytes(baseResult.size)} | ${formatBytes(result.size)} | Not comparable | Required |`;
@@ -637,7 +694,10 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
     const baseGraph = baseGraphs.get(graph.subpath);
     const change = baseGraph ? graphChange(baseGraph, graph) : graph.error || 'New production subpath';
     const moduleCount = graph.status === 'measured' ? graph.modules.length : 'Unmeasured';
-    return `| \`${graph.subpath}\` | ${moduleCount} | ${graph.externalImports.join(', ') || 'None'} | ${change} |`;
+    const approval = baseGraph ? 'Not required' : !growthApproval.newProductionEnforced ?
+      'Reporting only' : growthApproval.accepted && growthApproval.status === 'approved' ?
+        'Approved' : 'Required';
+    return `| \`${graph.subpath}\` | ${moduleCount} | ${graph.externalImports.join(', ') || 'None'} | ${change} | ${approval} |`;
   });
   const cumulativeGrowth = formatChange(base.cumulative.size, current.cumulative.size);
   const phase0Growth = formatChange(current.cumulative.baselineSize, current.cumulative.size);
@@ -666,8 +726,8 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
     '',
     `Cumulative Brotli-${current.brotliQuality}: **${formatBytes(current.cumulative.size)}** / ${formatBytes(current.cumulative.absoluteCeiling)} authority-contract ceiling (${cumulativeGrowth} from PR base; ${phase0Growth} from Phase 0).`,
     '',
-    '| Production subpath | Internal modules | External imports | PR graph change |',
-    '| --- | ---: | --- | --- |',
+    '| Production subpath | Internal modules | External imports | PR graph change | Approval |',
+    '| --- | ---: | --- | --- | --- |',
     ...graphRows,
     '',
     current.violations.length ?

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -554,15 +554,18 @@ function growthApprovalReport(base, current, supplied) {
   const newProduction = newProductionReportDelta(base, current);
   const newProductionPresent = newProduction.artifacts.length || newProduction.subpaths.length;
   const newProductionEnforced = supplied?.newProductionEnforced === true;
-  const approvalRequired = required.length || newProductionEnforced && newProductionPresent;
+  const approvalRequired = required.length || newProductionPresent;
   const violations = [];
 
   if (!supplied) {
-    const status = required.length ? 'required' : 'not-required';
+    const status = approvalRequired ? 'required' : 'not-required';
     if (required.length) {
       violations.push('Existing artifact growth above the approval threshold has no structured approval result');
     }
-    return { accepted: !required.length, approval: null, diagnostics: [], headSha: null,
+    if (newProductionPresent) {
+      violations.push('New-production approval enforcement is not active');
+    }
+    return { accepted: !approvalRequired, approval: null, diagnostics: [], headSha: null,
       newArtifacts: newProduction.artifacts, newSubpaths: newProduction.subpaths,
       newProductionEnforced: false, required, status, thresholdPercent, violations };
   }
@@ -580,12 +583,17 @@ function growthApprovalReport(base, current, supplied) {
   if (newProductionPresent && typeof supplied.newProductionEnforced !== 'boolean') {
     violations.push('Growth approval result is missing its new-production enforcement state');
   }
+  if (newProductionPresent && !newProductionEnforced) {
+    violations.push('New-production approval enforcement is not active');
+  }
 
   if (!sameApprovalRequirements(supplied.required, required)) {
     violations.push('Growth approval requirements do not match the exact report comparison');
   }
-  if (!sameNewArtifacts(supplied.newArtifacts || [], newProduction.artifacts) ||
-      !isDeepStrictEqual(supplied.newSubpaths || [], newProduction.subpaths)) {
+  const suppliedNewArtifacts = supplied.newArtifacts === undefined ? [] : supplied.newArtifacts;
+  const suppliedNewSubpaths = supplied.newSubpaths === undefined ? [] : supplied.newSubpaths;
+  if (!sameNewArtifacts(suppliedNewArtifacts, newProduction.artifacts) ||
+      !isDeepStrictEqual(suppliedNewSubpaths, newProduction.subpaths)) {
     violations.push('New-production approval requirements do not match the exact report comparison');
   }
   if (!['approved', 'not-required'].includes(supplied.status)) {
@@ -627,7 +635,7 @@ function growthApprovalSection(result) {
     lines.push(`Head: \`${result.headSha}\`.`);
   }
   if (result.newSubpaths.length && !result.newProductionEnforced) {
-    lines.push('New-subpath approval enforcement: **Reporting only**; activation is pending.');
+    lines.push('New-subpath approval enforcement: **Blocked pending activation**.');
     lines.push(`New subpaths: ${result.newSubpaths.map(subpath => `\`${subpath}\``).join(', ')}.`);
     lines.push(result.newArtifacts.length ?
       `New artifacts at full Brotli size: ${result.newArtifacts
@@ -676,7 +684,7 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
   const rows = current.artifacts.map(result => {
     const baseResult = baseByPath.get(result.path);
     if (!baseResult) {
-      const approval = !growthApproval.newProductionEnforced ? 'Reporting only' :
+      const approval = !growthApproval.newProductionEnforced ? 'Blocked pending activation' :
         newArtifactPaths.has(result.path) && growthApproval.accepted &&
           growthApproval.status === 'approved' ? 'Approved' : 'Required';
       return `| ${result.name} | New | ${formatBytes(result.size)} | New artifact | ${approval} |`;
@@ -695,7 +703,7 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
     const change = baseGraph ? graphChange(baseGraph, graph) : graph.error || 'New production subpath';
     const moduleCount = graph.status === 'measured' ? graph.modules.length : 'Unmeasured';
     const approval = baseGraph ? 'Not required' : !growthApproval.newProductionEnforced ?
-      'Reporting only' : growthApproval.accepted && growthApproval.status === 'approved' ?
+      'Blocked pending activation' : growthApproval.accepted && growthApproval.status === 'approved' ?
         'Approved' : 'Required';
     return `| \`${graph.subpath}\` | ${moduleCount} | ${graph.externalImports.join(', ') || 'None'} | ${change} | ${approval} |`;
   });

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -387,8 +387,7 @@ function reportContractViolations(
   report,
   expectedContract,
   authority,
-  label,
-  { allowAdditions = false } = {}
+  label
 ) {
   const violations = [];
   if (report?.schemaVersion !== 1) {
@@ -431,7 +430,7 @@ function reportContractViolations(
     .filter(path => !reportArtifacts.has(path)).sort();
   const extraArtifacts = [...reportArtifacts.keys()]
     .filter(path => !expectedArtifacts.map.has(path)).sort();
-  if (missingArtifacts.length || (!allowAdditions && extraArtifacts.length)) {
+  if (missingArtifacts.length || extraArtifacts.length) {
     violations.push(`${label} report artifact set mismatch; missing: ${missingArtifacts.join(', ') || 'none'}; extra: ${extraArtifacts.join(', ') || 'none'}`);
   }
   let artifactTotal = 0;
@@ -457,7 +456,7 @@ function reportContractViolations(
     .filter(subpath => !reportGraphs.has(subpath)).sort();
   const extraGraphs = [...reportGraphs.keys()]
     .filter(subpath => !expectedGraphs.map.has(subpath)).sort();
-  if (missingGraphs.length || (!allowAdditions && extraGraphs.length)) {
+  if (missingGraphs.length || extraGraphs.length) {
     violations.push(`${label} report graph set mismatch; missing: ${missingGraphs.join(', ') || 'none'}; extra: ${extraGraphs.join(', ') || 'none'}`);
   }
   for (const [subpath, graph] of reportGraphs) {
@@ -529,10 +528,6 @@ export function requiredNewProductionApproval({
   if (baseViolations.length) {
     throw new Error(baseViolations.join('; '));
   }
-  const delta = newProductionReportDelta(baseReport, currentReport);
-  if (delta.artifacts.length && !delta.subpaths.length) {
-    throw new Error('A new runtime artifact cannot be adopted without a new production subpath');
-  }
   const effectiveContract = candidateContract || authorityContract;
   const contractViolations = validateCandidateGrowthContract(authorityContract, effectiveContract);
   if (contractViolations.length) {
@@ -542,14 +537,20 @@ export function requiredNewProductionApproval({
     currentReport,
     effectiveContract,
     authorityContract,
-    'Pull request',
-    { allowAdditions: !candidateContract }
+    'Pull request'
   );
   if (currentViolations.length) {
     throw new Error(currentViolations.join('; '));
   }
-  if (!delta.artifacts.length && !delta.subpaths.length || !candidateContract) {
-    return { ...delta, enforced: !!candidateContract };
+  const delta = newProductionReportDelta(baseReport, currentReport);
+  if (delta.artifacts.length && !delta.subpaths.length) {
+    throw new Error('A new runtime artifact cannot be adopted without a new production subpath');
+  }
+  if (!candidateContract) {
+    return { ...delta, enforced: false };
+  }
+  if (!delta.artifacts.length && !delta.subpaths.length) {
+    return { ...delta, enforced: true };
   }
 
   const authorityArtifacts = new Set(authorityContract.runtimeArtifacts.map(({ path }) => path));

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -3,10 +3,12 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { promisify } from 'node:util';
+import { isDeepStrictEqual, promisify } from 'node:util';
 
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
-const recordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
+const requiredRecordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
+const optionalRecordFields = ['approvedNewArtifacts', 'approvedNewSubpaths'];
+const recordFields = [...requiredRecordFields, ...optionalRecordFields];
 const allowedAuthorAssociations = new Set(['COLLABORATOR', 'MEMBER', 'OWNER']);
 const bodyLimit = 16 * 1024;
 const execFileAsync = promisify(execFile);
@@ -17,11 +19,32 @@ function diagnostic(code, message, commentUrl) {
   return commentUrl ? { code, commentUrl, message } : { code, message };
 }
 
-function uniqueSortedStrings(values, limit) {
-  return Array.isArray(values) && values.length > 0 && values.length <= limit &&
+function uniqueSortedStrings(values, limit, allowEmpty = false) {
+  return Array.isArray(values) && (allowEmpty || values.length > 0) && values.length <= limit &&
     values.every(value => typeof value === 'string' && value.length > 0) &&
     new Set(values).size === values.length &&
     values.every((value, index) => index === 0 || values[index - 1] < value);
+}
+
+function validSubpath(subpath) {
+  return /^\.\/[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(subpath) &&
+    !subpath.includes('//') && !subpath.split('/').includes('..');
+}
+
+function validSourcePath(path) {
+  return typeof path === 'string' &&
+    /^[A-Za-z0-9][A-Za-z0-9._/-]*\.js$/.test(path) &&
+    !path.includes('//') && !path.split('/').includes('..');
+}
+
+function validNewArtifacts(artifacts) {
+  return Array.isArray(artifacts) && artifacts.length <= pathLimit &&
+    artifacts.every((artifact, index) => {
+      return artifact && typeof artifact === 'object' && !Array.isArray(artifact) &&
+        isDeepStrictEqual(Object.keys(artifact).sort(), ['path', 'size']) &&
+        validArtifactPath(artifact.path) && Number.isInteger(artifact.size) && artifact.size >= 0 &&
+        (index === 0 || artifacts[index - 1].path < artifact.path);
+    });
 }
 
 function validArtifactPath(path) {
@@ -61,13 +84,20 @@ function evidenceCommentUrl(repository, issueNumber, comment) {
 }
 
 function canonicalRecord(record) {
-  return {
+  const canonical = {
     schemaVersion: record.schemaVersion,
     headSha: record.headSha,
     issueUrl: record.issueUrl,
     approvedPaths: record.approvedPaths,
-    evidenceUrls: record.evidenceUrls,
   };
+  if (Object.hasOwn(record, 'approvedNewSubpaths')) {
+    canonical.approvedNewSubpaths = record.approvedNewSubpaths;
+  }
+  if (Object.hasOwn(record, 'approvedNewArtifacts')) {
+    canonical.approvedNewArtifacts = record.approvedNewArtifacts;
+  }
+  canonical.evidenceUrls = record.evidenceUrls;
+  return canonical;
 }
 
 export function formatGrowthApprovalComment(record) {
@@ -117,7 +147,7 @@ function validateRecord(record, policy) {
   const unknownFields = Object.keys(record)
     .filter(field => !recordFields.includes(field))
     .sort();
-  const missingFields = recordFields
+  const missingFields = requiredRecordFields
     .filter(field => !Object.hasOwn(record, field))
     .sort();
   if (unknownFields.length || missingFields.length) {
@@ -144,11 +174,27 @@ function validateRecord(record, policy) {
       `Approval issueUrl must be ${policy.trackingIssueUrl}`
     ));
   }
-  if (!uniqueSortedStrings(record.approvedPaths, pathLimit) ||
+  const hasNewSubpaths = Object.hasOwn(record, 'approvedNewSubpaths');
+  const hasNewArtifacts = Object.hasOwn(record, 'approvedNewArtifacts');
+  if (!uniqueSortedStrings(record.approvedPaths, pathLimit, hasNewSubpaths && hasNewArtifacts) ||
       !record.approvedPaths.every(validArtifactPath)) {
     diagnostics.push(diagnostic(
       'GROWTH_APPROVAL_PATHS',
       'Approval approvedPaths must contain sorted, unique safe runtime artifact paths'
+    ));
+  }
+  if (hasNewSubpaths !== hasNewArtifacts || (hasNewSubpaths &&
+      (!uniqueSortedStrings(record.approvedNewSubpaths, pathLimit) ||
+        !record.approvedNewSubpaths.every(validSubpath)))) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_NEW_SUBPATHS',
+      'Approval new-subpath fields must be paired and approvedNewSubpaths must contain sorted, unique safe package subpaths'
+    ));
+  }
+  if (hasNewArtifacts && !validNewArtifacts(record.approvedNewArtifacts)) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_NEW_ARTIFACTS',
+      'Approval approvedNewArtifacts must contain sorted, unique safe paths with full non-negative integer Brotli sizes'
     ));
   }
   if (!uniqueSortedStrings(record.evidenceUrls, evidenceLimit) ||
@@ -227,6 +273,315 @@ function artifactMap(report, label) {
   return artifacts;
 }
 
+function graphMap(report, label) {
+  if (!Array.isArray(report?.graphs)) {
+    throw new Error(`${label} report graphs must be an array`);
+  }
+  const graphs = new Map();
+  for (const graph of report.graphs) {
+    if (typeof graph?.subpath !== 'string' || graphs.has(graph.subpath)) {
+      throw new Error(`${label} report has an invalid or duplicate graph subpath ${graph?.subpath}`);
+    }
+    graphs.set(graph.subpath, graph);
+  }
+  return graphs;
+}
+
+function mapBy(items, key, label) {
+  if (!Array.isArray(items)) {
+    return { map: new Map(), violations: [`${label} must be an array`] };
+  }
+  const map = new Map();
+  const violations = [];
+  for (const item of items) {
+    const value = item?.[key];
+    if (typeof value !== 'string' || map.has(value)) {
+      violations.push(`${label} has an invalid or duplicate ${key} ${value}`);
+      continue;
+    }
+    map.set(value, item);
+  }
+  return { map, violations };
+}
+
+function exactObjectFields(value, fields) {
+  return value && typeof value === 'object' && !Array.isArray(value) &&
+    isDeepStrictEqual(Object.keys(value).sort(), [...fields].sort());
+}
+
+export function validateCandidateGrowthContract(authority, candidate) {
+  const violations = [];
+  if (!authority || typeof authority !== 'object' || !candidate || typeof candidate !== 'object') {
+    return ['Authority and candidate performance contracts must be objects'];
+  }
+  const authorityKeys = Object.keys(authority).sort();
+  const candidateKeys = Object.keys(candidate).sort();
+  if (!isDeepStrictEqual(authorityKeys, candidateKeys)) {
+    violations.push('Candidate performance contract top-level fields differ from the exact-base contract');
+  }
+  for (const key of authorityKeys) {
+    if (key === 'runtimeArtifacts' || key === 'productionGraphs') {
+      continue;
+    }
+    if (!isDeepStrictEqual(authority[key], candidate[key])) {
+      violations.push(`Candidate performance contract changes exact-base ${key}`);
+    }
+  }
+
+  const authorityArtifacts = mapBy(authority.runtimeArtifacts, 'path', 'Exact-base runtimeArtifacts');
+  const candidateArtifacts = mapBy(candidate.runtimeArtifacts, 'path', 'Candidate runtimeArtifacts');
+  violations.push(...authorityArtifacts.violations, ...candidateArtifacts.violations);
+  for (const [path, artifact] of authorityArtifacts.map) {
+    if (!isDeepStrictEqual(candidateArtifacts.map.get(path), artifact)) {
+      violations.push(`Candidate performance contract removes or changes exact-base runtime artifact ${path}`);
+    }
+  }
+  for (const [path, artifact] of candidateArtifacts.map) {
+    if (authorityArtifacts.map.has(path)) {
+      continue;
+    }
+    if (!exactObjectFields(artifact, ['baselineBrotliBytes', 'name', 'path']) ||
+        typeof artifact.name !== 'string' || !artifact.name || !validArtifactPath(path)) {
+      violations.push(`New runtime artifact ${path} must contain only name, path, and baselineBrotliBytes`);
+    }
+    if (artifact.baselineBrotliBytes !== 0) {
+      violations.push(`New runtime artifact ${path} baselineBrotliBytes must be 0`);
+    }
+  }
+
+  const authorityGraphs = mapBy(authority.productionGraphs, 'subpath', 'Exact-base productionGraphs');
+  const candidateGraphs = mapBy(candidate.productionGraphs, 'subpath', 'Candidate productionGraphs');
+  violations.push(...authorityGraphs.violations, ...candidateGraphs.violations);
+  for (const [subpath, graph] of authorityGraphs.map) {
+    if (!isDeepStrictEqual(candidateGraphs.map.get(subpath), graph)) {
+      violations.push(`Candidate performance contract removes or changes exact-base production graph ${subpath}`);
+    }
+  }
+  for (const [subpath, graph] of candidateGraphs.map) {
+    if (authorityGraphs.map.has(subpath)) {
+      continue;
+    }
+    if (!exactObjectFields(graph, [
+      'baselineExternalImports',
+      'baselineModules',
+      'input',
+      'output',
+      'subpath',
+    ]) || !validSubpath(subpath) || !validSourcePath(graph.input) ||
+        !validArtifactPath(graph.output)) {
+      violations.push(`New production graph ${subpath} has an invalid additive contract shape`);
+    }
+    if (!Array.isArray(graph.baselineModules) || graph.baselineModules.length ||
+        !Array.isArray(graph.baselineExternalImports) || graph.baselineExternalImports.length) {
+      violations.push(`New production graph ${subpath} Phase 0 module baselines must be empty`);
+    }
+    if (!candidateArtifacts.map.has(graph.output)) {
+      violations.push(`New production graph ${subpath} output must be a tracked runtime artifact`);
+    }
+  }
+
+  return violations;
+}
+
+function reportContractViolations(
+  report,
+  expectedContract,
+  authority,
+  label,
+  { allowAdditions = false } = {}
+) {
+  const violations = [];
+  if (report?.schemaVersion !== 1) {
+    violations.push(`${label} report schemaVersion must be 1`);
+  }
+  if (report?.baselineSourceCommit !== authority?.baseline?.sourceCommit ||
+      report?.brotliQuality !== authority?.baseline?.brotliQuality ||
+      !isDeepStrictEqual(report?.thresholds, authority?.thresholds) ||
+      report?.cumulative?.baselineSize !== authority?.baseline?.totalBrotliBytes ||
+      report?.cumulative?.absoluteCeiling !== authority?.baseline?.absoluteCeilingBytes) {
+    violations.push(`${label} report does not use the exact-base performance authority`);
+  }
+  if (!Array.isArray(report?.violations)) {
+    violations.push(`${label} report violations must be an array`);
+  } else if (report.violations.length) {
+    violations.push(`${label} report has contract violations: ${report.violations.join('; ')}`);
+  }
+
+  let reportArtifacts;
+  let reportGraphs;
+  try {
+    reportArtifacts = artifactMap(report, label);
+    reportGraphs = graphMap(report, label);
+  } catch (error) {
+    violations.push(error.message);
+    return violations;
+  }
+  const expectedArtifacts = mapBy(
+    expectedContract?.runtimeArtifacts,
+    'path',
+    `${label} expected runtimeArtifacts`
+  );
+  const expectedGraphs = mapBy(
+    expectedContract?.productionGraphs,
+    'subpath',
+    `${label} expected productionGraphs`
+  );
+  violations.push(...expectedArtifacts.violations, ...expectedGraphs.violations);
+  const missingArtifacts = [...expectedArtifacts.map.keys()]
+    .filter(path => !reportArtifacts.has(path)).sort();
+  const extraArtifacts = [...reportArtifacts.keys()]
+    .filter(path => !expectedArtifacts.map.has(path)).sort();
+  if (missingArtifacts.length || (!allowAdditions && extraArtifacts.length)) {
+    violations.push(`${label} report artifact set mismatch; missing: ${missingArtifacts.join(', ') || 'none'}; extra: ${extraArtifacts.join(', ') || 'none'}`);
+  }
+  let artifactTotal = 0;
+  for (const [path, artifact] of reportArtifacts) {
+    const expected = expectedArtifacts.map.get(path);
+    if (artifact.status !== 'measured' || !Number.isInteger(artifact.size) || artifact.size < 0) {
+      violations.push(`${label} runtime artifact ${path} is not measured at a non-negative integer size`);
+      continue;
+    }
+    artifactTotal += artifact.size;
+    if (expected && artifact.name !== expected.name) {
+      violations.push(`${label} runtime artifact ${path} name does not match its contract`);
+    }
+  }
+  if (!Number.isInteger(report?.cumulative?.size) || report.cumulative.size !== artifactTotal) {
+    violations.push(`${label} cumulative size does not equal the complete measured artifact set`);
+  }
+  if (artifactTotal > authority?.baseline?.absoluteCeilingBytes) {
+    violations.push(`${label} cumulative size ${artifactTotal} exceeds the exact-base cumulative ceiling ${authority?.baseline?.absoluteCeilingBytes}`);
+  }
+
+  const missingGraphs = [...expectedGraphs.map.keys()]
+    .filter(subpath => !reportGraphs.has(subpath)).sort();
+  const extraGraphs = [...reportGraphs.keys()]
+    .filter(subpath => !expectedGraphs.map.has(subpath)).sort();
+  if (missingGraphs.length || (!allowAdditions && extraGraphs.length)) {
+    violations.push(`${label} report graph set mismatch; missing: ${missingGraphs.join(', ') || 'none'}; extra: ${extraGraphs.join(', ') || 'none'}`);
+  }
+  for (const [subpath, graph] of reportGraphs) {
+    const expected = expectedGraphs.map.get(subpath);
+    if (graph.status !== 'measured' || !Array.isArray(graph.modules) ||
+        !Array.isArray(graph.externalImports) || !Array.isArray(graph.forbiddenModules)) {
+      violations.push(`${label} production graph ${subpath} is not completely measured`);
+      continue;
+    }
+    if (graph.forbiddenModules.length) {
+      violations.push(`${label} production graph ${subpath} includes forbidden modules`);
+    }
+    if (expected && (graph.input !== expected.input || graph.output !== expected.output)) {
+      violations.push(`${label} production graph ${subpath} input or output does not match its contract`);
+    }
+  }
+  return violations;
+}
+
+export function newProductionReportDelta(baseReport, currentReport) {
+  const baseArtifacts = artifactMap(baseReport, 'Exact-base');
+  const currentArtifacts = artifactMap(currentReport, 'Pull request');
+  const baseGraphs = graphMap(baseReport, 'Exact-base');
+  const currentGraphs = graphMap(currentReport, 'Pull request');
+  const missingPaths = [...baseArtifacts.keys()].filter(path => !currentArtifacts.has(path)).sort();
+  if (missingPaths.length) {
+    throw new Error(`Pull request report is missing exact-base artifacts: ${missingPaths.join(', ')}`);
+  }
+  const missingSubpaths = [...baseGraphs.keys()].filter(subpath => !currentGraphs.has(subpath)).sort();
+  if (missingSubpaths.length) {
+    throw new Error(`Pull request report is missing exact-base production graphs: ${missingSubpaths.join(', ')}`);
+  }
+  const artifacts = [...currentArtifacts]
+    .filter(([path]) => !baseArtifacts.has(path))
+    .map(([path, artifact]) => {
+      if (artifact.status !== 'measured' || !Number.isInteger(artifact.size) || artifact.size < 0) {
+        throw new Error(`New runtime artifact ${path} is not measured at a non-negative integer size`);
+      }
+      return { path, size: artifact.size };
+    })
+    .sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  const subpaths = [...currentGraphs]
+    .filter(([subpath]) => !baseGraphs.has(subpath))
+    .map(([subpath, graph]) => {
+      if (graph.status !== 'measured') {
+        throw new Error(`New production graph ${subpath} is not measured`);
+      }
+      if (!Array.isArray(graph.forbiddenModules) || graph.forbiddenModules.length) {
+        throw new Error(`New production graph ${subpath} includes forbidden modules`);
+      }
+      return subpath;
+    })
+    .sort();
+  return { artifacts, subpaths };
+}
+
+export function requiredNewProductionApproval({
+  authorityContract,
+  baseReport,
+  candidateContract,
+  currentReport,
+}) {
+  const baseViolations = reportContractViolations(
+    baseReport,
+    authorityContract,
+    authorityContract,
+    'Exact-base'
+  );
+  if (baseViolations.length) {
+    throw new Error(baseViolations.join('; '));
+  }
+  const delta = newProductionReportDelta(baseReport, currentReport);
+  if (delta.artifacts.length && !delta.subpaths.length) {
+    throw new Error('A new runtime artifact cannot be adopted without a new production subpath');
+  }
+  const effectiveContract = candidateContract || authorityContract;
+  const contractViolations = validateCandidateGrowthContract(authorityContract, effectiveContract);
+  if (contractViolations.length) {
+    throw new Error(contractViolations.join('; '));
+  }
+  const currentViolations = reportContractViolations(
+    currentReport,
+    effectiveContract,
+    authorityContract,
+    'Pull request',
+    { allowAdditions: !candidateContract }
+  );
+  if (currentViolations.length) {
+    throw new Error(currentViolations.join('; '));
+  }
+  if (!delta.artifacts.length && !delta.subpaths.length || !candidateContract) {
+    return { ...delta, enforced: !!candidateContract };
+  }
+
+  const authorityArtifacts = new Set(authorityContract.runtimeArtifacts.map(({ path }) => path));
+  const candidateArtifacts = candidateContract.runtimeArtifacts
+    .filter(({ path }) => !authorityArtifacts.has(path))
+    .map(({ path }) => path)
+    .sort();
+  const authoritySubpaths = new Set(authorityContract.productionGraphs.map(({ subpath }) => subpath));
+  const candidateSubpaths = candidateContract.productionGraphs
+    .filter(({ subpath }) => !authoritySubpaths.has(subpath))
+    .map(({ subpath }) => subpath)
+    .sort();
+  if (!isDeepStrictEqual(candidateArtifacts, delta.artifacts.map(({ path }) => path))) {
+    throw new Error('Candidate contract new runtime artifacts do not match the measured report');
+  }
+  if (!isDeepStrictEqual(candidateSubpaths, delta.subpaths)) {
+    throw new Error('Candidate contract new production graphs do not match the measured report');
+  }
+  const candidateGraphsBySubpath = new Map(candidateContract.productionGraphs
+    .map(graph => [graph.subpath, graph]));
+  const currentGraphsBySubpath = graphMap(currentReport, 'Pull request');
+  for (const subpath of delta.subpaths) {
+    const candidateGraph = candidateGraphsBySubpath.get(subpath);
+    const currentGraph = currentGraphsBySubpath.get(subpath);
+    if (currentGraph.input !== candidateGraph.input || currentGraph.output !== candidateGraph.output) {
+      throw new Error(`Measured new production graph ${subpath} does not match its candidate contract input and output`);
+    }
+  }
+
+  return { ...delta, enforced: true };
+}
+
 export function requiredArtifactGrowth(baseReport, currentReport, thresholdPercent) {
   if (!Number.isFinite(thresholdPercent) || thresholdPercent < 0) {
     throw new Error(`Growth approval threshold must be a non-negative number; received ${thresholdPercent}`);
@@ -267,7 +622,9 @@ export function requiredArtifactGrowth(baseReport, currentReport, thresholdPerce
 }
 
 export function validateGrowthApproval({
+  authorityContract,
   baseReport,
+  candidateContract,
   comments,
   currentReport,
   evidenceComments,
@@ -277,9 +634,27 @@ export function validateGrowthApproval({
   thresholdPercent,
 }) {
   let required = [];
+  let newArtifacts = [];
+  let newProductionEnforced = false;
+  let newSubpaths = [];
   const diagnostics = validateGrowthApprovalPolicy(policy);
   try {
     required = requiredArtifactGrowth(baseReport, currentReport, thresholdPercent);
+    if (authorityContract) {
+      const validated = requiredNewProductionApproval({
+        authorityContract,
+        baseReport,
+        candidateContract,
+        currentReport,
+      });
+      newArtifacts = validated.artifacts;
+      newProductionEnforced = validated.enforced;
+      newSubpaths = validated.subpaths;
+    } else {
+      const newProduction = newProductionReportDelta(baseReport, currentReport);
+      newArtifacts = newProduction.artifacts;
+      newSubpaths = newProduction.subpaths;
+    }
   } catch (error) {
     diagnostics.push(diagnostic('GROWTH_APPROVAL_REPORT', error.message));
   }
@@ -288,6 +663,9 @@ export function validateGrowthApproval({
     diagnostics,
     headSha,
     ignored: [],
+    newArtifacts,
+    newProductionEnforced,
+    newSubpaths,
     required,
     schemaVersion: 1,
     status: 'required',
@@ -309,7 +687,8 @@ export function validateGrowthApproval({
     result.status = 'blocked';
     return result;
   }
-  if (!required.length) {
+  if (!required.length && (!newProductionEnforced ||
+      !newArtifacts.length && !newSubpaths.length)) {
     result.status = 'not-required';
     return result;
   }
@@ -389,6 +768,8 @@ export function validateGrowthApproval({
       continue;
     }
     matching.push({
+      approvedNewArtifacts: parsed.approval.approvedNewArtifacts,
+      approvedNewSubpaths: parsed.approval.approvedNewSubpaths,
       approvedPaths: parsed.approval.approvedPaths,
       authorLogin,
       commentId: comment.id,
@@ -430,6 +811,32 @@ export function validateGrowthApproval({
       result.approval.commentUrl
     ));
     return result;
+  }
+
+  if (newProductionEnforced) {
+    const approvedNewSubpaths = result.approval.approvedNewSubpaths || [];
+    const missingSubpaths = newSubpaths.filter(subpath => !approvedNewSubpaths.includes(subpath));
+    const extraSubpaths = approvedNewSubpaths.filter(subpath => !newSubpaths.includes(subpath));
+    if (missingSubpaths.length || extraSubpaths.length) {
+      result.status = 'invalid';
+      result.diagnostics.push(diagnostic(
+        'GROWTH_APPROVAL_NEW_SUBPATH_SET_MISMATCH',
+        `Approval new subpaths mismatch; missing: ${missingSubpaths.join(', ') || 'none'}; extra: ${extraSubpaths.join(', ') || 'none'}`,
+        result.approval.commentUrl
+      ));
+      return result;
+    }
+
+    const approvedNewArtifacts = result.approval.approvedNewArtifacts || [];
+    if (!isDeepStrictEqual(approvedNewArtifacts, newArtifacts)) {
+      result.status = 'invalid';
+      result.diagnostics.push(diagnostic(
+        'GROWTH_APPROVAL_NEW_ARTIFACT_SET_MISMATCH',
+        'Approval new artifact paths and full Brotli sizes do not match the measured report',
+        result.approval.commentUrl
+      ));
+      return result;
+    }
   }
 
   const availableEvidence = new Set(evidenceComments.comments
@@ -494,6 +901,9 @@ function blockedResult(error, headSha = null) {
     diagnostics: [diagnostic('GROWTH_APPROVAL_INPUT', error.message)],
     headSha,
     ignored: [],
+    newArtifacts: [],
+    newProductionEnforced: false,
+    newSubpaths: [],
     required: [],
     schemaVersion: 1,
     status: 'blocked',
@@ -511,16 +921,21 @@ export async function main(args = process.argv.slice(2)) {
       throw new Error(`Requested head SHA ${headSha} does not match checkout ${checkoutHeadSha}`);
     }
     const pullRequestNumber = parsePullRequestNumber(getArgument(args, '--pull-request'));
-    const [contract, baseReport, currentReport, comments, evidenceComments] =
+    const candidateContractPath = args.includes('--candidate-contract') ?
+      getArgument(args, '--candidate-contract') : null;
+    const [contract, candidateContract, baseReport, currentReport, comments, evidenceComments] =
       await Promise.all([
         readJson(getArgument(args, '--contract')),
+        candidateContractPath ? readJson(candidateContractPath) : null,
         readJson(getArgument(args, '--base-report')),
         readJson(getArgument(args, '--current-report')),
         readJson(getArgument(args, '--comments')),
         readJson(getArgument(args, '--evidence-comments')),
       ]);
     result = validateGrowthApproval({
+      authorityContract: contract,
       baseReport,
+      candidateContract,
       comments,
       currentReport,
       evidenceComments,

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -197,9 +197,9 @@ The parser, additive-contract validator, and report schema are defined before ne
 subpath enforcement. This contract change does not alter Actions. A separate activation
 must measure the candidate with the exact-base validator and invoke the parser from an
 exact base containing this reviewed contract. Until that wiring lands, new-subpath
-results carry `newProductionEnforced: false`, are labeled reporting-only, and do not
-fail the existing size job. The activation supplies the reviewed candidate contract and
-changes that state to `true`. This two-step bootstrap prevents the first enforcement
+results carry `newProductionEnforced: false`, are labeled blocked pending activation,
+and fail the existing size job. The activation supplies the reviewed candidate contract
+and changes that state to `true`. This two-step bootstrap prevents the first enforcement
 change from authorizing itself with candidate-owned policy.
 
 ## Hosted timing

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -88,7 +88,8 @@ the repository's read-only workflow plus the separate comment workflow.
 The roadmap also requires explicit issue approval and evidence for growth above one
 percent versus the pull request base and for every new production subpath. Existing
 artifact growth now has a versioned, base-owned approval contract in
-`pullRequestGrowthApproval`; new subpaths remain a separate fail-closed case.
+`pullRequestGrowthApproval`. The same exact-head record can bind a new production
+subpath to every new runtime artifact and its full measured Brotli size.
 
 An approval is one complete pull request timeline comment. The comment author comes
 from GitHub rather than the JSON body, must appear in the exact-base allowlist, must
@@ -112,9 +113,55 @@ canonical form:
 ```
 ````
 
+A new-subpath-only record leaves `approvedPaths` empty and adds both new-production
+fields:
+
+````markdown
+<!-- marionette-performance-growth-approval:v1 -->
+```json
+{
+  "schemaVersion": 1,
+  "headSha": "0123456789abcdef0123456789abcdef01234567",
+  "issueUrl": "https://github.com/marionettejs/marionette/issues/127",
+  "approvedPaths": [],
+  "approvedNewSubpaths": [
+    "./example"
+  ],
+  "approvedNewArtifacts": [
+    {
+      "path": "dist/example.js",
+      "size": 456
+    }
+  ],
+  "evidenceUrls": [
+    "https://github.com/marionettejs/marionette/issues/127#issuecomment-123456789"
+  ]
+}
+```
+````
+
+`approvedNewArtifacts` is empty when a new public subpath aliases an already tracked
+runtime artifact. The new subpath still requires exact-head approval even though it
+adds zero artifact bytes. Conversely, a new runtime artifact without a corresponding
+new production subpath is invalid rather than independently approvable. Approval binds
+the complete additive artifact set from the same exact head; conditional artifacts such
+as CommonJS outputs need not each be the selected production-graph output, but every
+artifact is named at full size and charged against the cumulative ceiling.
+
 The full lowercase head SHA prevents an approval from surviving a code change. The
 approved path list must exactly match all existing artifacts above the strict
-greater-than-one-percent threshold. Evidence is limited to durable issue-comment
+greater-than-one-percent threshold. New subpaths and new artifact path/size pairs must
+exactly match the additive candidate contract and measured report. A candidate may
+only add runtime artifact and production graph entries: it cannot change the base
+thresholds, allowlist, baseline, ceiling, toolchain, forbidden modules, resource
+contract, timing contract, or any existing artifact or graph. New artifact Phase 0
+baselines remain zero, so their full size counts against the original absolute ceiling;
+after adoption, the exact merged artifact becomes the comparison base for later pull
+requests. Unmeasured graphs, forbidden modules, removed or renamed base entries,
+non-integer sizes, report-contract drift, and cumulative growth above the ceiling fail
+closed.
+
+Evidence is limited to durable issue-comment
 permalinks in this repository; Actions artifacts and external mutable pages cannot
 be the sole record. The evaluator binds each marked comment to the expected repository
 and pull request from the API snapshot, and every evidence URL must resolve to a real
@@ -145,6 +192,15 @@ The refresh workflow selects only a CI run whose immutable run name records the
 current pull request number, base SHA, and head SHA. If the base advances, it refuses
 to replay an older comparison. The default-branch rules require strict up-to-date
 status checks, so merge remains blocked until CI records the new exact base.
+
+The parser, additive-contract validator, and report schema are defined before new-
+subpath enforcement. This contract change does not alter Actions. A separate activation
+must measure the candidate with the exact-base validator and invoke the parser from an
+exact base containing this reviewed contract. Until that wiring lands, new-subpath
+results carry `newProductionEnforced: false`, are labeled reporting-only, and do not
+fail the existing size job. The activation supplies the reviewed candidate contract and
+changes that state to `true`. This two-step bootstrap prevents the first enforcement
+change from authorizing itself with candidate-owned policy.
 
 ## Hosted timing
 

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -304,6 +304,14 @@ describe('performance contract validation', () => {
       assert.match(approved, /## Artifact growth approval\n\nStatus: \*\*Approved\*\*\./);
       assert.match(approved, /Approved by \[@paulfalgout\]/);
 
+      for (const field of ['newArtifacts', 'newSubpaths']) {
+        const malformedApproval = growthApproval();
+        malformedApproval[field] = null;
+        await writeFile(approvalReport, JSON.stringify(malformedApproval));
+        const malformed = await createReport(baseReport, currentReport, approvalReport);
+        assert.match(malformed, /New-production approval requirements do not match/);
+      }
+
       const missing = await createReport(baseReport, currentReport);
       assert.match(missing, /\| Main .* \| Required \|/);
       assert.match(missing, /Status: \*\*Required\*\*\./);
@@ -337,9 +345,10 @@ describe('performance contract validation', () => {
       assert.match(approved, /New artifacts at full Brotli size: `dist\/feature\.js` \(4 B\)\./);
 
       const missing = await createReport(baseReport, currentReport);
-      assert.match(missing, /\| Feature \| New \| 4 B \| New artifact \| Reporting only \|/);
-      assert.match(missing, /\| `\.\/feature` .* \| Reporting only \|/);
-      assert.match(missing, /New-subpath approval enforcement: \*\*Reporting only\*\*/);
+      assert.match(missing, /\| Feature \| New \| 4 B \| New artifact \| Blocked pending activation \|/);
+      assert.match(missing, /\| `\.\/feature` .* \| Blocked pending activation \|/);
+      assert.match(missing, /New-subpath approval enforcement: \*\*Blocked pending activation\*\*/);
+      assert.match(missing, /New-production approval enforcement is not active/);
 
       const malformedApproval = newSubpathApproval();
       malformedApproval.newArtifacts[0].size = 3;

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -87,6 +87,53 @@ function growthApproval(status = 'approved') {
   };
 }
 
+function newSubpathReport(includeFeature = false) {
+  const report = bundleReport(100);
+  report.graphs = [{
+    subpath: '.',
+    status: 'measured',
+    modules: ['index.js'],
+    externalImports: [],
+  }];
+  if (includeFeature) {
+    report.artifacts.push({
+      name: 'Feature',
+      path: 'dist/feature.js',
+      status: 'measured',
+      size: 4,
+    });
+    report.cumulative.size = 104;
+    report.graphs.push({
+      subpath: './feature',
+      status: 'measured',
+      modules: ['feature.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+  }
+  return report;
+}
+
+function newSubpathApproval(status = 'approved') {
+  return {
+    schemaVersion: 1,
+    status,
+    headSha: '1234567890abcdef1234567890abcdef12345678',
+    thresholdPercent: 1,
+    required: [],
+    newProductionEnforced: true,
+    newSubpaths: ['./feature'],
+    newArtifacts: [{ path: 'dist/feature.js', size: 4 }],
+    approval: status === 'approved' ? {
+      approvedNewSubpaths: ['./feature'],
+      approvedNewArtifacts: [{ path: 'dist/feature.js', size: 4 }],
+      authorLogin: 'paulfalgout',
+      commentUrl: 'https://github.com/marionettejs/marionette/pull/1#issuecomment-1',
+    } : null,
+    diagnostics: status === 'approved' ? [] : [{ message: 'Approval is required' }],
+  };
+}
+
 describe('performance contract validation', () => {
   test('recognizes shipped mjs entrypoints', () => {
     assert.equal(runtimePath('./dist/index.mjs'), true);
@@ -265,6 +312,113 @@ describe('performance contract validation', () => {
       const identical = await createReport(baseReport, baseReport);
       assert.match(identical, /\| Main .* \| Not required \|/);
       assert.match(identical, /Status: \*\*Not required\*\*\./);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('reports exact new subpath and full-size approval without accepting malformed results', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-new-subpath-report-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvalReport = join(fixtureRoot, 'approval.json');
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(newSubpathReport())),
+        writeFile(currentReport, JSON.stringify(newSubpathReport(true))),
+        writeFile(approvalReport, JSON.stringify(newSubpathApproval())),
+      ]);
+
+      const approved = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(approved, /\| Feature \| New \| 4 B \| New artifact \| Approved \|/);
+      assert.match(approved, /\| `\.\/feature` \| 1 \| None \| New production subpath \| Approved \|/);
+      assert.match(approved, /New subpaths: `\.\/feature`\./);
+      assert.match(approved, /New artifacts at full Brotli size: `dist\/feature\.js` \(4 B\)\./);
+
+      const missing = await createReport(baseReport, currentReport);
+      assert.match(missing, /\| Feature \| New \| 4 B \| New artifact \| Reporting only \|/);
+      assert.match(missing, /\| `\.\/feature` .* \| Reporting only \|/);
+      assert.match(missing, /New-subpath approval enforcement: \*\*Reporting only\*\*/);
+
+      const malformedApproval = newSubpathApproval();
+      malformedApproval.newArtifacts[0].size = 3;
+      await writeFile(approvalReport, JSON.stringify(malformedApproval));
+      const malformed = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(malformed, /New-production approval requirements do not match/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('reports approval for a zero-byte new subpath aliasing an existing artifact', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-new-subpath-alias-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvalReport = join(fixtureRoot, 'approval.json');
+    const base = newSubpathReport();
+    const current = structuredClone(base);
+    current.graphs.push({
+      subpath: './feature',
+      status: 'measured',
+      modules: ['feature.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+    const approval = newSubpathApproval();
+    approval.newArtifacts = [];
+    approval.approval.approvedNewArtifacts = [];
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(base)),
+        writeFile(currentReport, JSON.stringify(current)),
+        writeFile(approvalReport, JSON.stringify(approval)),
+      ]);
+
+      const report = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(report, /\| `\.\/feature` \| 1 \| None \| New production subpath \| Approved \|/);
+      assert.match(report, /New artifacts: none; the approved subpath aliases an existing runtime artifact\./);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('accepts canonically ordered mixed-case new artifacts in the report', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-new-subpath-order-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvalReport = join(fixtureRoot, 'approval.json');
+    const base = newSubpathReport();
+    const current = structuredClone(base);
+    current.artifacts.push(
+      { name: 'View', path: 'dist/View.mjs', status: 'measured', size: 2 },
+      { name: 'All', path: 'dist/all.mjs', status: 'measured', size: 2 });
+    current.cumulative.size = 104;
+    current.graphs.push({
+      subpath: './feature',
+      status: 'measured',
+      modules: ['feature.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+    const approval = newSubpathApproval();
+    approval.newArtifacts = [
+      { path: 'dist/View.mjs', size: 2 },
+      { path: 'dist/all.mjs', size: 2 },
+    ];
+    approval.approval.approvedNewArtifacts = approval.newArtifacts;
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(base)),
+        writeFile(currentReport, JSON.stringify(current)),
+        writeFile(approvalReport, JSON.stringify(approval)),
+      ]);
+
+      const report = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(report, /\| View \| New \| 2 B \| New artifact \| Approved \|/);
+      assert.match(report, /\| All \| New \| 2 B \| New artifact \| Approved \|/);
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -9,6 +9,8 @@ import {
   formatGrowthApprovalComment,
   parseGrowthApprovalComment,
   requiredArtifactGrowth,
+  requiredNewProductionApproval,
+  validateCandidateGrowthContract,
   validateGrowthApproval,
   validateGrowthApprovalPolicy,
 } from '../../config/performance-growth-approval.mjs';
@@ -25,18 +27,137 @@ const policy = {
   allowedLogins: ['paulfalgout'],
 };
 
-function report(artifacts) {
-  return { artifacts };
+function report(artifacts, graphs = []) {
+  return { artifacts, graphs };
 }
 
-function approvalRecord(approvedPaths = ['dist/over.js']) {
-  return {
+function approvalRecord(approvedPaths = ['dist/over.js'], newProduction) {
+  const record = {
     schemaVersion: 1,
     headSha,
     issueUrl: policy.trackingIssueUrl,
     approvedPaths,
     evidenceUrls: [evidenceUrl],
   };
+
+  if (newProduction) {
+    record.approvedNewSubpaths = newProduction.subpaths;
+    record.approvedNewArtifacts = newProduction.artifacts;
+  }
+
+  return record;
+}
+
+function growthContract() {
+  return {
+    schemaVersion: 1,
+    baseline: {
+      sourceCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+      brotliQuality: 11,
+      totalBrotliBytes: 100,
+      absoluteCeilingBytes: 105,
+    },
+    thresholds: {
+      cumulativeGrowthPercent: 5,
+      pullRequestApprovalPercent: 1,
+    },
+    pullRequestGrowthApproval: policy,
+    forbiddenProductionModulePrefixes: ['test/'],
+    forbiddenProductionModules: ['config/performance.json'],
+    runtimeArtifacts: [{
+      name: 'Main',
+      path: 'dist/main.js',
+      baselineBrotliBytes: 100,
+    }],
+    productionGraphs: [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/main.js',
+      baselineModules: ['index.js'],
+      baselineExternalImports: [],
+    }],
+  };
+}
+
+function candidateGrowthContract() {
+  const contract = structuredClone(growthContract());
+  contract.runtimeArtifacts.push({
+    name: 'Feature',
+    path: 'dist/feature.js',
+    baselineBrotliBytes: 0,
+  });
+  contract.productionGraphs.push({
+    subpath: './feature',
+    input: 'feature.js',
+    output: 'dist/feature.js',
+    baselineModules: [],
+    baselineExternalImports: [],
+  });
+  return contract;
+}
+
+function candidateAliasContract() {
+  const contract = structuredClone(growthContract());
+  contract.productionGraphs.push({
+    subpath: './feature',
+    input: 'index.js',
+    output: 'dist/main.js',
+    baselineModules: [],
+    baselineExternalImports: [],
+  });
+  return contract;
+}
+
+function productionReport({ aliasFeature = false, includeFeature = false, featureStatus = 'measured' } = {}) {
+  const artifacts = [{ name: 'Main', path: 'dist/main.js', status: 'measured', size: 100 }];
+  const graphs = [{
+    subpath: '.',
+    input: 'index.js',
+    output: 'dist/main.js',
+    status: 'measured',
+    modules: ['index.js'],
+    externalImports: [],
+    forbiddenModules: [],
+  }];
+  if (includeFeature) {
+    artifacts.push({ name: 'Feature', path: 'dist/feature.js', status: 'measured', size: 4 });
+  }
+  if (includeFeature || aliasFeature) {
+    graphs.push({
+      subpath: './feature',
+      input: aliasFeature ? 'index.js' : 'feature.js',
+      output: aliasFeature ? 'dist/main.js' : 'dist/feature.js',
+      status: featureStatus,
+      modules: [aliasFeature ? 'index.js' : 'feature.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    baselineSourceCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+    brotliQuality: 11,
+    thresholds: {
+      cumulativeGrowthPercent: 5,
+      pullRequestApprovalPercent: 1,
+    },
+    artifacts,
+    cumulative: {
+      size: includeFeature ? 104 : 100,
+      baselineSize: 100,
+      absoluteCeiling: 105,
+    },
+    graphs,
+    violations: [],
+  };
+}
+
+function grownProductionReport() {
+  const current = productionReport();
+  current.artifacts[0].size = 102;
+  current.cumulative.size = 102;
+  return current;
 }
 
 function comment(record, {
@@ -161,6 +282,302 @@ describe('exact-head performance growth approval contract', () => {
     );
   });
 
+  test('derives exact new subpaths and full artifact sizes from additive candidate evidence', () => {
+    assert.deepEqual(requiredNewProductionApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract: candidateGrowthContract(),
+      currentReport: productionReport({ includeFeature: true }),
+    }), {
+      artifacts: [{ path: 'dist/feature.js', size: 4 }],
+      enforced: true,
+      subpaths: ['./feature'],
+    });
+  });
+
+  test('requires approval when a new public subpath aliases an existing artifact at zero bytes', () => {
+    const currentReport = productionReport({ aliasFeature: true });
+    const required = requiredNewProductionApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract: candidateAliasContract(),
+      currentReport,
+    });
+    assert.deepEqual(required, {
+      artifacts: [],
+      enforced: true,
+      subpaths: ['./feature'],
+    });
+
+    const record = approvalRecord([], required);
+    assert.deepEqual(parseGrowthApprovalComment(formatGrowthApprovalComment(record), policy), {
+      matched: true,
+      approval: record,
+    });
+    const result = validateGrowthApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract: candidateAliasContract(),
+      comments: snapshot([comment(record)]),
+      currentReport,
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(result.newArtifacts, []);
+    assert.deepEqual(result.newSubpaths, ['./feature']);
+  });
+
+  test('reports new production deltas without enforcing before activation', () => {
+    const result = validateGrowthApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      comments: snapshot([]),
+      currentReport: productionReport({ includeFeature: true }),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+
+    assert.equal(result.status, 'not-required');
+    assert.equal(result.newProductionEnforced, false);
+    assert.deepEqual(result.newArtifacts, [{ path: 'dist/feature.js', size: 4 }]);
+    assert.deepEqual(result.newSubpaths, ['./feature']);
+    assert.deepEqual(result.diagnostics, []);
+  });
+
+  test('uses canonical code-unit order for new artifact approvals', () => {
+    const candidateContract = candidateGrowthContract();
+    candidateContract.runtimeArtifacts.splice(1, 1,
+      { name: 'View', path: 'dist/View.mjs', baselineBrotliBytes: 0 },
+      { name: 'All', path: 'dist/all.mjs', baselineBrotliBytes: 0 });
+    candidateContract.productionGraphs[1].output = 'dist/View.mjs';
+    const currentReport = productionReport();
+    currentReport.artifacts.push(
+      { name: 'View', path: 'dist/View.mjs', status: 'measured', size: 2 },
+      { name: 'All', path: 'dist/all.mjs', status: 'measured', size: 2 });
+    currentReport.cumulative.size = 104;
+    currentReport.graphs.push({
+      subpath: './feature',
+      input: 'feature.js',
+      output: 'dist/View.mjs',
+      status: 'measured',
+      modules: ['feature.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+
+    const required = requiredNewProductionApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract,
+      currentReport,
+    });
+    assert.deepEqual(required.artifacts, [
+      { path: 'dist/View.mjs', size: 2 },
+      { path: 'dist/all.mjs', size: 2 },
+    ]);
+
+    const result = validateGrowthApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract,
+      comments: snapshot([comment(approvalRecord([], required))]),
+      currentReport,
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(result.status, 'approved');
+  });
+
+  test('permits only zero-Phase-0-cost artifact and graph additions to the candidate contract', () => {
+    assert.deepEqual(
+      validateCandidateGrowthContract(growthContract(), candidateGrowthContract()),
+      []
+    );
+
+    const changedPolicy = candidateGrowthContract();
+    changedPolicy.pullRequestGrowthApproval.allowedLogins = ['attacker'];
+    assert.match(
+      validateCandidateGrowthContract(growthContract(), changedPolicy)[0],
+      /pullRequestGrowthApproval/
+    );
+
+    const changedCeiling = candidateGrowthContract();
+    changedCeiling.baseline.absoluteCeilingBytes = 1000;
+    assert.match(
+      validateCandidateGrowthContract(growthContract(), changedCeiling)[0],
+      /baseline/
+    );
+
+    const resetPhase0 = candidateGrowthContract();
+    resetPhase0.runtimeArtifacts[1].baselineBrotliBytes = 4;
+    assert.match(
+      validateCandidateGrowthContract(growthContract(), resetPhase0)[0],
+      /baselineBrotliBytes must be 0/
+    );
+  });
+
+  test('fails closed for removed base entries and invalid new production evidence', () => {
+    const removedArtifact = candidateGrowthContract();
+    removedArtifact.runtimeArtifacts.shift();
+    assert.match(
+      validateCandidateGrowthContract(growthContract(), removedArtifact)[0],
+      /removes or changes exact-base runtime artifact dist\/main\.js/
+    );
+
+    const unmeasured = productionReport({ includeFeature: true, featureStatus: 'unconfigured' });
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        candidateContract: candidateGrowthContract(),
+        currentReport: unmeasured,
+      }),
+      /New production graph \.\/feature is not measured/
+    );
+
+    const forbidden = productionReport({ includeFeature: true });
+    forbidden.graphs[1].forbiddenModules = ['test/helper.js'];
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        candidateContract: candidateGrowthContract(),
+        currentReport: forbidden,
+      }),
+      /includes forbidden modules/
+    );
+
+    const overCeiling = productionReport({ includeFeature: true });
+    overCeiling.artifacts[1].size = 6;
+    overCeiling.cumulative.size = 106;
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        candidateContract: candidateGrowthContract(),
+        currentReport: overCeiling,
+      }),
+      /exceeds the exact-base cumulative ceiling/
+    );
+
+    for (const size of [null, '4', -1]) {
+      const malformedSize = productionReport({ includeFeature: true });
+      malformedSize.artifacts[1].size = size;
+      assert.throws(
+        () => requiredNewProductionApproval({
+          authorityContract: growthContract(),
+          baseReport: productionReport(),
+          candidateContract: candidateGrowthContract(),
+          currentReport: malformedSize,
+        }),
+        /not measured at a non-negative integer size/
+      );
+    }
+
+    const orphanArtifact = productionReport({ includeFeature: true });
+    orphanArtifact.graphs.pop();
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        candidateContract: candidateGrowthContract(),
+        currentReport: orphanArtifact,
+      }),
+      /cannot be adopted without a new production subpath/
+    );
+  });
+
+  test('binds complete base and candidate report sets before discovering approval deltas', () => {
+    const omittedBase = productionReport();
+    omittedBase.artifacts = [];
+    omittedBase.graphs = [];
+    omittedBase.cumulative.size = 0;
+    const omittedCurrent = structuredClone(omittedBase);
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: omittedBase,
+        currentReport: omittedCurrent,
+      }),
+      /Exact-base report artifact set mismatch.*dist\/main\.js.*graph set mismatch.*\./
+    );
+    const omittedResult = validateGrowthApproval({
+      authorityContract: growthContract(),
+      baseReport: omittedBase,
+      comments: snapshot([], 'unavailable'),
+      currentReport: omittedCurrent,
+      evidenceComments: evidenceSnapshot([], 'unavailable'),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+    assert.equal(omittedResult.status, 'blocked');
+    assert.equal(omittedResult.diagnostics[0].code, 'GROWTH_APPROVAL_REPORT');
+
+    const preseededBase = productionReport({ includeFeature: true });
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: preseededBase,
+        candidateContract: candidateGrowthContract(),
+        currentReport: productionReport({ includeFeature: true }),
+      }),
+      /Exact-base report artifact set mismatch.*dist\/feature\.js.*graph set mismatch.*\.\/feature/
+    );
+
+    const extraCurrent = productionReport({ includeFeature: true });
+    extraCurrent.artifacts.push({
+      name: 'Extra',
+      path: 'dist/extra.js',
+      status: 'measured',
+      size: 1,
+    });
+    extraCurrent.cumulative.size += 1;
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        candidateContract: candidateGrowthContract(),
+        currentReport: extraCurrent,
+      }),
+      /Pull request report artifact set mismatch.*dist\/extra\.js/
+    );
+
+    const malformedBase = productionReport();
+    malformedBase.artifacts[0].status = 'missing';
+    malformedBase.graphs[0].status = 'measurement-error';
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: malformedBase,
+        currentReport: productionReport(),
+      }),
+      /runtime artifact dist\/main\.js is not measured.*production graph \. is not completely measured/
+    );
+
+    const incompleteTotal = productionReport();
+    incompleteTotal.cumulative.size = 99;
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        currentReport: incompleteTotal,
+      }),
+      /Pull request cumulative size does not equal the complete measured artifact set/
+    );
+  });
+
   test('rejects duplicate report paths and malformed thresholds', () => {
     assert.throws(
       () => requiredArtifactGrowth(
@@ -212,6 +629,21 @@ describe('exact-head performance growth approval contract', () => {
     });
     assert.deepEqual(parseGrowthApprovalComment('ordinary comment', policy), { matched: false });
     assert.equal(body.split('\n')[0], '<!-- marionette-performance-growth-approval:v1 -->');
+  });
+
+  test('formats and parses exact new-subpath approval fields without changing existing records', () => {
+    const newProduction = {
+      artifacts: [{ path: 'dist/feature.js', size: 4 }],
+      subpaths: ['./feature'],
+    };
+    const record = approvalRecord([], newProduction);
+
+    assert.deepEqual(parseGrowthApprovalComment(formatGrowthApprovalComment(record), policy), {
+      matched: true,
+      approval: record,
+    });
+    assert.equal(Object.hasOwn(approvalRecord(), 'approvedNewSubpaths'), false);
+    assert.equal(Object.hasOwn(approvalRecord(), 'approvedNewArtifacts'), false);
   });
 
   test('rejects ambiguous formatting, fields, paths, and evidence', () => {
@@ -301,6 +733,78 @@ describe('exact-head performance growth approval contract', () => {
     assert.deepEqual(result.diagnostics, []);
     assert.equal(result.approval.authorLogin, 'paulfalgout');
     assert.deepEqual(result.approval.approvedPaths, ['dist/over.js']);
+  });
+
+  test('accepts one exact-head approval for the exact new subpath and full artifact size', () => {
+    const newProduction = {
+      artifacts: [{ path: 'dist/feature.js', size: 4 }],
+      subpaths: ['./feature'],
+    };
+    const result = validateGrowthApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract: candidateGrowthContract(),
+      comments: snapshot([comment(approvalRecord([], newProduction))]),
+      currentReport: productionReport({ includeFeature: true }),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(result.newSubpaths, ['./feature']);
+    assert.deepEqual(result.newArtifacts, [{ path: 'dist/feature.js', size: 4 }]);
+    assert.deepEqual(result.approval.approvedNewSubpaths, ['./feature']);
+  });
+
+  test('rejects missing, extra, or stale new-production approval details', () => {
+    const newProduction = {
+      artifacts: [{ path: 'dist/feature.js', size: 4 }],
+      subpaths: ['./feature'],
+    };
+    const options = {
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract: candidateGrowthContract(),
+      currentReport: productionReport({ includeFeature: true }),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    };
+
+    const missing = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(approvalRecord([]))]),
+    });
+    assert.equal(missing.diagnostics[0].code, 'GROWTH_APPROVAL_MISSING');
+
+    const extraSubpath = structuredClone(newProduction);
+    extraSubpath.subpaths.push('./other');
+    const extra = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(approvalRecord([], extraSubpath))]),
+    });
+    assert.equal(extra.diagnostics[0].code, 'GROWTH_APPROVAL_NEW_SUBPATH_SET_MISMATCH');
+
+    const wrongSize = structuredClone(newProduction);
+    wrongSize.artifacts[0].size = 3;
+    const mismatched = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(approvalRecord([], wrongSize))]),
+    });
+    assert.equal(mismatched.diagnostics[0].code, 'GROWTH_APPROVAL_NEW_ARTIFACT_SET_MISMATCH');
+
+    const stale = approvalRecord([], newProduction);
+    stale.headSha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const staleResult = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(stale)]),
+    });
+    assert.equal(staleResult.diagnostics[0].code, 'GROWTH_APPROVAL_MISSING');
   });
 
   test('fails closed for absent, stale, unauthorized, or unavailable approval comments', () => {
@@ -492,6 +996,7 @@ describe('exact-head performance growth approval contract', () => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-growth-approval-'));
     const paths = {
       base: join(fixtureRoot, 'base.json'),
+      candidate: join(fixtureRoot, 'candidate.json'),
       comments: join(fixtureRoot, 'comments.json'),
       contract: join(fixtureRoot, 'contract.json'),
       current: join(fixtureRoot, 'current.json'),
@@ -502,7 +1007,7 @@ describe('exact-head performance growth approval contract', () => {
       cwd: root,
       encoding: 'utf8',
     }).stdout.trim();
-    const cliApproval = approvalRecord();
+    const cliApproval = approvalRecord(['dist/main.js']);
     cliApproval.headSha = checkoutHead;
     const args = [
       cli,
@@ -517,16 +1022,9 @@ describe('exact-head performance growth approval contract', () => {
 
     try {
       await Promise.all([
-        writeFile(paths.contract, JSON.stringify({
-          thresholds: { pullRequestApprovalPercent: 1 },
-          pullRequestGrowthApproval: policy,
-        })),
-        writeFile(paths.base, JSON.stringify(report([
-          { name: 'Over', path: 'dist/over.js', size: 100 },
-        ]))),
-        writeFile(paths.current, JSON.stringify(report([
-          { name: 'Over', path: 'dist/over.js', size: 102 },
-        ]))),
+        writeFile(paths.contract, JSON.stringify(growthContract())),
+        writeFile(paths.base, JSON.stringify(productionReport())),
+        writeFile(paths.current, JSON.stringify(grownProductionReport())),
         writeFile(paths.comments, JSON.stringify(snapshot([comment(cliApproval)]))),
         writeFile(paths.evidence, JSON.stringify(evidenceSnapshot())),
       ]);
@@ -534,6 +1032,38 @@ describe('exact-head performance growth approval contract', () => {
       const approved = spawnSync(process.execPath, args, { encoding: 'utf8' });
       assert.equal(approved.status, 0);
       assert.equal(JSON.parse(approved.stdout).status, 'approved');
+
+      const newProduction = {
+        artifacts: [{ path: 'dist/feature.js', size: 4 }],
+        subpaths: ['./feature'],
+      };
+      const cliNewApproval = approvalRecord([], newProduction);
+      cliNewApproval.headSha = checkoutHead;
+      await Promise.all([
+        writeFile(paths.contract, JSON.stringify(growthContract())),
+        writeFile(paths.candidate, JSON.stringify(candidateGrowthContract())),
+        writeFile(paths.base, JSON.stringify(productionReport())),
+        writeFile(paths.current, JSON.stringify(productionReport({ includeFeature: true }))),
+        writeFile(paths.comments, JSON.stringify(snapshot([comment(cliNewApproval)]))),
+      ]);
+      const reportingOnly = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      assert.equal(reportingOnly.status, 0);
+      assert.equal(JSON.parse(reportingOnly.stdout).status, 'not-required');
+      assert.equal(JSON.parse(reportingOnly.stdout).newProductionEnforced, false);
+
+      const newSubpath = spawnSync(process.execPath, [
+        ...args,
+        '--candidate-contract', paths.candidate,
+      ], { encoding: 'utf8' });
+      assert.equal(newSubpath.status, 0);
+      assert.deepEqual(JSON.parse(newSubpath.stdout).newSubpaths, ['./feature']);
+
+      await Promise.all([
+        writeFile(paths.contract, JSON.stringify(growthContract())),
+        writeFile(paths.base, JSON.stringify(productionReport())),
+        writeFile(paths.current, JSON.stringify(grownProductionReport())),
+        writeFile(paths.comments, JSON.stringify(snapshot([comment(cliApproval)]))),
+      ]);
 
       const mismatchedArgs = [...args];
       mismatchedArgs[mismatchedArgs.indexOf('--head-sha') + 1] = headSha;

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -331,12 +331,27 @@ describe('exact-head performance growth approval contract', () => {
     assert.deepEqual(result.newSubpaths, ['./feature']);
   });
 
-  test('reports new production deltas without enforcing before activation', () => {
+  test('blocks new production additions until candidate-contract activation', () => {
+    const currentReport = productionReport({ includeFeature: true });
+    currentReport.violations = [
+      'Declared runtime artifacts missing from the contract: dist/feature.js',
+      'Shipped runtime artifacts are untracked: dist/feature.js',
+      'Production graph subpaths mismatch exports; missing: ./feature; extra: none',
+    ];
+    currentReport.graphs[1] = {
+      subpath: './feature',
+      status: 'unconfigured',
+      modules: [],
+      externalImports: [],
+      forbiddenModules: [],
+      error: 'New exported runtime subpath is not defined by the authority contract',
+    };
+
     const result = validateGrowthApproval({
       authorityContract: growthContract(),
       baseReport: productionReport(),
       comments: snapshot([]),
-      currentReport: productionReport({ includeFeature: true }),
+      currentReport,
       evidenceComments: evidenceSnapshot(),
       headSha,
       policy,
@@ -344,11 +359,12 @@ describe('exact-head performance growth approval contract', () => {
       thresholdPercent: 1,
     });
 
-    assert.equal(result.status, 'not-required');
+    assert.equal(result.status, 'blocked');
     assert.equal(result.newProductionEnforced, false);
-    assert.deepEqual(result.newArtifacts, [{ path: 'dist/feature.js', size: 4 }]);
-    assert.deepEqual(result.newSubpaths, ['./feature']);
-    assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(result.newArtifacts, []);
+    assert.deepEqual(result.newSubpaths, []);
+    assert.equal(result.diagnostics[0].code, 'GROWTH_APPROVAL_REPORT');
+    assert.match(result.diagnostics[0].message, /report has contract violations/);
   });
 
   test('uses canonical code-unit order for new artifact approvals', () => {
@@ -442,7 +458,7 @@ describe('exact-head performance growth approval contract', () => {
         candidateContract: candidateGrowthContract(),
         currentReport: unmeasured,
       }),
-      /New production graph \.\/feature is not measured/
+      /Pull request production graph \.\/feature is not completely measured/
     );
 
     const forbidden = productionReport({ includeFeature: true });
@@ -493,7 +509,7 @@ describe('exact-head performance growth approval contract', () => {
         candidateContract: candidateGrowthContract(),
         currentReport: orphanArtifact,
       }),
-      /cannot be adopted without a new production subpath/
+      /Pull request report graph set mismatch; missing: \.\/feature/
     );
   });
 
@@ -1046,10 +1062,10 @@ describe('exact-head performance growth approval contract', () => {
         writeFile(paths.current, JSON.stringify(productionReport({ includeFeature: true }))),
         writeFile(paths.comments, JSON.stringify(snapshot([comment(cliNewApproval)]))),
       ]);
-      const reportingOnly = spawnSync(process.execPath, args, { encoding: 'utf8' });
-      assert.equal(reportingOnly.status, 0);
-      assert.equal(JSON.parse(reportingOnly.stdout).status, 'not-required');
-      assert.equal(JSON.parse(reportingOnly.stdout).newProductionEnforced, false);
+      const beforeActivation = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      assert.equal(beforeActivation.status, 1);
+      assert.equal(JSON.parse(beforeActivation.stdout).status, 'blocked');
+      assert.equal(JSON.parse(beforeActivation.stdout).newProductionEnforced, false);
 
       const newSubpath = spawnSync(process.execPath, [
         ...args,


### PR DESCRIPTION
Related #127

## What

- Extend the versioned exact-head approval record with exact new production subpaths and every new runtime artifact's full measured Brotli-11 size.
- Restrict candidate performance contracts to additive, zero-Phase-0-baseline artifact and graph entries while rejecting changes to exact-base policy and existing entries.
- Keep new production additions fail-closed until the separate activation wiring supplies and validates the candidate contract.
- Reject malformed supplied new-artifact and new-subpath fields instead of treating falsy values as empty arrays.

## Why

The existing growth gate compares established artifacts with an exact base, but a new public production subpath has no percentage baseline. Its complete initial artifact cost must remain visible against the original cumulative ceiling and require durable exact-head approval.

Defining the reviewed base-owned contract before activation prevents candidate-owned policy from authorizing the first enforcement change. Pre-activation additions remain blocked because the active exact-base workflow cannot safely measure an unconfigured candidate graph.

## Scope

This changes performance-contract tooling, deterministic tests, and repository documentation only. It does not modify runtime source, package exports, dependencies, distribution artifacts, release behavior, or application behavior.

This PR does not activate new-subpath enforcement in GitHub Actions. A separate follow-up must measure with the validated candidate contract and invoke the reviewed parser from an exact pull request base containing this contract.

## Deployment Impact

No deployment or consumer redeploy is required. The production package and runtime graph are unchanged.

## Testing

Current refreshed head:

- `node --test test/performance/growth-approval.test.mjs test/performance/contract.test.mjs` — 43/43 passed.
- `./node_modules/.bin/eslint config/bundle-size.mjs config/performance-growth-approval.mjs test/performance/contract.test.mjs test/performance/growth-approval.test.mjs --max-warnings=0` — passed.
- `npm run docs:check` — 29 pages built; 30 HTML files and 288 internal links validated.
- `git diff --check marionettejs/master...HEAD` — passed.
- Exact-head CI is the authoritative full-suite, package, and distribution validation.