### PR TITLE
test(lifecycle): specify host-managed Behavior transitions

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -423,7 +423,10 @@ State lifecycle to Behavior.
 
 If a Region's owning view sets `monitorViewEvents: false`, the shown host does not
 receive attachment lifecycle notifications, so its Behaviors do not receive them
-either.
+either. Separately, setting `monitorViewEvents: false` on the host itself does not
+by itself suppress Region attachment lifecycle. It suppresses the host's
+`dom:refresh` and `dom:remove` notifications, so its Behaviors do not receive those
+notifications.
 
 ## Destroying a Behavior
 

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -29,6 +29,7 @@ Instead a `Behavior` should be instantiated by the view it is related to by
   * [Events / Initialize Order](#events--initialize-order)
   * [Using `ui`](#using-ui)
   * [View DOM proxies](#view-dom-proxies)
+* [Behavior Lifecycle](#behavior-lifecycle)
 * [Destroying a Behavior](#destroying-a-behavior)
 
 
@@ -396,6 +397,33 @@ const ViewBehavior = Behavior.extend({
 **Note** in rare cases when a view's `el` is modified via `setElement` if utilizing
 these proxies they will need to be manually updated by calling
 `myBehavior.proxyViewProperties();`
+
+## Behavior Lifecycle
+
+A `Behavior` has a host-managed lifetime rather than the independent rendered,
+attached, and destroyed state exposed by a View. In this table, the host view is
+either a `View` or `CollectionView`. It constructs its Behaviors, keeps the same
+instances through render and attachment transitions, and cleans them up when it
+is destroyed. Nested Behaviors participate as Behaviors of the same host view.
+
+| Operation | Host view | Behavior |
+| --- | --- | --- |
+| Construct the View | Constructs each Behavior before the View's `initialize`. | Receives its `view` and runs its own `initialize`; after the View initializes, receives the View's `initialize` notification. |
+| Render or re-render the View | Runs each View lifecycle callback first. | The same instance receives the corresponding lifecycle callback after the View. |
+| Show, detach, or re-show the host through a Region with lifecycle monitoring enabled | Changes the host's attachment state. | The same instance receives the corresponding attachment lifecycle after the host. |
+| First direct `behavior.destroy()` while the View is alive | Remains alive without the removed Behavior. | Undelegates its events, stops listening, removes itself from the View, and deletes its entity-event handlers. It receives no later host lifecycle notifications. |
+| Destroy the View | Runs `before:destroy`, tears down the View, and runs its `destroy` callback. Repeated View destruction is a no-op. | Receives `before:destroy` while the View is alive, is cleaned up after the View enters destroyed, then receives `destroy` after the View's callback. Nested Behaviors follow the same ordering. |
+
+`Behavior` does not expose an independent `isDestroyed()` state. Repeated direct
+`behavior.destroy()` calls, reuse after direct cleanup, and other post-cleanup
+operations are outside this lifecycle contract. UI capture and collision rules,
+dependency access, invalid references, and dynamic replacement semantics are also
+separate Behavior contract decisions; this table does not add an Application or
+State lifecycle to Behavior.
+
+If a Region's owning view sets `monitorViewEvents: false`, the shown host does not
+receive attachment lifecycle notifications, so its Behaviors do not receive them
+either.
 
 ## Destroying a Behavior
 

--- a/test/unit/behavior-lifecycle.spec.js
+++ b/test/unit/behavior-lifecycle.spec.js
@@ -1,0 +1,260 @@
+import Backbone from 'backbone';
+
+import Behavior from '../../modules/behavior';
+import Region from '../../modules/region';
+import View from '../../modules/view';
+
+describe('Behavior lifecycle contract', function() {
+  it('initializes around its host View in public lifecycle order', function() {
+    const lifecycle = [];
+    let behavior;
+
+    const TestBehavior = Behavior.extend({
+      initialize(options, hostView) {
+        behavior = this;
+        expect(this.view).to.equal(hostView);
+        lifecycle.push('behavior:initialize');
+      },
+      onInitialize() {
+        lifecycle.push('behavior:onInitialize');
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      initialize() {
+        lifecycle.push('view:initialize');
+      },
+    });
+
+    const view = new TestView();
+
+    expect(lifecycle).to.deep.equal([
+      'behavior:initialize',
+      'view:initialize',
+      'behavior:onInitialize',
+    ]);
+    expect(behavior.view).to.equal(view);
+    expect(behavior.el).to.equal(view.el);
+
+    view.destroy();
+  });
+
+  it('keeps one instance through render and attachment transitions', function() {
+    this.setFixtures('<div id="behavior-region"></div>');
+    const lifecycle = [];
+    let behavior;
+
+    const TestBehavior = Behavior.extend({
+      initialize() {
+        behavior = this;
+        lifecycle.push('behavior:initialize');
+      },
+      onBeforeRender() {
+        lifecycle.push('behavior:before:render');
+      },
+      onRender() {
+        lifecycle.push('behavior:render');
+      },
+      onBeforeAttach() {
+        lifecycle.push('behavior:before:attach');
+      },
+      onAttach() {
+        lifecycle.push('behavior:attach');
+      },
+      onBeforeDetach() {
+        lifecycle.push('behavior:before:detach');
+      },
+      onDetach() {
+        lifecycle.push('behavior:detach');
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        return '<span>content</span>';
+      },
+      onBeforeRender() {
+        lifecycle.push('view:before:render');
+      },
+      onRender() {
+        lifecycle.push('view:render');
+      },
+      onBeforeAttach() {
+        lifecycle.push('view:before:attach');
+      },
+      onAttach() {
+        lifecycle.push('view:attach');
+      },
+      onBeforeDetach() {
+        lifecycle.push('view:before:detach');
+      },
+      onDetach() {
+        lifecycle.push('view:detach');
+      },
+    });
+    const view = new TestView();
+    const initialBehavior = behavior;
+    const region = new Region({ el: '#behavior-region' });
+    lifecycle.length = 0;
+
+    region.show(view);
+    view.render();
+    region.detachView();
+    region.show(view);
+
+    expect(behavior).to.equal(initialBehavior);
+    expect(lifecycle).to.deep.equal([
+      'view:before:render',
+      'behavior:before:render',
+      'view:render',
+      'behavior:render',
+      'view:before:attach',
+      'behavior:before:attach',
+      'view:attach',
+      'behavior:attach',
+      'view:before:render',
+      'behavior:before:render',
+      'view:render',
+      'behavior:render',
+      'view:before:detach',
+      'behavior:before:detach',
+      'view:detach',
+      'behavior:detach',
+      'view:before:attach',
+      'behavior:before:attach',
+      'view:attach',
+      'behavior:attach',
+    ]);
+
+    region.destroy();
+  });
+
+  it('stops host, entity, and DOM participation after direct cleanup', function() {
+    const model = new Backbone.Model();
+    const hostEvent = this.sinon.spy();
+    const modelEvent = this.sinon.spy();
+    const domEvent = this.sinon.spy();
+    const beforeDestroy = this.sinon.spy();
+    const destroy = this.sinon.spy();
+    let behavior;
+
+    const TestBehavior = Behavior.extend({
+      events: {
+        'click .action': 'onAction',
+      },
+      modelEvents: {
+        change: 'onModelChange',
+      },
+      initialize() {
+        behavior = this;
+      },
+      onAction: domEvent,
+      onModelChange: modelEvent,
+      onHostEvent: hostEvent,
+      onBeforeDestroy: beforeDestroy,
+      onDestroy: destroy,
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        return '<button class="action">Action</button>';
+      },
+    });
+    const view = new TestView({ model });
+    view.render();
+
+    view.triggerMethod('host:event');
+    model.set('value', 1);
+    view.el.querySelector('.action').click();
+    expect(hostEvent).to.have.been.calledOnce;
+    expect(modelEvent).to.have.been.calledOnce;
+    expect(domEvent).to.have.been.calledOnce;
+
+    this.sinon.spy(behavior, 'stopListening');
+    expect(behavior.destroy()).to.equal(behavior);
+
+    view.triggerMethod('host:event');
+    model.set('value', 2);
+    view.el.querySelector('.action').click();
+    view.destroy();
+
+    expect(hostEvent).to.have.been.calledOnce;
+    expect(modelEvent).to.have.been.calledOnce;
+    expect(domEvent).to.have.been.calledOnce;
+    expect(beforeDestroy).to.not.have.been.called;
+    expect(destroy).to.not.have.been.called;
+    expect(behavior.stopListening).to.have.been.calledOnce;
+  });
+
+  it('cleans up top-level and nested Behaviors once in host destroy order', function() {
+    this.setFixtures('<div id="destroy-region"></div>');
+    const lifecycle = [];
+    const behaviors = [];
+
+    const NestedBehavior = Behavior.extend({
+      initialize() {
+        behaviors.push(this);
+      },
+      onBeforeDestroy(view) {
+        expect(view.isDestroyed()).to.be.false;
+        lifecycle.push('nested:before:destroy');
+      },
+      onDestroy(view) {
+        expect(view.isDestroyed()).to.be.true;
+        lifecycle.push('nested:destroy');
+      },
+    });
+    const ParentBehavior = Behavior.extend({
+      behaviors: [NestedBehavior],
+      initialize() {
+        behaviors.push(this);
+      },
+      onBeforeDestroy(view) {
+        expect(view.isDestroyed()).to.be.false;
+        lifecycle.push('parent:before:destroy');
+      },
+      onDestroy(view) {
+        expect(view.isDestroyed()).to.be.true;
+        lifecycle.push('parent:destroy');
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [ParentBehavior],
+      template() {
+        return '<span>content</span>';
+      },
+      onBeforeDestroy() {
+        lifecycle.push('view:before:destroy');
+      },
+      onDestroy() {
+        lifecycle.push('view:destroy');
+      },
+    });
+    const view = new TestView();
+    const region = new Region({ el: '#destroy-region' });
+    region.show(view);
+    const parentBehavior = behaviors[0];
+    const nestedBehavior = behaviors[1];
+    expect(parentBehavior.view).to.equal(view);
+    expect(nestedBehavior.view).to.equal(view);
+    this.sinon.spy(parentBehavior, 'stopListening');
+    this.sinon.spy(nestedBehavior, 'stopListening');
+
+    expect(view.destroy()).to.equal(view);
+    expect(view.destroy()).to.equal(view);
+
+    expect(lifecycle).to.deep.equal([
+      'view:before:destroy',
+      'parent:before:destroy',
+      'nested:before:destroy',
+      'view:destroy',
+      'parent:destroy',
+      'nested:destroy',
+    ]);
+    expect(parentBehavior.stopListening).to.have.been.calledOnce;
+    expect(nestedBehavior.stopListening).to.have.been.calledOnce;
+    expect(region.hasView()).to.be.false;
+
+    region.destroy();
+  });
+});


### PR DESCRIPTION
Related #131

## What

- Define the host-managed Behavior lifecycle for View and CollectionView hosts.
- Add executable ordering coverage for construction, render and rerender, Region attachment transitions, direct cleanup, nested Behaviors, host destruction, and repeated host destruction.
- Document lifecycle-monitoring behavior and explicitly defer ambiguous direct-repeat and reuse semantics.

## Why

Behavior lifecycle is currently distributed across host construction, proxied lifecycle events, entity and DOM delegation, nested Behavior flattening, and host teardown. Agents need one compact contract before later Behavior diagnostics and dependency work in #133.

## Scope

- Changes only the Behavior reference documentation and one new lifecycle contract spec.
- Records current public behavior; no runtime, distribution, diagnostic, package, or API implementation changes.
- Does not add Behavior isDestroyed state or define repeated direct destroy, post-cleanup reuse, UI collisions, dependency access, invalid references, dynamic replacement, Application, or State semantics.

## Deployment Impact

No application, website, documentation deployment, npm publication, or release tag is performed. This PR changes repository documentation and tests only.

## Testing

- npx vitest run test/unit/behavior-lifecycle.spec.js test/unit/behavior.spec.js test/unit/mixins/behaviors.spec.js --coverage.enabled=false — 3 files, 82 tests passed.
- npm run docs:check — 29 pages built; 30 HTML files and 288 internal links validated.
- npm run lint:ci
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and tests the host-managed Behavior lifecycle for View and CollectionView hosts, giving agents a single contract to rely on before Behavior diagnostics work in #133. Relates to #131.

- Records the current lifecycle ordering for construction, render, Region attachment and its `monitorViewEvents` interaction, direct cleanup, nested Behaviors, and repeated host destruction.
- Adds a new spec covering those transitions; no runtime, API, or distribution behavior changes.
- Deliberately defers direct-repeat destroy, reuse after cleanup, UI collisions, dependency access, dynamic replacement, and Application/State semantics.

<sup>Written for commit f5e5fe91fbb09fef2b122328edcca1274d6bb569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

