### PR TITLE
test(lifecycle): specify View state transitions

### DIFF
--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -60,9 +60,9 @@ following observable transitions:
 | Re-show a detached view | Rendered stays `true`; attachment reflects the Region | Does not render the view again |
 | `region.empty()` or `view.destroy()` | Rendered and attached become `false`; destroyed becomes `true` | Repeated destroy is a no-op |
 
-Region-managed attachment state assumes lifecycle monitoring is enabled. Setting
-`monitorViewEvents: false` on the owning view intentionally disables attachment events
-and automatic `isAttached()` updates for views shown through its Regions.
+Setting `monitorViewEvents: false` on either a Region's owning view or the shown view
+itself intentionally disables attachment events and automatic `isAttached()` updates
+for that shown view.
 
 This table specifies the normal managed lifecycle. Operations on an already destroyed
 view, other than repeated `destroy()`, are intentionally outside this contract until

--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -37,6 +37,37 @@ Returns a boolean value reflecting if the view is considered attached to the DOM
 
 Returns a boolean value reflecting if the view has been destroyed.
 
+### State vectors
+
+The three lifecycle methods are independent observations, not one linear state enum.
+Construction can therefore produce any of the four alive render/attachment vectors:
+
+| Initial `el` | `isRendered()` | `isAttached()` | `isDestroyed()` |
+| --- | --- | --- | --- |
+| Empty and detached | `false` | `false` | `false` |
+| Empty and in the document | `false` | `true` | `false` |
+| Populated and detached | `true` | `false` | `false` |
+| Populated and in the document | `true` | `true` | `false` |
+
+With lifecycle monitoring enabled, Marionette-managed operations preserve the
+following observable transitions:
+
+| Operation | Result | Repeated call |
+| --- | --- | --- |
+| `view.render()` with a renderable template while alive | Rendered becomes `true`; attachment is unchanged | Renders again and runs the render lifecycle again |
+| `region.show(view)` | Ensures the view is rendered; attached becomes `true` only when the Region is in the document | Showing the current view is a no-op |
+| `region.detachView()` | Rendered stays `true`; attached becomes `false`; destroyed stays `false` | Returns `undefined` with no transition |
+| Re-show a detached view | Rendered stays `true`; attachment reflects the Region | Does not render the view again |
+| `region.empty()` or `view.destroy()` | Rendered and attached become `false`; destroyed becomes `true` | Repeated destroy is a no-op |
+
+Region-managed attachment state assumes lifecycle monitoring is enabled. Setting
+`monitorViewEvents: false` on the owning view intentionally disables attachment events
+and automatic `isAttached()` updates for views shown through its Regions.
+
+This table specifies the normal managed lifecycle. Operations on an already destroyed
+view, other than repeated `destroy()`, are intentionally outside this contract until
+their invalid-transition behavior is made consistent.
+
 ## Instantiating a View
 
 Marionette Views are Backbone Views and so when they are instantiated the view

--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -60,9 +60,8 @@ following observable transitions:
 | Re-show a detached view | Rendered stays `true`; attachment reflects the Region | Does not render the view again |
 | `region.empty()` or `view.destroy()` | Rendered and attached become `false`; destroyed becomes `true` | Repeated destroy is a no-op |
 
-Setting `monitorViewEvents: false` on either a Region's owning view or the shown view
-itself intentionally disables attachment events and automatic `isAttached()` updates
-for that shown view.
+Setting `monitorViewEvents: false` on a Region's owning view intentionally disables
+attachment events and automatic `isAttached()` updates for the shown view.
 
 This table specifies the normal managed lifecycle. Operations on an already destroyed
 view, other than repeated `destroy()`, are intentionally outside this contract until

--- a/test/unit/view-lifecycle.spec.js
+++ b/test/unit/view-lifecycle.spec.js
@@ -1,0 +1,124 @@
+import Region from '../../modules/region';
+import View from '../../modules/view';
+
+function state(view) {
+  return {
+    rendered: view.isRendered(),
+    attached: view.isAttached(),
+    destroyed: view.isDestroyed(),
+  };
+}
+
+describe('View lifecycle contract', function() {
+  const constructionStates = [
+    {
+      name: 'generated empty detached element',
+      create() {
+        return new View({ template: false });
+      },
+      expected: { rendered: false, attached: false, destroyed: false },
+    },
+    {
+      name: 'empty attached element',
+      create(context) {
+        context.setFixtures('<div id="empty-attached"></div>');
+        return new View({ el: document.querySelector('#empty-attached'), template: false });
+      },
+      expected: { rendered: false, attached: true, destroyed: false },
+    },
+    {
+      name: 'populated detached element',
+      create() {
+        const el = document.createElement('div');
+        el.innerHTML = '<span>Existing content</span>';
+        return new View({ el, template: false });
+      },
+      expected: { rendered: true, attached: false, destroyed: false },
+    },
+    {
+      name: 'populated attached element',
+      create(context) {
+        context.setFixtures('<div id="populated-attached"><span>Existing content</span></div>');
+        return new View({ el: document.querySelector('#populated-attached'), template: false });
+      },
+      expected: { rendered: true, attached: true, destroyed: false },
+    },
+  ];
+
+  for (const scenario of constructionStates) {
+    it(`exposes the ${scenario.name} state vector`, function() {
+      const view = scenario.create(this);
+
+      expect(state(view)).to.deep.equal(scenario.expected);
+
+      view.destroy();
+    });
+  }
+
+  it('follows the normal Region-managed transition sequence', function() {
+    this.setFixtures('<div id="lifecycle-region"></div>');
+    const region = new Region({ el: '#lifecycle-region' });
+    const view = new View({ template: () => '<span>Rendered content</span>' });
+    const render = this.sinon.spy(view, 'render');
+    const beforeDestroy = this.sinon.spy();
+    const destroy = this.sinon.spy();
+    view.on('before:destroy', beforeDestroy);
+    view.on('destroy', destroy);
+
+    expect(state(view)).to.deep.equal({
+      rendered: false,
+      attached: false,
+      destroyed: false,
+    });
+
+    expect(region.show(view)).to.equal(region);
+    expect(state(view)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(render).to.have.been.calledOnce;
+
+    view.render();
+    expect(state(view)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(render).to.have.been.calledTwice;
+
+    expect(region.show(view)).to.equal(region);
+    expect(render).to.have.been.calledTwice;
+
+    expect(region.detachView()).to.equal(view);
+    expect(state(view)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(region.detachView()).to.be.undefined;
+
+    region.show(view);
+    expect(state(view)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(render).to.have.been.calledTwice;
+
+    region.empty();
+    expect(state(view)).to.deep.equal({
+      rendered: false,
+      attached: false,
+      destroyed: true,
+    });
+    expect(beforeDestroy).to.have.been.calledOnce;
+    expect(destroy).to.have.been.calledOnce;
+
+    view.destroy();
+    expect(beforeDestroy).to.have.been.calledOnce;
+    expect(destroy).to.have.been.calledOnce;
+
+    region.destroy();
+  });
+});


### PR DESCRIPTION
Related #131

## What

- Document `View` lifecycle as the observable `rendered` / `attached` / `destroyed` state vector rather than a single linear enum.
- Add the normal Region-managed transition table, including repeat render, show, detach, re-show, empty, and destroy behavior.
- Add one focused table-driven test file covering all four valid construction vectors and the managed transition sequence through public APIs.
- Clarify that `monitorViewEvents: false` on the Region owner disables attachment tracking for the shown View.

## Why

Agents currently have to infer lifecycle state and idempotence from distributed implementation details and event-oriented tests. A compact state/operation table makes the existing contract directly inspectable and executable.

## Scope

This changes View lifecycle documentation and tests only. It does not change runtime source, events, diagnostics, package output, or compatibility behavior.

Operations on an already destroyed view, other than repeated `destroy()`, remain intentionally unspecified in this slice because current `render`, `Region.show`, and `setElement` behavior is inconsistent. #131 retains that explicit design decision.

## Deployment Impact

No deployment or consumer redeploy is required. Runtime and distribution artifacts are unchanged.

## Testing

Before the current master refresh, the lifecycle commit passed:

- `./node_modules/.bin/vitest run test/unit/view-lifecycle.spec.js --coverage.enabled=false --reporter=dot` — 5/5 passed.
- `npm run docs:check` — 29 pages built; 30 HTML files and 288 internal links validated.
- `./node_modules/.bin/eslint test/unit/view-lifecycle.spec.js --max-warnings=0` — passed.

For the refreshed head:

- `git diff --check marionettejs/master...HEAD` — passed.
- Exact-head CI is the authoritative full validation because this isolated worktree does not have dependencies installed.