### PR TITLE
feat(performance): activate new subpath approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,12 +233,13 @@ jobs:
 
           node "${authority_script}" --root bundle-size-base --config "${base_contract}" --json --no-enforce > "${PERFORMANCE_DIR}/bundle-size-base.json"
           authority_status=0
-          node "${authority_script}" --config "${base_contract}" --json > "${PERFORMANCE_DIR}/bundle-size-authority.json" || authority_status=$?
+          node "${authority_script}" --config config/performance.json --json > "${PERFORMANCE_DIR}/bundle-size-authority.json" || authority_status=$?
           candidate_status=0
           node "${authority_script}" --validate-resource-contract "${base_contract}" config/performance.json || candidate_status=$?
           approval_status=0
           node "${approval_script}" \
             --contract "${base_contract}" \
+            --candidate-contract config/performance.json \
             --base-report "${PERFORMANCE_DIR}/bundle-size-base.json" \
             --current-report "${PERFORMANCE_DIR}/bundle-size-authority.json" \
             --comments "${PERFORMANCE_DIR}/approval-comments.json" \

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -195,14 +195,13 @@ current pull request number, base SHA, and head SHA. If the base advances, it re
 to replay an older comparison. The default-branch rules require strict up-to-date
 status checks, so merge remains blocked until CI records the new exact base.
 
-The parser, additive-contract validator, and report schema are defined before new-
-subpath enforcement. This contract change does not alter Actions. A separate activation
-must measure the candidate with the exact-base validator and invoke the parser from an
-exact base containing this reviewed contract. Until that wiring lands, new-subpath
-results carry `newProductionEnforced: false`, are labeled blocked pending activation,
-and fail the existing size job. The activation supplies the reviewed candidate contract
-and changes that state to `true`. This two-step bootstrap prevents the first enforcement
-change from authorizing itself with candidate-owned policy.
+The exact-base bundle tool measures the current checkout against its candidate
+performance contract, while the exact-base evaluator validates that contract as an
+additive change to the authority contract. New-subpath results carry
+`newProductionEnforced: true`; every new public subpath and its complete new artifact
+cost therefore require an exact-head approval record. The threshold, approver policy,
+parser, contract validator, and evaluator all come from the pull request's exact base,
+so the first enforcement change cannot authorize itself with candidate-owned policy.
 
 ## Hosted timing
 
@@ -239,5 +238,5 @@ CODEOWNERS assigns the contract, growth-approval parser, resource probe, harness
 focused tests, and performance workflows to the project maintainer and core team.
 Current live repository rules do not require a CODEOWNER approval, so ownership is
 review routing rather than an automated merge gate. The exact-base authority contract
-is the automated anti-relaxation guard. Approved new-subpath adoption and the
-controlled timing runner remain separate follow-ups.
+is the automated anti-relaxation guard. The controlled timing runner remains a
+separate follow-up.

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -483,6 +483,49 @@ describe('performance contract validation', () => {
     }
   });
 
+  test('wires candidate measurement and validation through exact-base CI code', async() => {
+    const workflow = await readFile(join(root, '.github/workflows/ci.yml'), 'utf8');
+    const authorityStep = workflow.match(
+      /- name:\s+Enforce exact base performance contract\r?\n([\s\S]*?)(?=\n\s+- name: )/
+    )?.[1];
+    assert.ok(authorityStep);
+
+    const commands = authorityStep
+      .replace(/\\\r?\n\s*/g, ' ')
+      .split(/\r?\n/)
+      .map(line => line.trim().replace(/\s+/g, ' '))
+      .filter(Boolean);
+    const measurementIndex = commands.findIndex(command =>
+      command.startsWith('node "${authority_script}"') &&
+      command.includes('> "${PERFORMANCE_DIR}/bundle-size-authority.json"')
+    );
+    const resourceValidationIndex = commands.findIndex(command =>
+      command.includes('--validate-resource-contract')
+    );
+    const approvalIndex = commands.findIndex(command =>
+      command.startsWith('node "${approval_script}"')
+    );
+
+    assert.ok(commands.includes('authority_script=\'bundle-size-base/config/bundle-size.mjs\''));
+    assert.ok(commands.includes(
+      'approval_script=\'bundle-size-base/config/performance-growth-approval.mjs\''
+    ));
+    assert.notEqual(measurementIndex, -1);
+    assert.notEqual(resourceValidationIndex, -1);
+    assert.notEqual(approvalIndex, -1);
+    assert.match(
+      commands[measurementIndex],
+      /^node "\$\{authority_script\}" --config config\/performance\.json --json > "\$\{PERFORMANCE_DIR\}\/bundle-size-authority\.json" \|\| authority_status=\$\?$/
+    );
+    assert.match(
+      commands[resourceValidationIndex],
+      /^node "\$\{authority_script\}" --validate-resource-contract "\$\{base_contract\}" config\/performance\.json \|\| candidate_status=\$\?$/
+    );
+    assert.ok(commands[approvalIndex].includes('--candidate-contract config/performance.json'));
+    assert.ok(measurementIndex < approvalIndex);
+    assert.ok(resourceValidationIndex < approvalIndex);
+  });
+
   test('rejects forbidden modules from the measured production graph', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-forbidden-'));
     const contract = contractFor();


### PR DESCRIPTION
Related #127

## What

- Measure the pull request checkout with its candidate performance contract while continuing to execute the bundle and approval tools from the exact pull request base.
- Pass the candidate contract to the exact-base approval evaluator so every new public subpath and its complete artifact cost require exact-head maintainer approval.
- Add a workflow-wiring regression test and update the performance documentation from bootstrap-pending to active enforcement.

## Why

The parser and additive contract were introduced separately so the first enforcement change could not authorize itself with candidate-owned policy. With that base-owned authority now merged—and the shipped-output graph binding hardened in #193—CI can safely activate fail-closed approval for future public subpaths.

## Scope

This changes the required Bundle size workflow, its focused regression coverage, and performance-contract documentation. Runtime source, package exports, distribution artifacts, release publication, and website publication are unchanged. Controlled-runner timing enforcement remains a separate #127 follow-up.

## Deployment Impact

No application, package, website, or documentation deployment is required. The trusted-workflow ruleset intentionally executes its previously pinned CI definition on this PR. After merge:

- Repin `.github/workflows/ci.yml` to the activation merge SHA; that repin is the point at which enforcement becomes live.
- Add `.github/workflows/docs-pages.yml` at the same trusted SHA because it backs the required `Build and validate` status check. CodeQL uses GitHub-managed default setup and is not a PR-owned workflow file; Node 26 remains advisory rather than a required check.
- Open a disposable validation PR that adds a trivial new subpath, confirm live `blocked` → `approved` behavior against an exact-head approval comment, then close it without merging.

`DOCS_PAGES_ENABLED` remains unset, so documentation deployment stays disabled.

## Testing

- `npm run test:performance` — 66/66 tests passed.
- `npx eslint test/performance/contract.test.mjs` — passed.
- `npm run docs:check` — passed; 29 pages, 30 HTML documents, and 288 links checked.
- `git diff --check` — passed.
- An independent authority-boundary audit found no actionable issues.
- Canonical Ubuntu execution of the new workflow definition is intentionally deferred until the trusted-workflow repin and disposable live validation PR.