### PR TITLE
test(lifecycle): specify Region state transitions

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -84,8 +84,7 @@ change which lifecycle operations are valid.
 
 Successful `show`, `empty`, and `destroy` calls return the Region when their
 operation completes. With `allowMissingEl: true`, `show` instead returns `undefined`
-and leaves the Region empty when its element does not resolve; `empty` returns the
-Region without changing unresolved DOM contents. A View returned
+and leaves the Region empty when its element does not resolve. A View returned
 by `detachView()` remains the caller's responsibility until another Region shows it
 or it is destroyed. Operations other than repeated `destroy()` after Region
 destruction are unsupported; this contract does not make a destroyed Region reusable.

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -16,6 +16,7 @@ Regions maintain the [View's lifecycle](./view.lifecycle.md) while showing or em
 ## Documentation Index
 
 * [Instantiating a Region](#instantiating-a-region)
+* [Lifecycle transition contract](#lifecycle-transition-contract)
 * [Defining the Application Region](#defining-the-application-region)
 * [Defining Regions](#defining-regions)
   * [String Selector](#string-selector)
@@ -54,6 +55,40 @@ const myRegion = new Region({ ... });
 
 While regions may be instantiated and useful on their own, their primary use case is through
 the [`Application`](#defining-the-application-region) and [`View`](#defining-regions) classes.
+
+## Lifecycle transition contract
+
+A Region owns at most one current View. Its public lifecycle
+state can be read without changing it:
+
+| State | `hasView()` | `isDestroyed()` | `currentView` |
+| --- | --- | --- | --- |
+| Empty | `false` | `false` | `undefined` |
+| Occupied | `true` | `false` | The View shown by the Region |
+| Destroyed | `false` | `true` | `undefined` |
+
+`isSwappingView()` is a temporary operation flag rather than a fourth stable state.
+It is `true` while one occupied Region replaces its current View with another,
+including the Region's `before:show`, `before:empty`, `empty`, and `show` callbacks.
+It returns to `false` when `show` completes. `isReplaced()` independently reports
+whether `replaceElement` has temporarily replaced the Region element; it does not
+change which lifecycle operations are valid.
+
+| Operation | Empty Region | Occupied Region | Destroyed Region |
+| --- | --- | --- | --- |
+| `show(view)` when the Region element resolves | Renders the View if needed, shows it, and enters occupied. | Showing the same View is a no-op. Showing a different View destroys the old View and swaps to the new one. | Reuse is unsupported. |
+| `detachView()` | Returns `undefined`; state is unchanged. | Detaches and returns the live View, then enters empty. | Reuse is unsupported. |
+| `empty()` | Returns the Region and, when its element resolves, removes unmanaged contents from that element. | Destroys the current View, clears `currentView`, and enters empty. | Reuse is unsupported. |
+| Current View is destroyed externally | No effect. | Runs the Region's empty lifecycle once, clears `currentView`, and enters empty. | No effect. |
+| `destroy()` | Runs the destroy lifecycle and enters destroyed. | Emits `before:destroy`, enters destroyed, destroys and empties the current View, then emits `destroy`. | Returns the Region without repeating cleanup or lifecycle events. |
+
+Successful `show`, `empty`, and `destroy` calls return the Region when their
+operation completes. With `allowMissingEl: true`, `show` instead returns `undefined`
+and leaves the Region empty when its element does not resolve; `empty` returns the
+Region without changing unresolved DOM contents. A View returned
+by `detachView()` remains the caller's responsibility until another Region shows it
+or it is destroyed. Operations other than repeated `destroy()` after Region
+destruction are unsupported; this contract does not make a destroyed Region reusable.
 
 ## Defining the Application Region
 

--- a/test/unit/region-lifecycle.spec.js
+++ b/test/unit/region-lifecycle.spec.js
@@ -65,6 +65,18 @@ describe('Region lifecycle contract', function() {
     });
   });
 
+  it('stays empty when a missing element is allowed', function() {
+    const missingRegion = new Region({
+      el: '#missing',
+      allowMissingEl: true,
+    });
+    const view = new TestView();
+
+    expect(missingRegion.show(view)).to.be.undefined;
+    expect(missingRegion.hasView()).to.be.false;
+    expect(view.isRendered()).to.be.false;
+  });
+
   it('treats repeated show, empty, and destroy operations deterministically', function() {
     const lifecycle = [];
     const view = new TestView();

--- a/test/unit/region-lifecycle.spec.js
+++ b/test/unit/region-lifecycle.spec.js
@@ -1,0 +1,202 @@
+import _ from 'underscore';
+
+import Region from '../../modules/region';
+import View from '../../modules/view';
+
+describe('Region lifecycle contract', function() {
+  'use strict';
+
+  let region;
+
+  const TestView = View.extend({
+    template: _.template('<span>content</span>')
+  });
+
+  function state() {
+    return {
+      hasView: region.hasView(),
+      destroyed: region.isDestroyed(),
+      currentView: region.currentView,
+    };
+  }
+
+  beforeEach(function() {
+    this.setFixtures('<div id="region"></div>');
+    region = new Region({ el: '#region' });
+  });
+
+  it('moves through empty, occupied, detached, and destroyed states', function() {
+    const view = new TestView();
+    this.sinon.spy(view, 'render');
+
+    expect(state()).to.deep.equal({
+      hasView: false,
+      destroyed: false,
+      currentView: undefined,
+    });
+
+    expect(region.show(view)).to.equal(region);
+    expect(state()).to.deep.equal({
+      hasView: true,
+      destroyed: false,
+      currentView: view,
+    });
+    expect(view.render).to.have.been.calledOnce;
+
+    expect(region.show(view)).to.equal(region);
+    expect(view.render).to.have.been.calledOnce;
+
+    expect(region.detachView()).to.equal(view);
+    expect(region.detachView()).to.be.undefined;
+    expect(state()).to.deep.equal({
+      hasView: false,
+      destroyed: false,
+      currentView: undefined,
+    });
+
+    expect(region.show(view)).to.equal(region);
+    expect(view.render).to.have.been.calledOnce;
+
+    expect(region.destroy()).to.equal(region);
+    expect(state()).to.deep.equal({
+      hasView: false,
+      destroyed: true,
+      currentView: undefined,
+    });
+  });
+
+  it('treats repeated show, empty, and destroy operations deterministically', function() {
+    const lifecycle = [];
+    const view = new TestView();
+
+    region.on('before:show', () => lifecycle.push('before:show'));
+    region.on('show', () => lifecycle.push('show'));
+    region.on('before:empty', () => lifecycle.push('before:empty'));
+    region.on('empty', () => lifecycle.push('empty'));
+    region.on('before:destroy', () => lifecycle.push('before:destroy'));
+    region.on('destroy', () => lifecycle.push('destroy'));
+
+    region.show(view);
+    region.show(view);
+    expect(lifecycle).to.deep.equal(['before:show', 'show']);
+
+    expect(region.empty()).to.equal(region);
+    expect(region.empty()).to.equal(region);
+    expect(lifecycle).to.deep.equal([
+      'before:show',
+      'show',
+      'before:empty',
+      'empty',
+    ]);
+
+    expect(region.destroy()).to.equal(region);
+    expect(region.destroy()).to.equal(region);
+    expect(lifecycle).to.deep.equal([
+      'before:show',
+      'show',
+      'before:empty',
+      'empty',
+      'before:destroy',
+      'destroy',
+    ]);
+  });
+
+  it('reports swapping throughout replacement lifecycle callbacks', function() {
+    const lifecycle = [];
+    const firstView = new TestView();
+    const secondView = new TestView();
+
+    region.on('before:show', (currentRegion, view) => {
+      lifecycle.push(`before:show:${view.cid}:${currentRegion.isSwappingView()}`);
+    });
+    region.on('before:empty', (currentRegion, view) => {
+      lifecycle.push(`before:empty:${view.cid}:${currentRegion.isSwappingView()}`);
+    });
+    region.on('empty', (currentRegion, view) => {
+      lifecycle.push(`empty:${view.cid}:${currentRegion.isSwappingView()}`);
+    });
+    region.on('show', (currentRegion, view) => {
+      lifecycle.push(`show:${view.cid}:${currentRegion.isSwappingView()}`);
+    });
+
+    region.show(firstView);
+    lifecycle.length = 0;
+    region.show(secondView);
+
+    expect(lifecycle).to.deep.equal([
+      `before:show:${secondView.cid}:true`,
+      `before:empty:${firstView.cid}:true`,
+      `empty:${firstView.cid}:true`,
+      `show:${secondView.cid}:true`,
+    ]);
+    expect(firstView.isDestroyed()).to.be.true;
+    expect(region.currentView).to.equal(secondView);
+    expect(region.isSwappingView()).to.be.false;
+  });
+
+  it('reports replacement independently from its lifecycle state', function() {
+    const view = new TestView();
+    region.replaceElement = true;
+
+    expect(region.isReplaced()).to.be.false;
+    region.show(view);
+    expect(region.isReplaced()).to.be.true;
+    expect(region.hasView()).to.be.true;
+
+    expect(region.detachView()).to.equal(view);
+    expect(region.isReplaced()).to.be.false;
+    expect(region.hasView()).to.be.false;
+  });
+
+  it('destroys an occupied Region in public lifecycle order', function() {
+    const lifecycle = [];
+    const view = new TestView();
+    region.show(view);
+
+    region.on('before:destroy', currentRegion => {
+      lifecycle.push(`region:before:destroy:${currentRegion.isDestroyed()}`);
+    });
+    region.on('before:empty', currentRegion => {
+      lifecycle.push(`region:before:empty:${currentRegion.isDestroyed()}`);
+    });
+    view.on('before:destroy', () => lifecycle.push('view:before:destroy'));
+    view.on('destroy', () => lifecycle.push('view:destroy'));
+    region.on('empty', currentRegion => {
+      lifecycle.push(`region:empty:${currentRegion.isDestroyed()}`);
+    });
+    region.on('destroy', currentRegion => {
+      lifecycle.push(`region:destroy:${currentRegion.isDestroyed()}`);
+    });
+
+    region.destroy();
+
+    expect(lifecycle).to.deep.equal([
+      'region:before:destroy:false',
+      'region:before:empty:true',
+      'view:before:destroy',
+      'view:destroy',
+      'region:empty:true',
+      'region:destroy:true',
+    ]);
+    expect(region.hasView()).to.be.false;
+    expect(region.isDestroyed()).to.be.true;
+  });
+
+  it('clears the Region once when its current View is destroyed externally', function() {
+    const view = new TestView();
+    const beforeEmpty = this.sinon.spy();
+    const empty = this.sinon.spy();
+
+    region.on('before:empty', beforeEmpty);
+    region.on('empty', empty);
+    region.show(view);
+
+    view.destroy();
+    view.destroy();
+
+    expect(beforeEmpty).to.have.been.calledOnceWith(region, view);
+    expect(empty).to.have.been.calledOnceWith(region, view);
+    expect(region.hasView()).to.be.false;
+    expect(region.currentView).to.be.undefined;
+  });
+});


### PR DESCRIPTION
Related #131

## What
- Document the public Region lifecycle states and operation transitions.
- Define repeated show, detach, empty, replacement, external View destruction, and Region destruction behavior.
- Add six executable transition-contract tests covering state, ordering, idempotence, swapping, replacement, and teardown.

## Why
Agents currently have to infer Region lifecycle behavior from distributed implementation details and individual tests. This gives issue #131 a compact public transition table backed by one focused executable contract.

## Scope
- Documentation and tests for Region lifecycle behavior.
- No runtime, public API, Application lifecycle, package, release, or website publication changes.
- Post-destroy operations other than repeated destroy remain intentionally outside this slice.

## Deployment Impact
No application, package, documentation-site, or form redeploy is needed. This PR does not publish the website.

## Testing
- npx vitest run test/unit/region.spec.js test/unit/region-lifecycle.spec.js test/unit/region-el-validation.spec.js --coverage.enabled=false (128 passed)
- npx vitest run test/unit/region-lifecycle.spec.js --coverage.enabled=false (6 passed after final edits)
- npm run lint:ci
- npm run docs:check (29 pages, 30 HTML files, 288 internal links)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Region lifecycle contract and backs it with executable tests, so agents no longer have to infer state transitions from scattered implementation details. Addresses the documentation gap from #131.

- Adds a lifecycle transition table and operation semantics for `show`, `detachView`, `empty`, external View destruction, missing-element handling, and `destroy` to `docs/marionette.region.md`.
- Adds seven contract tests in `test/unit/region-lifecycle.spec.js` covering state ordering, idempotence, swapping, replacement, missing-element handling, and teardown.
- No runtime, API, package, or release changes. Post-destroy operations other than repeated `destroy()` remain unsupported.

<sup>Written for commit 2736849441aff603e48c630ba1e53fc612d84df4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a lifecycle guide for regions, covering empty, occupied, detached, and destroyed states.
  * Documented supported operations, view detachment responsibilities, missing-element handling, and temporary view-swapping behavior.

* **Tests**
  * Added coverage for region state transitions, repeated operations, view replacement, event ordering, and external view destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->