### PR TITLE
fix(performance): bind graphs to shipped outputs

### DIFF
--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -173,6 +173,14 @@ export function validateContract(contract, packageJson, runtimeFiles) {
   if (missingGraphs.length || extraGraphs.length) {
     violations.push(`Production graph subpaths mismatch exports; missing: ${missingGraphs.join(', ') || 'none'}; extra: ${extraGraphs.join(', ') || 'none'}`);
   }
+  for (const graph of contract.productionGraphs) {
+    const exportedPaths = collectRuntimePaths(packageJson.exports?.[graph.subpath]);
+    if (!exportedPaths.has(graph.output)) {
+      violations.push(
+        `Production graph ${graph.subpath} output ${graph.output} is not exported by that subpath`
+      );
+    }
+  }
 
   return violations;
 }
@@ -239,16 +247,31 @@ export async function validateToolchain(contract, root) {
   return violations;
 }
 
-function findRollupConfiguration(configurations, graph) {
-  const configuration = configurations.find(candidate => candidate.input === graph.input);
-  if (!configuration) {
-    throw new Error(`No Rollup input found for ${graph.input}`);
+function findRollupConfiguration(root, configurations, graph) {
+  const matches = [];
+  const graphOutput = resolve(root, graph.output);
+  for (const configuration of configurations) {
+    const outputs = Array.isArray(configuration.output) ?
+      configuration.output : [configuration.output];
+    for (const output of outputs) {
+      if (typeof output?.file === 'string' && resolve(root, output.file) === graphOutput) {
+        matches.push({ configuration, output });
+      }
+    }
+  }
+  if (!matches.length) {
+    throw new Error(`No Rollup output found for ${graph.output}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`Multiple Rollup configurations write ${graph.output}`);
   }
 
-  const outputs = Array.isArray(configuration.output) ? configuration.output : [configuration.output];
-  const output = outputs.find(candidate => normalizePath(candidate.file) === graph.output);
-  if (!output) {
-    throw new Error(`No Rollup output found for ${graph.output}`);
+  const [{ configuration, output }] = matches;
+  if (typeof configuration.input !== 'string') {
+    throw new Error(`Rollup output ${graph.output} must use one string input ${graph.input}`);
+  }
+  if (resolveRollupInput(root, configuration.input) !== resolveRollupInput(root, graph.input)) {
+    throw new Error(`Rollup output ${graph.output} does not use input ${graph.input}`);
   }
 
   return { configuration, output };
@@ -268,7 +291,7 @@ export function resolveRollupInput(root, input) {
 }
 
 async function measureGraph(root, configurations, graph, contract) {
-  const { configuration, output } = findRollupConfiguration(configurations, graph);
+  const { configuration, output } = findRollupConfiguration(root, configurations, graph);
   const bundle = await rollup({
     ...configuration,
     input: resolveRollupInput(root, configuration.input),

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -29,6 +29,8 @@ a new artifact cannot silently avoid the cumulative budget.
 The same command asks Rollup for the actual internal modules and external imports of
 `.`, `./backbone`, and `./jquery-dom-api`. It records graph changes and fails if test,
 documentation, benchmark, release, or diagnostic tooling enters a production graph.
+Each graph output must be exported by that exact package subpath and have one unique
+Rollup producer with the single declared input, so the measured graph is the shipped graph.
 The Phase 0 module lists remain fixed evidence; ordinary source-module refactors are
 reported rather than prohibited when the resulting graph remains clean.
 

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -554,6 +554,210 @@ describe('performance contract validation', () => {
     assert.ok(violations.includes('Production graph subpaths mismatch exports; missing: ./feature; extra: none'));
   });
 
+  test('rejects production graph outputs not exported by their subpath', () => {
+    const contract = contractFor(['dist/index.mjs', 'dist/feature.mjs']);
+    contract.productionGraphs = [
+      {
+        subpath: '.',
+        input: 'index.js',
+        output: 'dist/index.mjs',
+        baselineModules: [],
+        baselineExternalImports: [],
+      },
+      {
+        subpath: './feature',
+        input: 'index.js',
+        output: 'dist/index.mjs',
+        baselineModules: [],
+        baselineExternalImports: [],
+      },
+    ];
+    const packageJson = {
+      exports: {
+        '.': { import: './dist/index.mjs' },
+        './feature': { import: './dist/feature.mjs' },
+      },
+    };
+
+    const violations = validateContract(contract, packageJson, ['feature.mjs', 'index.mjs']);
+
+    assert.ok(violations.includes(
+      'Production graph ./feature output dist/index.mjs is not exported by that subpath'
+    ));
+  });
+
+  for (const outputAlias of [
+    'dist/nested/../index.mjs',
+    'absolute',
+  ]) {
+    test(`rejects an ambiguous ${outputAlias === 'absolute' ? 'absolute' : 'relative'} Rollup output alias`, async() => {
+      const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-output-'));
+      const contract = contractFor();
+      contract.productionGraphs = [{
+        subpath: '.',
+        input: 'index.js',
+        output: 'dist/index.mjs',
+        baselineModules: [],
+        baselineExternalImports: [],
+      }];
+      const packageJson = {
+        type: 'module',
+        exports: { '.': { import: './dist/index.mjs' } },
+      };
+      const duplicateOutput = outputAlias === 'absolute' ?
+        join(fixtureRoot, 'dist/index.mjs') : outputAlias;
+
+      try {
+        await mkdir(join(fixtureRoot, 'dist'));
+        await writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(packageJson));
+        await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
+        await writeFile(join(fixtureRoot, 'index.js'), 'export const value = 1;\n');
+        await writeFile(join(fixtureRoot, 'other.js'), 'export const other = 1;\n');
+        await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
+        await writeFile(
+          join(fixtureRoot, 'rollup.config.mjs'),
+          'export default [' +
+            '{ input: \'index.js\', output: { file: \'dist/index.mjs\', format: \'es\' } },' +
+            `{ input: 'other.js', output: { file: ${JSON.stringify(duplicateOutput)}, format: 'es' } }` +
+          '];\n'
+        );
+
+        const result = await measure({
+          root: fixtureRoot,
+          configPath: join(fixtureRoot, 'performance.json'),
+          checkToolchain: false,
+        });
+
+        assert.equal(result.graphs[0].status, 'measurement-error');
+        assert.match(result.graphs[0].error, /Multiple Rollup configurations write dist\/index\.mjs/);
+      } finally {
+        await rm(fixtureRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test('accepts an equivalent Rollup input alias', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-input-'));
+    const contract = contractFor();
+    contract.productionGraphs = [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/index.mjs',
+      baselineModules: ['index.js'],
+      baselineExternalImports: [],
+    }];
+    const packageJson = {
+      type: 'module',
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+
+    try {
+      await mkdir(join(fixtureRoot, 'dist'));
+      await writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(packageJson));
+      await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
+      await writeFile(join(fixtureRoot, 'index.js'), 'export const value = 1;\n');
+      await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
+      await writeFile(
+        join(fixtureRoot, 'rollup.config.mjs'),
+        'export default [{ input: \'./index.js\', output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
+      );
+
+      const result = await measure({
+        root: fixtureRoot,
+        configPath: join(fixtureRoot, 'performance.json'),
+        checkToolchain: false,
+      });
+
+      assert.equal(result.graphs[0].status, 'measured');
+      assert.deepEqual(result.graphs[0].modules, ['index.js']);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  for (const input of [
+    '[\'index.js\']',
+    '{ main: \'index.js\' }',
+  ]) {
+    test(`rejects an ${input.startsWith('[') ? 'array' : 'object'} Rollup input for a single graph output`, async() => {
+      const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-input-'));
+      const contract = contractFor();
+      contract.productionGraphs = [{
+        subpath: '.',
+        input: 'index.js',
+        output: 'dist/index.mjs',
+        baselineModules: ['index.js'],
+        baselineExternalImports: [],
+      }];
+      const packageJson = {
+        type: 'module',
+        exports: { '.': { import: './dist/index.mjs' } },
+      };
+
+      try {
+        await mkdir(join(fixtureRoot, 'dist'));
+        await writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(packageJson));
+        await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
+        await writeFile(join(fixtureRoot, 'index.js'), 'export const value = 1;\n');
+        await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
+        await writeFile(
+          join(fixtureRoot, 'rollup.config.mjs'),
+          `export default [{ input: ${input}, output: { file: 'dist/index.mjs', format: 'es' } }];\n`
+        );
+
+        const result = await measure({
+          root: fixtureRoot,
+          configPath: join(fixtureRoot, 'performance.json'),
+          checkToolchain: false,
+        });
+
+        assert.equal(result.graphs[0].status, 'measurement-error');
+        assert.match(result.graphs[0].error, /must use one string input index\.js/);
+      } finally {
+        await rm(fixtureRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test('rejects a unique Rollup producer with the wrong input', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-input-'));
+    const contract = contractFor();
+    contract.productionGraphs = [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/index.mjs',
+      baselineModules: [],
+      baselineExternalImports: [],
+    }];
+    const packageJson = {
+      type: 'module',
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+
+    try {
+      await mkdir(join(fixtureRoot, 'dist'));
+      await writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(packageJson));
+      await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
+      await writeFile(join(fixtureRoot, 'other.js'), 'export const other = 1;\n');
+      await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
+      await writeFile(
+        join(fixtureRoot, 'rollup.config.mjs'),
+        'export default [{ input: \'other.js\', output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
+      );
+
+      const result = await measure({
+        root: fixtureRoot,
+        configPath: join(fixtureRoot, 'performance.json'),
+        checkToolchain: false,
+      });
+
+      assert.equal(result.graphs[0].status, 'measurement-error');
+      assert.match(result.graphs[0].error, /Rollup output dist\/index\.mjs does not use input index\.js/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   test('rejects cumulative size above the authority ceiling', () => {
     const contract = contractFor();
 


### PR DESCRIPTION
Related #127

## What

- Bind each measured production graph output to the artifact exported by its exact package subpath.
- Require one unique Rollup producer for that resolved output and require it to use the single declared graph input by resolved file identity.
- Add adversarial contract tests for mismatched exports, output aliases, equivalent input aliases, unsupported aggregate inputs, and incorrect inputs; document the invariant.

## Why

The new-subpath approval contract must measure the artifact consumers actually receive. The previous input-first lookup was also declaration-order dependent because the current Rollup configuration has two producers with `index.js` as input. Reordering those configurations could select the minified producer and fail to locate the declared graph output. Binding lookup to the shipped output removes that ambiguity and prevents a clean but unrelated graph from standing in for a shipped subpath before activation.

## Scope

Performance tooling, focused tests, and performance-contract documentation only. Runtime source, package exports, built artifacts, workflow behavior, and release behavior are unchanged. Activating the new-subpath contract in CI is intentionally left to the follow-up PR.

## Deployment Impact

No deploy or redeploy is required. This does not change runtime code or distribution artifacts.

## Testing

- `npm run test:performance` — 65/65 tests passed.
- `npx eslint config/bundle-size.mjs test/performance/contract.test.mjs` — passed.
- `npm run size` — passed; artifact sizes remained 49.50 kB and 51.98 kB, and all production graphs/resources were measured.
- `npm run docs:check` — passed; 29 pages, 30 HTML documents, and 288 links checked.
- `git diff --check` — passed.