### PR TITLE
test(lifecycle): specify CollectionView state transitions

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -123,9 +123,34 @@ the child views that may have previously been added.
 
 ## View Lifecycle and Events
 
-An instantiated `CollectionView` is aware of its lifecycle state and will throw events related
-to when that state changes. The view states indicate whether the view is rendered, attached to
-the DOM, or destroyed.
+Like `View`, a `CollectionView` exposes its lifecycle as the independent
+`isRendered()`, `isAttached()`, and `isDestroyed()` state values. Its managed
+children have their own View lifecycle state. Existing contents in the
+`CollectionView` element do not make the `CollectionView` rendered; rendering
+means its child set has been built and inserted into its element.
+
+The table describes the default rendered and monitored path. Passing
+`{ preventRender: true }` to `addChildView` still renders the parent when
+needed, but manages the supplied child without rendering it; detaching that
+child returns it in its current lifecycle state. Setting
+`monitorViewEvents: false` intentionally disables child attachment events and
+automatic child `isAttached()` updates.
+
+| Operation | CollectionView state | Managed child state |
+| --- | --- | --- |
+| Construct | Starts not rendered and not destroyed. It is attached only when its element is already in the document. | No children have been built. |
+| `render()` | Enters rendered and preserves its attached state. Repeated render stays rendered. | Builds and renders the current children. Repeated render destroys the previous children before building replacements. |
+| A rendered collection resets | Remains rendered and preserves its attached state. | Destroys the previous children and builds replacements for the reset collection. |
+| `addChildView(view)` | Renders first when needed, then remains rendered. | Renders and manages the added View. |
+| `detachChildView(view)` | State is unchanged. | Removes and returns the live View in a detached state. The caller becomes responsible for it. |
+| `removeChildView(view)` or external child destruction | State is unchanged. | Removes the child from the managed set. `removeChildView` destroys it; an externally destroyed child is removed once. |
+| The owning Region detaches and re-shows the CollectionView | Remains rendered while attached changes to `false`, then back to `true`. | Live children follow the parent's detached and attached state. |
+| `destroy()` | Detaches, becomes not rendered, and enters destroyed. Repeated destroy returns the CollectionView without repeating lifecycle events. | Detaches and destroys every still-managed child after the parent element is removed. |
+
+A View returned by `detachChildView()` is no longer managed by the
+`CollectionView`; another owner may show it, or the caller must destroy it.
+Operations on an already destroyed `CollectionView`, other than repeated
+`destroy()`, are not part of this lifecycle contract.
 
 Read More:
 - [View Lifecycle](./view.lifecycle.md)

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -133,8 +133,8 @@ The table describes the default rendered and monitored path. Passing
 `{ preventRender: true }` to `addChildView` still renders the parent when
 needed, but manages the supplied child without rendering it; detaching that
 child returns it in its current lifecycle state. Setting
-`monitorViewEvents: false` intentionally disables child attachment events and
-automatic child `isAttached()` updates.
+`monitorViewEvents: false` on the `CollectionView` intentionally disables child
+attachment events and automatic child `isAttached()` updates.
 
 | Operation | CollectionView state | Managed child state |
 | --- | --- | --- |

--- a/test/unit/collection-view/collection-view-lifecycle.spec.js
+++ b/test/unit/collection-view/collection-view-lifecycle.spec.js
@@ -160,6 +160,36 @@ describe('CollectionView lifecycle contract', function() {
     region.destroy();
   });
 
+  it('leaves child attachment state unmonitored when parent monitoring is disabled', function() {
+    this.setFixtures('<div id="unmonitored-region"></div>');
+    const collectionView = new CollectionView();
+    const region = new Region({ el: '#unmonitored-region' });
+    const child = new ChildView();
+    const beforeAttach = this.sinon.spy();
+    const attach = this.sinon.spy();
+    child.on('before:attach', beforeAttach);
+    child.on('attach', attach);
+    region.show(collectionView);
+    collectionView.monitorViewEvents = false;
+
+    collectionView.addChildView(child);
+
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(state(child)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(beforeAttach).to.not.be.called;
+    expect(attach).to.not.be.called;
+
+    region.destroy();
+  });
+
   it('releases detached and externally destroyed children once', function() {
     this.setFixtures('<div id="managed-region"></div>');
     const collectionView = new CollectionView();

--- a/test/unit/collection-view/collection-view-lifecycle.spec.js
+++ b/test/unit/collection-view/collection-view-lifecycle.spec.js
@@ -1,0 +1,279 @@
+import Backbone from 'backbone';
+
+import CollectionView from '../../../modules/collection-view';
+import Region from '../../../modules/region';
+import View from '../../../modules/view';
+
+function state(view) {
+  return {
+    rendered: view.isRendered(),
+    attached: view.isAttached(),
+    destroyed: view.isDestroyed(),
+  };
+}
+
+function childStates(collectionView) {
+  return collectionView.children.map(state);
+}
+
+describe('CollectionView lifecycle contract', function() {
+  const ChildView = View.extend({
+    template() {
+      return '<span>Child</span>';
+    },
+  });
+
+  const constructionStates = [
+    {
+      name: 'generated empty detached element',
+      create() {
+        return new CollectionView();
+      },
+      expected: { rendered: false, attached: false, destroyed: false },
+    },
+    {
+      name: 'empty attached element',
+      create(context) {
+        context.setFixtures('<div id="empty-attached"></div>');
+        return new CollectionView({ el: document.querySelector('#empty-attached') });
+      },
+      expected: { rendered: false, attached: true, destroyed: false },
+    },
+    {
+      name: 'populated detached element',
+      create() {
+        const el = document.createElement('div');
+        el.innerHTML = '<span>Existing content</span>';
+        return new CollectionView({ el });
+      },
+      expected: { rendered: false, attached: false, destroyed: false },
+    },
+    {
+      name: 'populated attached element',
+      create(context) {
+        context.setFixtures('<div id="populated-attached"><span>Existing content</span></div>');
+        return new CollectionView({ el: document.querySelector('#populated-attached') });
+      },
+      expected: { rendered: false, attached: true, destroyed: false },
+    },
+  ];
+
+  for (const scenario of constructionStates) {
+    it(`exposes the ${scenario.name} state vector`, function() {
+      const collectionView = scenario.create(this);
+
+      expect(state(collectionView)).to.deep.equal(scenario.expected);
+      expect(collectionView.children).to.have.lengthOf(0);
+
+      collectionView.destroy();
+    });
+  }
+
+  it('follows the normal Region-managed transition sequence', function() {
+    this.setFixtures('<div id="collection-region"></div>');
+    const collection = new Backbone.Collection([{ id: 1 }, { id: 2 }]);
+    const collectionView = new CollectionView({ collection, childView: ChildView });
+    const region = new Region({ el: '#collection-region' });
+
+    expect(state(collectionView)).to.deep.equal({
+      rendered: false,
+      attached: false,
+      destroyed: false,
+    });
+
+    expect(region.show(collectionView)).to.equal(region);
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(childStates(collectionView)).to.deep.equal([
+      { rendered: true, attached: true, destroyed: false },
+      { rendered: true, attached: true, destroyed: false },
+    ]);
+
+    const firstChildren = collectionView.children.toArray();
+    expect(collectionView.render()).to.equal(collectionView);
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(firstChildren.every(child => child.isDestroyed())).to.be.true;
+    expect(collectionView.children.toArray()).to.not.deep.equal(firstChildren);
+    expect(childStates(collectionView)).to.deep.equal([
+      { rendered: true, attached: true, destroyed: false },
+      { rendered: true, attached: true, destroyed: false },
+    ]);
+
+    const secondChildren = collectionView.children.toArray();
+    expect(region.detachView()).to.equal(collectionView);
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(childStates(collectionView)).to.deep.equal([
+      { rendered: true, attached: false, destroyed: false },
+      { rendered: true, attached: false, destroyed: false },
+    ]);
+
+    expect(region.show(collectionView)).to.equal(region);
+    expect(collectionView.children.toArray()).to.deep.equal(secondChildren);
+    expect(childStates(collectionView)).to.deep.equal([
+      { rendered: true, attached: true, destroyed: false },
+      { rendered: true, attached: true, destroyed: false },
+    ]);
+
+    region.empty();
+    expect(state(collectionView)).to.deep.equal({
+      rendered: false,
+      attached: false,
+      destroyed: true,
+    });
+    expect(secondChildren.every(child => child.isDestroyed())).to.be.true;
+
+    region.destroy();
+  });
+
+  it('replaces children on collection reset without changing parent state', function() {
+    this.setFixtures('<div id="reset-region"></div>');
+    const collection = new Backbone.Collection([{ id: 1 }, { id: 2 }]);
+    const collectionView = new CollectionView({ collection, childView: ChildView });
+    const region = new Region({ el: '#reset-region' });
+    region.show(collectionView);
+    const previousChildren = collectionView.children.toArray();
+
+    collection.reset([{ id: 3 }]);
+
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(previousChildren.every(child => child.isDestroyed())).to.be.true;
+    expect(collectionView.children).to.have.lengthOf(1);
+    expect(childStates(collectionView)).to.deep.equal([
+      { rendered: true, attached: true, destroyed: false },
+    ]);
+
+    region.destroy();
+  });
+
+  it('releases detached and externally destroyed children once', function() {
+    this.setFixtures('<div id="managed-region"></div>');
+    const collectionView = new CollectionView();
+    const region = new Region({ el: '#managed-region' });
+    const detachedChild = new ChildView();
+    const removedChild = new ChildView();
+    const destroyedChild = new ChildView();
+    let beforeDestroyedChildRemoval = 0;
+    let destroyedChildRemoval = 0;
+
+    collectionView.on('before:remove:child', (owner, child) => {
+      if (child === destroyedChild) {
+        expect(owner).to.equal(collectionView);
+        beforeDestroyedChildRemoval += 1;
+      }
+    });
+    collectionView.on('remove:child', (owner, child) => {
+      if (child === destroyedChild) {
+        expect(owner).to.equal(collectionView);
+        destroyedChildRemoval += 1;
+      }
+    });
+
+    expect(collectionView.addChildView(detachedChild)).to.equal(detachedChild);
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(state(detachedChild)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+
+    region.show(collectionView);
+    collectionView.addChildView(removedChild);
+    collectionView.addChildView(destroyedChild);
+
+    expect(collectionView.detachChildView(detachedChild)).to.equal(detachedChild);
+    expect(state(detachedChild)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(collectionView.children.hasView(detachedChild)).to.be.false;
+
+    expect(collectionView.removeChildView(removedChild)).to.equal(removedChild);
+    expect(removedChild.isDestroyed()).to.be.true;
+    expect(collectionView.children.hasView(removedChild)).to.be.false;
+
+    destroyedChild.destroy();
+    destroyedChild.destroy();
+    expect(collectionView.children.hasView(destroyedChild)).to.be.false;
+    expect(beforeDestroyedChildRemoval).to.equal(1);
+    expect(destroyedChildRemoval).to.equal(1);
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+
+    detachedChild.destroy();
+    region.destroy();
+  });
+
+  it('destroys managed children after detaching the parent and only once', function() {
+    this.setFixtures('<div id="destroy-region"></div>');
+    const collection = new Backbone.Collection([{ id: 1 }]);
+    const collectionView = new CollectionView({ collection, childView: ChildView });
+    const region = new Region({ el: '#destroy-region' });
+    const lifecycle = [];
+    region.show(collectionView);
+    const child = collectionView.children.first();
+
+    collectionView.on('before:destroy', () => lifecycle.push('parent:before:destroy'));
+    child.on('before:detach', () => lifecycle.push('child:before:detach'));
+    child.on('detach', () => lifecycle.push('child:detach'));
+    collectionView.on('before:destroy:children', () => {
+      expect(collectionView.isAttached()).to.be.false;
+      expect(child.isAttached()).to.be.false;
+      lifecycle.push('parent:before:destroy:children');
+    });
+    child.on('before:destroy', () => lifecycle.push('child:before:destroy'));
+    child.on('destroy', () => lifecycle.push('child:destroy'));
+    collectionView.on('destroy:children', () => lifecycle.push('parent:destroy:children'));
+    collectionView.on('destroy', () => lifecycle.push('parent:destroy'));
+
+    expect(collectionView.destroy()).to.equal(collectionView);
+    expect(collectionView.destroy()).to.equal(collectionView);
+
+    expect(lifecycle).to.deep.equal([
+      'parent:before:destroy',
+      'child:before:detach',
+      'child:detach',
+      'parent:before:destroy:children',
+      'child:before:destroy',
+      'child:destroy',
+      'parent:destroy:children',
+      'parent:destroy',
+    ]);
+    expect(state(collectionView)).to.deep.equal({
+      rendered: false,
+      attached: false,
+      destroyed: true,
+    });
+    expect(state(child)).to.deep.equal({
+      rendered: false,
+      attached: false,
+      destroyed: true,
+    });
+    expect(collectionView.children).to.have.lengthOf(0);
+    expect(region.hasView()).to.be.false;
+
+    region.destroy();
+  });
+});


### PR DESCRIPTION
Related #131

## What

- Define the observable CollectionView lifecycle state table for the parent and its managed children.
- Add executable transition coverage for construction, render and rerender, Region detach and re-show, collection reset, explicit child detach/removal, external child destruction, and repeated parent destruction.
- Document default monitoring behavior plus the preventRender and monitorViewEvents exceptions.

## Why

View and Region now have explicit lifecycle contracts, but CollectionView still combined parent state, child ownership, and child lifecycle implicitly. Agents need a compact contract and executable examples before runtime ownership work proceeds.

## Scope

- Changes only the CollectionView reference documentation and one new lifecycle contract spec.
- Records current public behavior; no runtime, distribution, diagnostic, package, or API implementation changes.
- Leaves post-destroy operations other than repeated destroy, reentrant behavior, filters, Behavior ownership, and Application semantics for later #131 work.

## Deployment Impact

No application, website, documentation deployment, npm publication, or release tag is performed. This PR changes repository documentation and tests only.

## Testing

- npx vitest run test/unit/view-lifecycle.spec.js test/unit/region-lifecycle.spec.js test/unit/collection-view --coverage.enabled=false — 11 files, 307 tests passed.
- npm run docs:check — 29 pages built; 30 HTML files and 288 internal links validated.
- npm run lint:ci
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and tests the CollectionView lifecycle contract, specifying state transitions for the parent view and its managed children for #131. This is a test and documentation-only change; no runtime behavior changes.

Covers construction, render, Region detach/re-show, collection reset, child add/detach/removal, external child destruction, and repeated parent destruction, plus the `preventRender` and `monitorViewEvents: false` exceptions. Leaves post-destroy operations, reentrant behavior, filters, Behavior ownership, and Application semantics for later #131 work.

<sup>Written for commit 5e29a822d1b5fd915b2daa815d63dd1206629a81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

