### PR TITLE
test(agent-benchmark): define public corpus contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Verify diagnostic catalog
         run: npm run check:diagnostics
 
-      - name: Test agent benchmark contract
-        run: npm run test:agent-benchmark-contract
-
       - name: Test performance contract
         run: npm run test:performance
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Verify diagnostic catalog
         run: npm run check:diagnostics
 
+      - name: Test agent benchmark contract
+        run: npm run test:agent-benchmark-contract
+
       - name: Test performance contract
         run: npm run test:performance
 

--- a/benchmarks/agent/README.md
+++ b/benchmarks/agent/README.md
@@ -12,7 +12,7 @@ repository-root-relative paths:
 - `promptPath` names the public instructions supplied to the agent.
 - `workspacePath` names the original fixture copied into a fresh workspace for one
   attempt.
-- `acceptance.hiddenTests` maps each public acceptance-test source to a target inside
+- `acceptance.hiddenTests` maps each hidden acceptance-test source to a target inside
   the fresh workspace. The harness withholds those sources until the agent has
   finished, then copies them to their targets without overwriting fixture files.
 - `acceptance.command` is an argument array that the harness runs without a shell after

--- a/benchmarks/agent/README.md
+++ b/benchmarks/agent/README.md
@@ -1,0 +1,48 @@
+# Agent benchmark task contract
+
+This directory defines the repository-owned contract for Marionette's public agent
+benchmark tasks. It does not contain a corpus, benchmark profile, evaluator results,
+or a Phase 0 baseline yet.
+
+## Task isolation
+
+Each task is metadata validated by `task.schema.json`. Paths are portable,
+repository-root-relative paths:
+
+- `promptPath` names the public instructions supplied to the agent.
+- `workspacePath` names the original fixture copied into a fresh workspace for one
+  attempt.
+- `acceptance.hiddenTests` maps each public acceptance-test source to a target inside
+  the fresh workspace. The harness withholds those sources until the agent has
+  finished, then copies them to their targets without overwriting fixture files.
+- `acceptance.command` is an argument array that the harness runs without a shell after
+  installing the hidden tests, with the fresh workspace as its working directory.
+
+If an acceptance target exists after the attempt, the harness treats the attempt as
+incorrect instead of overwriting agent work.
+
+The contract validator and its filesystem-isolation cases run in CI through
+`npm run test:agent-benchmark-contract`.
+
+Hidden tests are hidden from the agent during an attempt, not from repository users.
+They must remain outside the agent-visible fixture tree in this repository. Every
+workspace tree is symlink-free so it cannot expose withheld files indirectly. Every
+attempt starts from a clean copy, and benchmark fixtures and tests may use only public
+Marionette package entrypoints and APIs.
+
+An evaluator may mark an attempt fully correct only when all acceptance checks pass.
+An aborted attempt remains an attempted, incorrect run. Architecture violations use
+codes from the shared diagnostic catalog and still count when discovered before an
+abort.
+
+## Capability coverage
+
+`capabilities.json` is the canonical vocabulary derived from the capability areas in
+ROADMAP.md and issue #128. A complete corpus contains at least ten real tasks and
+exercises every capability through at least two independently scored tasks. One task
+may exercise several capabilities, but no single task certifies a capability.
+
+The initial contract deliberately does not select a model or harness, set run counts
+or budgets, define a fallback, or claim benchmark completeness. Those decisions and
+the corpus, profile, evaluator, pilot, results, and rerun instructions are separate
+follow-up evidence.

--- a/benchmarks/agent/README.md
+++ b/benchmarks/agent/README.md
@@ -27,8 +27,10 @@ The contract validator and its filesystem-isolation cases run in CI through
 Hidden tests are hidden from the agent during an attempt, not from repository users.
 They must remain outside the agent-visible fixture tree in this repository. Every
 workspace tree is symlink-free so it cannot expose withheld files indirectly. Every
-attempt starts from a clean copy, and benchmark fixtures and tests may use only public
-Marionette package entrypoints and APIs.
+hidden source must also be distinct from every corpus prompt and every file in every
+visible workspace, including through symbolic-link and hard-link aliases. Every attempt
+starts from a clean copy, and benchmark fixtures and tests may use only public Marionette
+package entrypoints and APIs.
 
 An evaluator may mark an attempt fully correct only when all acceptance checks pass.
 An aborted attempt remains an attempted, incorrect run. Architecture violations use

--- a/benchmarks/agent/capabilities.json
+++ b/benchmarks/agent/capabilities.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "coverage": {
+    "minimumTasks": 10,
+    "minimumIndependentTasksPerCapability": 2
+  },
+  "capabilities": [
+    {
+      "id": "application-state-composition",
+      "description": "Compose Application-owned local State without confusing it with external domain data."
+    },
+    {
+      "id": "async-startup-and-teardown",
+      "description": "Handle asynchronous startup, invalidation, teardown, and cleanup deterministically."
+    },
+    {
+      "id": "behavior",
+      "description": "Add and manage Behavior concerns with explicit host scope and teardown."
+    },
+    {
+      "id": "collection-view",
+      "description": "Implement CollectionView child work through public collection and child-view contracts."
+    },
+    {
+      "id": "communication",
+      "description": "Use explicit communication boundaries between independently owned objects."
+    },
+    {
+      "id": "invalid-cases",
+      "description": "Reject or repair invalid framework usage through documented public contracts."
+    },
+    {
+      "id": "nested-application-ownership",
+      "description": "Compose nested Applications with explicit lifecycle and ownership."
+    },
+    {
+      "id": "nested-regions",
+      "description": "Compose nested Regions without bypassing Region-owned rendering and teardown."
+    },
+    {
+      "id": "plain-view",
+      "description": "Implement a stateless View without unnecessary application or state machinery."
+    },
+    {
+      "id": "resource-ownership-and-cleanup",
+      "description": "Own and release resources, listeners, subscriptions, and disposable work."
+    },
+    {
+      "id": "role-selection",
+      "description": "Choose correctly among a plain class, optional MnObject, and Application."
+    },
+    {
+      "id": "shared-overlay-host",
+      "description": "Display Views through a shared host Region while keeping positioning and exclusivity outside core."
+    },
+    {
+      "id": "state-vs-domain-data",
+      "description": "Keep owner-local State distinct from external model, collection, or domain data."
+    },
+    {
+      "id": "view-state-composition",
+      "description": "Compose View-owned local State while preserving View lifecycle boundaries."
+    }
+  ]
+}

--- a/benchmarks/agent/task.schema.json
+++ b/benchmarks/agent/task.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Marionette agent benchmark task",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "title",
+    "promptPath",
+    "workspacePath",
+    "capabilities",
+    "acceptance"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "promptPath": {
+      "$ref": "#/definitions/repositoryPath"
+    },
+    "workspacePath": {
+      "$ref": "#/definitions/repositoryPath"
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "acceptance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "hiddenTests"
+      ],
+      "properties": {
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "hiddenTests": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sourcePath",
+              "targetPath"
+            ],
+            "properties": {
+              "sourcePath": {
+                "$ref": "#/definitions/repositoryPath"
+              },
+              "targetPath": {
+                "$ref": "#/definitions/repositoryPath"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "repositoryPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*$"
+    }
+  }
+}

--- a/config/agent-benchmark/task-contract.mjs
+++ b/config/agent-benchmark/task-contract.mjs
@@ -1,0 +1,305 @@
+import Ajv from 'ajv';
+import { lstat, readFile, readdir, realpath, stat } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const defaultCapabilities = JSON.parse(await readFile(
+  resolve(repositoryRoot, 'benchmarks/agent/capabilities.json'),
+  'utf8'
+));
+const defaultSchema = JSON.parse(await readFile(
+  resolve(repositoryRoot, 'benchmarks/agent/task.schema.json'),
+  'utf8'
+));
+
+export class AgentBenchmarkTaskContractError extends Error {
+  constructor(errors) {
+    super(errors.join('\n'));
+    this.name = 'AgentBenchmarkTaskContractError';
+    this.errors = errors;
+  }
+}
+
+function isWithin(parent, child) {
+  const childRelativePath = relative(parent, child);
+
+  return childRelativePath === '' ||
+    (childRelativePath !== '..' &&
+      !childRelativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(childRelativePath));
+}
+
+function validateCapabilityCatalog(catalog, errors) {
+  if (!catalog || Object.keys(catalog).sort().join(',') !== 'capabilities,coverage,schemaVersion') {
+    errors.push('capability catalog must contain only schemaVersion, coverage, and capabilities');
+  }
+
+  if (catalog?.schemaVersion !== 1) {
+    errors.push('capability catalog schemaVersion must be 1');
+  }
+
+  if (!catalog?.coverage ||
+    Object.keys(catalog.coverage).sort().join(',') !==
+      'minimumIndependentTasksPerCapability,minimumTasks') {
+    errors.push('capability catalog coverage must contain only the two minimum task fields');
+  }
+
+  if (catalog?.coverage?.minimumTasks !== 10) {
+    errors.push('capability catalog minimumTasks must be 10');
+  }
+
+  if (catalog?.coverage?.minimumIndependentTasksPerCapability !== 2) {
+    errors.push('capability catalog minimumIndependentTasksPerCapability must be 2');
+  }
+
+  if (!Array.isArray(catalog?.capabilities) || !catalog.capabilities.length) {
+    errors.push('capability catalog must contain capabilities');
+    return new Set();
+  }
+
+  const capabilityIds = catalog.capabilities.map(capability => capability?.id);
+  const sortedCapabilityIds = [...capabilityIds].sort();
+
+  if (capabilityIds.some(id => !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id || ''))) {
+    errors.push('capability ids must be lowercase slugs');
+  }
+
+  if (new Set(capabilityIds).size !== capabilityIds.length) {
+    errors.push('capability ids must be unique');
+  }
+
+  if (JSON.stringify(capabilityIds) !== JSON.stringify(sortedCapabilityIds)) {
+    errors.push('capability ids must be sorted');
+  }
+
+  for (const capability of catalog.capabilities) {
+    if (!capability || Object.keys(capability).sort().join(',') !== 'description,id' ||
+      typeof capability.description !== 'string' || !capability.description.trim()) {
+      errors.push(`capability ${capability?.id || '<unknown>'} must contain only id and a non-empty description`);
+    }
+  }
+
+  return new Set(capabilityIds);
+}
+
+async function validateReferencedPath({
+  expectedType,
+  label,
+  path,
+  rejectSymlink = false,
+  root,
+  realRoot,
+}, errors) {
+  const absolutePath = resolve(root, path);
+  let realPath;
+  let linkStat;
+  let pathStat;
+
+  if (!isWithin(root, absolutePath)) {
+    errors.push(`${label} must stay within the repository root: ${path}`);
+    return;
+  }
+
+  try {
+    [realPath, linkStat, pathStat] = await Promise.all([
+      realpath(absolutePath),
+      lstat(absolutePath),
+      stat(absolutePath),
+    ]);
+  } catch {
+    errors.push(`${label} does not exist: ${path}`);
+    return;
+  }
+
+  if (!isWithin(realRoot, realPath)) {
+    errors.push(`${label} resolves outside the repository root: ${path}`);
+    return;
+  }
+
+  if (rejectSymlink && linkStat.isSymbolicLink()) {
+    errors.push(`${label} must not be a symlink: ${path}`);
+  }
+
+  if (expectedType === 'file' && !pathStat.isFile()) {
+    errors.push(`${label} must be a file: ${path}`);
+  }
+
+  if (expectedType === 'directory' && !pathStat.isDirectory()) {
+    errors.push(`${label} must be a directory: ${path}`);
+  }
+
+  return realPath;
+}
+
+async function validateHiddenTarget({ taskId, targetPath, workspacePath }, errors) {
+  const absoluteTargetPath = resolve(workspacePath, targetPath);
+  const targetParentPath = dirname(absoluteTargetPath);
+  let realTargetParent;
+  let targetParentStat;
+
+  if (!isWithin(workspacePath, absoluteTargetPath)) {
+    errors.push(`${taskId} hidden test target must stay within workspacePath: ${targetPath}`);
+    return;
+  }
+
+  try {
+    [realTargetParent, targetParentStat] = await Promise.all([
+      realpath(targetParentPath),
+      stat(targetParentPath),
+    ]);
+  } catch {
+    errors.push(`${taskId} hidden test target parent does not exist: ${targetPath}`);
+    return;
+  }
+
+  if (!isWithin(workspacePath, realTargetParent)) {
+    errors.push(`${taskId} hidden test target parent resolves outside workspacePath: ${targetPath}`);
+    return;
+  }
+
+  if (!targetParentStat.isDirectory()) {
+    errors.push(`${taskId} hidden test target parent must be a directory: ${targetPath}`);
+    return;
+  }
+
+  try {
+    await lstat(absoluteTargetPath);
+    errors.push(`${taskId} hidden test target already exists in workspacePath: ${targetPath}`);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      errors.push(`${taskId} hidden test target cannot be inspected: ${targetPath}`);
+    }
+  }
+}
+
+async function addWorkspaceSymlinkErrors(taskId, workspacePath, errors, directory = workspacePath) {
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = resolve(directory, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      errors.push(`${taskId} workspacePath must not contain symlinks: ${relative(workspacePath, entryPath)}`);
+    } else if (entry.isDirectory()) {
+      await addWorkspaceSymlinkErrors(taskId, workspacePath, errors, entryPath);
+    }
+  }
+}
+
+/**
+ * Validate agent benchmark task metadata and its referenced repository paths.
+ *
+ * @param {object} options Validation options.
+ * @param {string} options.root Repository root containing the referenced paths.
+ * @param {object[]} options.tasks Task metadata objects.
+ * @param {object} [options.capabilities] Capability catalog override.
+ * @param {object} [options.schema] Task schema override.
+ * @returns {Promise<object[]>} The validated task metadata.
+ */
+export async function validateTaskContracts({
+  root,
+  tasks,
+  capabilities = defaultCapabilities,
+  schema = defaultSchema,
+}) {
+  const errors = [];
+  const absoluteRoot = resolve(root);
+  const realRoot = await realpath(absoluteRoot);
+  const knownCapabilities = validateCapabilityCatalog(capabilities, errors);
+  const validateTask = new Ajv({ allErrors: true }).compile(schema);
+
+  if (!Array.isArray(tasks)) {
+    throw new AgentBenchmarkTaskContractError([...errors, 'tasks must be an array']);
+  }
+
+  const taskIds = new Set();
+
+  for (const [index, task] of tasks.entries()) {
+    const taskLabel = task?.id || `task at index ${index}`;
+
+    if (!validateTask(task)) {
+      for (const validationError of validateTask.errors) {
+        errors.push(`${taskLabel}${validationError.instancePath || ''} ${validationError.message}`);
+      }
+      continue;
+    }
+
+    if (taskIds.has(task.id)) {
+      errors.push(`duplicate task id ${task.id}`);
+    }
+    taskIds.add(task.id);
+
+    const sortedCapabilities = [...task.capabilities].sort();
+    if (JSON.stringify(task.capabilities) !== JSON.stringify(sortedCapabilities)) {
+      errors.push(`${task.id} capabilities must be sorted`);
+    }
+
+    for (const capability of task.capabilities) {
+      if (!knownCapabilities.has(capability)) {
+        errors.push(`${task.id} uses unknown capability ${capability}`);
+      }
+    }
+
+    const promptPath = await validateReferencedPath({
+      expectedType: 'file',
+      label: `${task.id} promptPath`,
+      path: task.promptPath,
+      root: absoluteRoot,
+      realRoot,
+    }, errors);
+    const workspacePath = await validateReferencedPath({
+      expectedType: 'directory',
+      label: `${task.id} workspacePath`,
+      path: task.workspacePath,
+      rejectSymlink: true,
+      root: absoluteRoot,
+      realRoot,
+    }, errors);
+
+    if (workspacePath) {
+      await addWorkspaceSymlinkErrors(task.id, workspacePath, errors);
+    }
+
+    const hiddenTargetPaths = new Set();
+
+    for (const hiddenTest of task.acceptance.hiddenTests) {
+      const hiddenTestPath = hiddenTest.sourcePath;
+      const resolvedTestPath = await validateReferencedPath({
+        expectedType: 'file',
+        label: `${task.id} hidden test`,
+        path: hiddenTestPath,
+        root: absoluteRoot,
+        realRoot,
+      }, errors);
+
+      if (workspacePath && resolvedTestPath && isWithin(workspacePath, resolvedTestPath)) {
+        errors.push(`${task.id} hidden test must be outside workspacePath: ${hiddenTestPath}`);
+      }
+
+      if (promptPath && resolvedTestPath === promptPath) {
+        errors.push(`${task.id} hidden test must not also be promptPath: ${hiddenTestPath}`);
+      }
+
+      if (hiddenTargetPaths.has(hiddenTest.targetPath)) {
+        errors.push(`${task.id} hidden test target must be unique: ${hiddenTest.targetPath}`);
+      }
+      hiddenTargetPaths.add(hiddenTest.targetPath);
+
+      if (workspacePath) {
+        await validateHiddenTarget({
+          taskId: task.id,
+          targetPath: hiddenTest.targetPath,
+          workspacePath,
+        }, errors);
+      }
+    }
+
+  }
+
+  if (errors.length) {
+    throw new AgentBenchmarkTaskContractError(errors);
+  }
+
+  return tasks;
+}

--- a/config/agent-benchmark/task-contract.mjs
+++ b/config/agent-benchmark/task-contract.mjs
@@ -61,7 +61,9 @@ function validateCapabilityCatalog(catalog, errors) {
   const capabilityIds = catalog.capabilities.map(capability => capability?.id);
   const sortedCapabilityIds = [...capabilityIds].sort();
 
-  if (capabilityIds.some(id => !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id || ''))) {
+  if (capabilityIds.some(id =>
+    typeof id !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)
+  )) {
     errors.push('capability ids must be lowercase slugs');
   }
 
@@ -129,7 +131,13 @@ async function validateReferencedPath({
     errors.push(`${label} must be a directory: ${path}`);
   }
 
-  return realPath;
+  return { realPath, stat: pathStat };
+}
+
+function isSameFile(left, right) {
+  return left.realPath === right.realPath ||
+    (left.stat.ino !== 0 && right.stat.ino !== 0 &&
+      left.stat.dev === right.stat.dev && left.stat.ino === right.stat.ino);
 }
 
 async function validateHiddenTarget({ taskId, targetPath, workspacePath }, errors) {
@@ -173,7 +181,7 @@ async function validateHiddenTarget({ taskId, targetPath, workspacePath }, error
   }
 }
 
-async function addWorkspaceSymlinkErrors(taskId, workspacePath, errors, directory = workspacePath) {
+async function inspectWorkspace(taskId, workspacePath, errors, directory = workspacePath, files = []) {
   const entries = await readdir(directory, { withFileTypes: true });
 
   for (const entry of entries) {
@@ -182,9 +190,14 @@ async function addWorkspaceSymlinkErrors(taskId, workspacePath, errors, director
     if (entry.isSymbolicLink()) {
       errors.push(`${taskId} workspacePath must not contain symlinks: ${relative(workspacePath, entryPath)}`);
     } else if (entry.isDirectory()) {
-      await addWorkspaceSymlinkErrors(taskId, workspacePath, errors, entryPath);
+      await inspectWorkspace(taskId, workspacePath, errors, entryPath, files);
+    } else if (entry.isFile()) {
+      const [fileRealPath, fileStat] = await Promise.all([realpath(entryPath), stat(entryPath)]);
+      files.push({ realPath: fileRealPath, stat: fileStat });
     }
   }
+
+  return files;
 }
 
 /**
@@ -214,6 +227,9 @@ export async function validateTaskContracts({
   }
 
   const taskIds = new Set();
+  const hiddenSources = [];
+  const prompts = [];
+  const workspaces = [];
 
   for (const [index, task] of tasks.entries()) {
     const taskLabel = task?.id || `task at index ${index}`;
@@ -241,14 +257,14 @@ export async function validateTaskContracts({
       }
     }
 
-    const promptPath = await validateReferencedPath({
+    const promptReference = await validateReferencedPath({
       expectedType: 'file',
       label: `${task.id} promptPath`,
       path: task.promptPath,
       root: absoluteRoot,
       realRoot,
     }, errors);
-    const workspacePath = await validateReferencedPath({
+    const workspaceReference = await validateReferencedPath({
       expectedType: 'directory',
       label: `${task.id} workspacePath`,
       path: task.workspacePath,
@@ -257,15 +273,29 @@ export async function validateTaskContracts({
       realRoot,
     }, errors);
 
-    if (workspacePath) {
-      await addWorkspaceSymlinkErrors(task.id, workspacePath, errors);
+    if (promptReference) {
+      prompts.push({ path: task.promptPath, reference: promptReference, taskId: task.id });
+    }
+
+    if (workspaceReference) {
+      const files = await inspectWorkspace(
+        task.id,
+        workspaceReference.realPath,
+        errors
+      );
+      workspaces.push({
+        files,
+        path: task.workspacePath,
+        reference: workspaceReference,
+        taskId: task.id,
+      });
     }
 
     const hiddenTargetPaths = new Set();
 
     for (const hiddenTest of task.acceptance.hiddenTests) {
       const hiddenTestPath = hiddenTest.sourcePath;
-      const resolvedTestPath = await validateReferencedPath({
+      const hiddenTestReference = await validateReferencedPath({
         expectedType: 'file',
         label: `${task.id} hidden test`,
         path: hiddenTestPath,
@@ -273,12 +303,12 @@ export async function validateTaskContracts({
         realRoot,
       }, errors);
 
-      if (workspacePath && resolvedTestPath && isWithin(workspacePath, resolvedTestPath)) {
-        errors.push(`${task.id} hidden test must be outside workspacePath: ${hiddenTestPath}`);
-      }
-
-      if (promptPath && resolvedTestPath === promptPath) {
-        errors.push(`${task.id} hidden test must not also be promptPath: ${hiddenTestPath}`);
+      if (hiddenTestReference) {
+        hiddenSources.push({
+          path: hiddenTestPath,
+          reference: hiddenTestReference,
+          taskId: task.id,
+        });
       }
 
       if (hiddenTargetPaths.has(hiddenTest.targetPath)) {
@@ -286,15 +316,59 @@ export async function validateTaskContracts({
       }
       hiddenTargetPaths.add(hiddenTest.targetPath);
 
-      if (workspacePath) {
+      if (workspaceReference) {
         await validateHiddenTarget({
           taskId: task.id,
           targetPath: hiddenTest.targetPath,
-          workspacePath,
+          workspacePath: workspaceReference.realPath,
         }, errors);
       }
     }
 
+  }
+
+  for (const hiddenSource of hiddenSources) {
+    for (const prompt of prompts) {
+      if (!isSameFile(prompt.reference, hiddenSource.reference)) {
+        continue;
+      }
+
+      if (prompt.taskId === hiddenSource.taskId) {
+        errors.push(
+          `${hiddenSource.taskId} hidden test must not also be promptPath: ${hiddenSource.path}`
+        );
+      } else {
+        errors.push(
+          `${prompt.taskId} promptPath must not expose ${hiddenSource.taskId} hidden test: ` +
+          hiddenSource.path
+        );
+      }
+    }
+
+    for (const workspace of workspaces) {
+      const hiddenInsideWorkspace = isWithin(
+        workspace.reference.realPath,
+        hiddenSource.reference.realPath
+      );
+      const hiddenLinkedFromWorkspace = workspace.files.some(file =>
+        isSameFile(file, hiddenSource.reference)
+      );
+
+      if (!hiddenInsideWorkspace && !hiddenLinkedFromWorkspace) {
+        continue;
+      }
+
+      if (workspace.taskId === hiddenSource.taskId) {
+        errors.push(
+          `${hiddenSource.taskId} hidden test must be outside workspacePath: ${hiddenSource.path}`
+        );
+      } else {
+        errors.push(
+          `${workspace.taskId} workspacePath must not expose ${hiddenSource.taskId} hidden test: ` +
+          hiddenSource.path
+        );
+      }
+    }
   }
 
   if (errors.length) {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "check:dist": "npm run build && node config/check-dist.mjs",
     "check:release-promotion": "node config/release/preflight.mjs",
     "check:release-profile": "node config/check-release-profile.mjs",
-    "coverage": "vitest run --coverage",
+    "coverage": "vitest run --coverage && npm run test:agent-benchmark-contract",
     "docs:build": "node config/docs/build.mjs",
     "docs:check": "npm run docs:build && node config/docs/check-links.mjs",
     "lint:base": "eslint .",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "release:verify": "node config/release/verify-artifact.mjs",
     "size": "npm run build && node config/bundle-size.mjs",
     "test": "vitest run",
+    "test:agent-benchmark-contract": "node --test test/agent-benchmark/task-contract.test.mjs",
     "test:dist": "node test/dist/validate.mjs",
     "test:fixtures": "node test/fixtures/run.mjs",
     "test:performance": "node --test test/performance/*.test.mjs",

--- a/test/agent-benchmark/task-contract.test.mjs
+++ b/test/agent-benchmark/task-contract.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { link, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, test } from 'node:test';
@@ -156,6 +156,75 @@ describe('agent benchmark task contract', () => {
     );
   });
 
+  test('rejects a public prompt hard-linked to a hidden test', async() => {
+    const promptPath = 'tasks/render-a-view/prompt-hard-link.md';
+    const hiddenTestPath = 'tasks/render-a-view/acceptance/render.test.mjs';
+    await link(join(root, hiddenTestPath), join(root, promptPath));
+
+    await expectContractError(
+      root,
+      [validTask({ promptPath })],
+      `render-a-view hidden test must not also be promptPath: ${hiddenTestPath}`
+    );
+  });
+
+  test('rejects a prompt that exposes another task hidden test', async() => {
+    await mkdir(join(root, 'tasks/edit-a-view/workspace/test'), { recursive: true });
+    await mkdir(join(root, 'tasks/edit-a-view/acceptance'), { recursive: true });
+    await writeFile(join(root, 'tasks/edit-a-view/acceptance/edit.test.mjs'), 'export {};\n');
+    const exposedHiddenTest = 'tasks/render-a-view/acceptance/render.test.mjs';
+    const secondTask = validTask({
+      id: 'edit-a-view',
+      title: 'Edit a view',
+      promptPath: exposedHiddenTest,
+      workspacePath: 'tasks/edit-a-view/workspace',
+      acceptance: {
+        command: ['npm', 'test'],
+        hiddenTests: [{
+          sourcePath: 'tasks/edit-a-view/acceptance/edit.test.mjs',
+          targetPath: 'test/edit.test.mjs',
+        }],
+      },
+    });
+
+    await expectContractError(
+      root,
+      [validTask(), secondTask],
+      `edit-a-view promptPath must not expose render-a-view hidden test: ${exposedHiddenTest}`
+    );
+  });
+
+  test('rejects a workspace that exposes another task hidden test', async() => {
+    await mkdir(join(root, 'tasks/edit-a-view/workspace/test'), { recursive: true });
+    await mkdir(join(root, 'tasks/edit-a-view/acceptance'), { recursive: true });
+    await writeFile(join(root, 'tasks/edit-a-view/prompt.md'), '# Edit a view\n');
+    await writeFile(join(root, 'tasks/edit-a-view/acceptance/edit.test.mjs'), 'export {};\n');
+    const exposedHiddenTest = 'tasks/render-a-view/acceptance/render.test.mjs';
+    await link(
+      join(root, exposedHiddenTest),
+      join(root, 'tasks/edit-a-view/workspace/render.test.mjs')
+    );
+    const secondTask = validTask({
+      id: 'edit-a-view',
+      title: 'Edit a view',
+      promptPath: 'tasks/edit-a-view/prompt.md',
+      workspacePath: 'tasks/edit-a-view/workspace',
+      acceptance: {
+        command: ['npm', 'test'],
+        hiddenTests: [{
+          sourcePath: 'tasks/edit-a-view/acceptance/edit.test.mjs',
+          targetPath: 'test/edit.test.mjs',
+        }],
+      },
+    });
+
+    await expectContractError(
+      root,
+      [validTask(), secondTask],
+      `edit-a-view workspacePath must not expose render-a-view hidden test: ${exposedHiddenTest}`
+    );
+  });
+
   test('rejects workspace symlinks that could expose withheld files', async() => {
     await symlink(
       join(root, 'tasks/render-a-view/acceptance/render.test.mjs'),
@@ -242,6 +311,18 @@ describe('agent benchmark task contract', () => {
       root,
       [validTask()],
       'capability ids must be sorted',
+      malformedCapabilities
+    );
+  });
+
+  test('rejects a numeric capability id instead of coercing it to a slug', async() => {
+    const malformedCapabilities = structuredClone(capabilities);
+    malformedCapabilities.capabilities[0].id = 123;
+
+    await expectContractError(
+      root,
+      [validTask()],
+      'capability ids must be lowercase slugs',
       malformedCapabilities
     );
   });

--- a/test/agent-benchmark/task-contract.test.mjs
+++ b/test/agent-benchmark/task-contract.test.mjs
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  AgentBenchmarkTaskContractError,
+  validateTaskContracts,
+} from '../../config/agent-benchmark/task-contract.mjs';
+
+const capabilities = {
+  schemaVersion: 1,
+  coverage: {
+    minimumTasks: 10,
+    minimumIndependentTasksPerCapability: 2,
+  },
+  capabilities: [
+    { id: 'nested-regions', description: 'Compose nested Regions.' },
+    { id: 'plain-view', description: 'Implement a plain View.' },
+  ],
+};
+
+function validTask(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    id: 'render-a-view',
+    title: 'Render a view',
+    promptPath: 'tasks/render-a-view/prompt.md',
+    workspacePath: 'tasks/render-a-view/workspace',
+    capabilities: ['plain-view'],
+    acceptance: {
+      command: ['npm', 'test'],
+      hiddenTests: [{
+        sourcePath: 'tasks/render-a-view/acceptance/render.test.mjs',
+        targetPath: 'test/render.test.mjs',
+      }],
+    },
+    ...overrides,
+  };
+}
+
+async function expectContractError(root, tasks, message, catalog = capabilities) {
+  await assert.rejects(
+    validateTaskContracts({ root, tasks, capabilities: catalog }),
+    error => error instanceof AgentBenchmarkTaskContractError && error.errors.includes(message)
+  );
+}
+
+describe('agent benchmark task contract', () => {
+  let root;
+
+  beforeEach(async() => {
+    root = await mkdtemp(join(tmpdir(), 'marionette-agent-task-'));
+    await mkdir(join(root, 'tasks/render-a-view/workspace'), { recursive: true });
+    await mkdir(join(root, 'tasks/render-a-view/workspace/test'));
+    await mkdir(join(root, 'tasks/render-a-view/acceptance'), { recursive: true });
+    await writeFile(join(root, 'tasks/render-a-view/prompt.md'), '# Task\n');
+    await writeFile(join(root, 'tasks/render-a-view/acceptance/render.test.mjs'), 'export {};\n');
+  });
+
+  afterEach(async() => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test('accepts valid task metadata with hidden tests outside the workspace', async() => {
+    const tasks = [validTask()];
+
+    assert.equal(await validateTaskContracts({ root, tasks, capabilities }), tasks);
+  });
+
+  test('accepts the checked-in capability catalog without claiming corpus completeness', async() => {
+    const tasks = [];
+
+    assert.equal(await validateTaskContracts({ root, tasks }), tasks);
+  });
+
+  test('rejects duplicate task ids', async() => {
+    await expectContractError(root, [validTask(), validTask()], 'duplicate task id render-a-view');
+  });
+
+  test('rejects unknown and unsorted capabilities', async() => {
+    const task = validTask({ capabilities: ['plain-view', 'nested-regions', 'missing-capability'] });
+
+    await assert.rejects(
+      validateTaskContracts({ root, tasks: [task], capabilities }),
+      error => error instanceof AgentBenchmarkTaskContractError &&
+        error.errors.includes('render-a-view capabilities must be sorted') &&
+        error.errors.includes('render-a-view uses unknown capability missing-capability')
+    );
+  });
+
+  test('rejects duplicate capabilities through the task schema', async() => {
+    const task = validTask({ capabilities: ['plain-view', 'plain-view'] });
+
+    await assert.rejects(
+      validateTaskContracts({ root, tasks: [task], capabilities }),
+      error => error instanceof AgentBenchmarkTaskContractError &&
+        error.errors.some(message => message.includes('/capabilities must NOT have duplicate items'))
+    );
+  });
+
+  test('rejects missing referenced paths and traversal', async() => {
+    const missing = validTask({ promptPath: 'tasks/render-a-view/missing.md' });
+    const traversal = validTask({ workspacePath: '../outside' });
+
+    await expectContractError(
+      root,
+      [missing],
+      'render-a-view promptPath does not exist: tasks/render-a-view/missing.md'
+    );
+    await assert.rejects(
+      validateTaskContracts({ root, tasks: [traversal], capabilities }),
+      error => error instanceof AgentBenchmarkTaskContractError &&
+        error.errors.some(message => message.includes('/workspacePath must match pattern'))
+    );
+  });
+
+  test('rejects hidden tests inside the agent-visible workspace', async() => {
+    await writeFile(join(root, 'tasks/render-a-view/workspace/leaked.test.mjs'), 'export {};\n');
+    const task = validTask({
+      acceptance: {
+        command: ['npm', 'test'],
+        hiddenTests: [{
+          sourcePath: 'tasks/render-a-view/workspace/leaked.test.mjs',
+          targetPath: 'test/leaked.test.mjs',
+        }],
+      },
+    });
+
+    await expectContractError(
+      root,
+      [task],
+      'render-a-view hidden test must be outside workspacePath: tasks/render-a-view/workspace/leaked.test.mjs'
+    );
+  });
+
+  test('rejects a hidden test used directly as the public prompt', async() => {
+    const hiddenTestPath = 'tasks/render-a-view/acceptance/render.test.mjs';
+
+    await expectContractError(
+      root,
+      [validTask({ promptPath: hiddenTestPath })],
+      `render-a-view hidden test must not also be promptPath: ${hiddenTestPath}`
+    );
+  });
+
+  test('rejects a public prompt symlinked to a hidden test', async() => {
+    const promptPath = 'tasks/render-a-view/prompt-alias.md';
+    const hiddenTestPath = 'tasks/render-a-view/acceptance/render.test.mjs';
+    await symlink(join(root, hiddenTestPath), join(root, promptPath));
+
+    await expectContractError(
+      root,
+      [validTask({ promptPath })],
+      `render-a-view hidden test must not also be promptPath: ${hiddenTestPath}`
+    );
+  });
+
+  test('rejects workspace symlinks that could expose withheld files', async() => {
+    await symlink(
+      join(root, 'tasks/render-a-view/acceptance/render.test.mjs'),
+      join(root, 'tasks/render-a-view/workspace/leaked.test.mjs')
+    );
+
+    await expectContractError(
+      root,
+      [validTask()],
+      'render-a-view workspacePath must not contain symlinks: leaked.test.mjs'
+    );
+  });
+
+  test('rejects a symlink used as the workspace root', async() => {
+    await mkdir(join(root, 'tasks/shared-workspace/test'), { recursive: true });
+    await symlink(
+      join(root, 'tasks/shared-workspace'),
+      join(root, 'tasks/render-a-view/workspace-link')
+    );
+
+    await expectContractError(
+      root,
+      [validTask({ workspacePath: 'tasks/render-a-view/workspace-link' })],
+      'render-a-view workspacePath must not be a symlink: tasks/render-a-view/workspace-link'
+    );
+  });
+
+  test('rejects hidden test targets that would overwrite agent-visible files', async() => {
+    await writeFile(join(root, 'tasks/render-a-view/workspace/test/render.test.mjs'), 'export {};\n');
+
+    await expectContractError(
+      root,
+      [validTask()],
+      'render-a-view hidden test target already exists in workspacePath: test/render.test.mjs'
+    );
+  });
+
+  test('rejects hidden test target parents that resolve outside the workspace', async() => {
+    const externalRoot = await mkdtemp(join(tmpdir(), 'marionette-agent-target-'));
+    await symlink(externalRoot, join(root, 'tasks/render-a-view/workspace/external'));
+    const task = validTask({
+      acceptance: {
+        command: ['npm', 'test'],
+        hiddenTests: [{
+          sourcePath: 'tasks/render-a-view/acceptance/render.test.mjs',
+          targetPath: 'external/render.test.mjs',
+        }],
+      },
+    });
+
+    try {
+      await expectContractError(
+        root,
+        [task],
+        'render-a-view hidden test target parent resolves outside workspacePath: external/render.test.mjs'
+      );
+    } finally {
+      await rm(externalRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects referenced symlinks that resolve outside the repository root', async() => {
+    const externalRoot = await mkdtemp(join(tmpdir(), 'marionette-agent-external-'));
+    const externalPrompt = join(externalRoot, 'prompt.md');
+    await writeFile(externalPrompt, '# External task\n');
+    await symlink(externalPrompt, join(root, 'tasks/render-a-view/external-prompt.md'));
+
+    try {
+      await expectContractError(
+        root,
+        [validTask({ promptPath: 'tasks/render-a-view/external-prompt.md' })],
+        'render-a-view promptPath resolves outside the repository root: tasks/render-a-view/external-prompt.md'
+      );
+    } finally {
+      await rm(externalRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a malformed capability catalog', async() => {
+    const malformedCapabilities = structuredClone(capabilities);
+    malformedCapabilities.capabilities.reverse();
+
+    await expectContractError(
+      root,
+      [validTask()],
+      'capability ids must be sorted',
+      malformedCapabilities
+    );
+  });
+});


### PR DESCRIPTION
Related #128

## What

- Define the versioned metadata schema and canonical capability vocabulary for the public agent benchmark corpus.
- Validate prompt, workspace, and withheld acceptance-test boundaries, including path traversal, symlink exposure, and overwrite protection.
- Run the contract and its adversarial filesystem tests in CI.

## Why

The v5 roadmap requires agent-readiness claims to be measured by a public, reproducible corpus. Establishing the task and isolation contract first lets the corpus be built without prematurely selecting a model, harness, run count, budget, or statistical profile.

## Scope

- Test and benchmark tooling only.
- No runtime, distribution artifact, package export, website, GitHub rules/settings, or public API changes.
- Does not add benchmark tasks, a reference application, evaluator results, a model profile, budgets, pilot runs, or a Phase 0 baseline.

## Deployment Impact

No application redeploy, npm publication, website publication, or release action is required.

## Testing

- `npm run test:agent-benchmark-contract` (15 tests)
- `npm run lint:ci`
- `npm run test:performance` (66 tests)
- `npm run size`
- `npm pack --dry-run`
- `git diff --check marionettejs/master...HEAD`

Adversarial cases cover prompt aliases to withheld tests, workspace and descendant symlinks, path traversal, hidden-test leakage, target overwrite, and paths resolving outside their allowed roots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a versioned metadata schema and canonical capability vocabulary for the public agent benchmark corpus, so tasks can be built without prematurely selecting a model or harness. This is the contract required by issue #128 for v5 agent-readiness claims.

**Details**
- Defines task fields for prompt, workspace, and hidden acceptance tests, validating they stay within the repo root with no path traversal or symlink escapes.
- Hidden tests stay outside the agent-visible workspace, must not overwrite existing files on install, and are withheld from the agent only during an attempt, not from repository users.
- Prompts and workspaces must not expose any hidden test, including another task's, via direct, symlink, or hard-link aliases.
- Adds `capabilities.json` as the canonical capability list derived from ROADMAP.md and issue #128, with minimum task and independent-task coverage requirements.
- Runs the contract validator and its filesystem-isolation tests in CI via `npm run test:agent-benchmark-contract`; the `coverage` script now enforces them in trusted CI.
- Test and benchmark tooling only; no runtime, API, distribution, or release changes, and no actual benchmark tasks yet.

<sup>Written for commit dd28fc21c609b26e037eba1d55390b28a2b5ab4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repository contract for defining agent benchmark tasks and supported capabilities.
  * Added validation for task metadata, repository paths, workspaces, hidden tests, and capability catalogs.
  * Added documented benchmark coverage requirements and task schema rules.

* **Tests**
  * Added comprehensive contract tests covering valid configurations, malformed metadata, unsafe paths, symlinks, and hidden-test exposure.
  * Integrated agent benchmark contract tests into continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->