### PR TITLE
test(behavior): specify UI resolution contract

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -329,10 +329,39 @@ const MyBehavior = Behavior.extend({
 
 [Live example](https://jsfiddle.net/marionettejs/6b8o3pmz/)
 
-If your `ui` keys clash with keys on the attached view, the view's `ui`
-declarations will take precidence over the behavior's `ui`.
-This allows for behaviors to be more easily reused without dictating
-necessary structures within the view itself.
+### UI resolution and binding
+
+For a host whose `el` is empty at construction, the host constructs each Behavior
+before the host's `initialize` and before binding UI elements. During that
+construction, the Behavior resolves its own `ui` declaration and the host's `ui`
+declaration into one selector map. When both declarations contain the same key, the
+host's selector wins. This allows a Behavior to provide reusable defaults without
+dictating the host's markup.
+
+The merged selector map is available to the Behavior's `initialize`, before either
+the Behavior or host has bound UI elements. The map is captured for that Behavior
+instance during construction; later changes to values returned by a `ui` function do
+not replace its captured selectors. The host evaluates its own `ui` again when it
+binds. If a stateful host `ui` function returns a different selector then, the host
+binds the later selector while the Behavior continues to bind its construction-time
+selector. Keep `ui` functions deterministic when the host and Behavior share keys.
+
+Before binding, `behavior.ui` contains selector strings. A template-rendered `View`
+binds those selectors during render, after which the values are array-like element
+collections found only within the host's `el`. Its rerender replaces the contents and
+rebinds the same Behavior to the replacement elements. Code must read the current
+`behavior.ui` or call `behavior.getUI(name)` after binding instead of retaining an
+element collection from an earlier render.
+
+A `CollectionView` also binds Behavior UI automatically when its render processes a
+template. Without a template, `CollectionView#render` leaves Behavior UI as selector
+strings; call `collectionView.bindUIElements()` after the expected elements exist to
+bind them explicitly.
+
+A `View` initialized around pre-rendered content binds its own UI before it
+constructs Behaviors. This contract pins only that construction ordering. It
+intentionally leaves the mixed Behavior UI representation for that path unresolved;
+do not infer the selector-before-binding sequence above or rely on that representation.
 
 ```javascript
 import { Behavior, View } from 'backbone.marionette';
@@ -416,10 +445,9 @@ is destroyed. Nested Behaviors participate as Behaviors of the same host view.
 
 `Behavior` does not expose an independent `isDestroyed()` state. Repeated direct
 `behavior.destroy()` calls, reuse after direct cleanup, and other post-cleanup
-operations are outside this lifecycle contract. UI capture and collision rules,
-dependency access, invalid references, and dynamic replacement semantics are also
-separate Behavior contract decisions; this table does not add an Application or
-State lifecycle to Behavior.
+operations are outside this lifecycle contract. Dependency access, invalid
+references, and dynamic replacement semantics are separate Behavior contract
+decisions; this table does not add an Application or State lifecycle to Behavior.
 
 If a Region's owning view sets `monitorViewEvents: false`, the shown host does not
 receive attachment lifecycle notifications, so its Behaviors do not receive them

--- a/test/unit/behavior-ui-contract.spec.js
+++ b/test/unit/behavior-ui-contract.spec.js
@@ -1,0 +1,251 @@
+import Behavior from '../../modules/behavior';
+import CollectionView from '../../modules/collection-view';
+import View from '../../modules/view';
+
+describe('Behavior UI contract', function() {
+  it('captures merged UI during host construction with host keys winning', function() {
+    const lifecycle = [];
+    let behavior;
+    let behaviorSelector = '.behavior-first';
+    let hostSelector = '.host-first';
+
+    const TestBehavior = Behavior.extend({
+      ui() {
+        return {
+          behaviorOnly: behaviorSelector,
+          shared: '.behavior-shared',
+        };
+      },
+      initialize() {
+        behavior = this;
+        lifecycle.push('behavior:initialize');
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        return [
+          '<span class="behavior-first"></span>',
+          '<span class="behavior-second"></span>',
+          '<span class="host-first"></span>',
+          '<span class="host-second"></span>',
+          '<span class="host-shared"></span>',
+        ].join('');
+      },
+      ui() {
+        return {
+          hostOnly: hostSelector,
+          shared: '.host-shared',
+        };
+      },
+      initialize() {
+        lifecycle.push('view:initialize');
+      },
+    });
+    const view = new TestView();
+
+    behaviorSelector = '.behavior-second';
+    hostSelector = '.host-second';
+
+    expect(lifecycle).to.deep.equal([
+      'behavior:initialize',
+      'view:initialize',
+    ]);
+    expect(behavior.ui).to.deep.equal({
+      behaviorOnly: '.behavior-first',
+      hostOnly: '.host-first',
+      shared: '.host-shared',
+    });
+
+    view.render();
+
+    expect(behavior.ui.behaviorOnly[0]).to.equal(view.el.querySelector('.behavior-first'));
+    expect(behavior.ui.hostOnly[0]).to.equal(view.el.querySelector('.host-first'));
+    expect(behavior.ui.shared[0]).to.equal(view.el.querySelector('.host-shared'));
+    expect(view.ui.hostOnly[0]).to.equal(view.el.querySelector('.host-second'));
+    expect(view.ui.hostOnly[0]).to.not.equal(behavior.ui.hostOnly[0]);
+
+    view.destroy();
+  });
+
+  it('exposes selectors before binding and host-scoped element collections after render', function() {
+    let behavior;
+
+    const TestBehavior = Behavior.extend({
+      ui: {
+        behaviorOnly: '.behavior-only',
+        shared: '.behavior-shared',
+      },
+      initialize() {
+        behavior = this;
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        return '<button class="behavior-only"></button><button class="host-shared"></button>';
+      },
+      ui: {
+        shared: '.host-shared',
+      },
+    });
+    const view = new TestView();
+
+    expect(behavior.ui).to.deep.equal({
+      behaviorOnly: '.behavior-only',
+      shared: '.host-shared',
+    });
+
+    view.render();
+
+    expect(behavior.ui.behaviorOnly).to.have.length(1);
+    expect(behavior.ui.behaviorOnly[0]).to.equal(view.el.querySelector('.behavior-only'));
+    expect(behavior.ui.shared).to.have.length(1);
+    expect(behavior.ui.shared[0]).to.equal(view.el.querySelector('.host-shared'));
+
+    view.destroy();
+  });
+
+  it('pins only that pre-rendered hosts bind host UI before Behavior construction', function() {
+    this.setFixtures('<div id="prerendered-host"><button class="shared"></button></div>');
+    const hostElement = document.querySelector('#prerendered-host');
+    const sharedElement = hostElement.querySelector('.shared');
+    let observedHostUI;
+    let observedRenderedState;
+
+    const TestBehavior = Behavior.extend({
+      initialize() {
+        observedHostUI = this.view.ui.shared[0];
+        observedRenderedState = this.view.isRendered();
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      ui: {
+        shared: '.shared',
+      },
+    });
+    const view = new TestView({ el: hostElement });
+
+    expect(observedRenderedState).to.be.true;
+    expect(observedHostUI).to.equal(sharedElement);
+
+    view.destroy();
+  });
+
+  it('binds CollectionView Behavior UI automatically only when rendering a template', function() {
+    let templatedBehavior;
+    let templateLessBehavior;
+
+    const TemplatedBehavior = Behavior.extend({
+      ui: {
+        action: '.action',
+      },
+      initialize() {
+        templatedBehavior = this;
+      },
+    });
+    const TemplatedCollectionView = CollectionView.extend({
+      behaviors: [TemplatedBehavior],
+      template() {
+        return '<button class="action templated"></button>';
+      },
+    });
+    const templatedView = new TemplatedCollectionView();
+
+    expect(templatedBehavior.ui.action).to.equal('.action');
+    templatedView.render();
+    expect(templatedBehavior.ui.action[0]).to.equal(templatedView.el.querySelector('.templated'));
+
+    const templateLessElement = document.createElement('div');
+    templateLessElement.innerHTML = '<button class="action template-less"></button>';
+    const TemplateLessBehavior = Behavior.extend({
+      ui: {
+        action: '.action',
+      },
+      initialize() {
+        templateLessBehavior = this;
+      },
+    });
+    const TemplateLessCollectionView = CollectionView.extend({
+      behaviors: [TemplateLessBehavior],
+    });
+    const templateLessView = new TemplateLessCollectionView({ el: templateLessElement });
+
+    expect(templateLessBehavior.ui.action).to.equal('.action');
+    templateLessView.render();
+    expect(templateLessBehavior.ui.action).to.equal('.action');
+
+    templateLessView.bindUIElements();
+    expect(templateLessBehavior.ui.action[0]).to.equal(templateLessElement.querySelector('.template-less'));
+
+    templatedView.destroy();
+    templateLessView.destroy();
+  });
+
+  it('rebinds Behavior UI to replacement elements after host rerender', function() {
+    let behavior;
+    let renderCount = 0;
+
+    const TestBehavior = Behavior.extend({
+      ui: {
+        action: '.action',
+      },
+      initialize() {
+        behavior = this;
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        renderCount += 1;
+        return `<button class="action" data-render="${renderCount}"></button>`;
+      },
+    });
+    const view = new TestView();
+
+    view.render();
+    const firstElement = behavior.ui.action[0];
+    const firstCollection = behavior.ui.action;
+
+    view.render();
+    const secondElement = behavior.ui.action[0];
+
+    expect(firstCollection[0]).to.equal(firstElement);
+    expect(view.el.contains(firstElement)).to.be.false;
+    expect(secondElement).to.not.equal(firstElement);
+    expect(secondElement.dataset.render).to.equal('2');
+    expect(secondElement).to.equal(view.el.querySelector('.action'));
+
+    view.destroy();
+  });
+
+  it('limits Behavior UI lookup to the host element', function() {
+    this.setFixtures('<div id="behavior-host"></div><button class="action outside"></button>');
+    let behavior;
+
+    const TestBehavior = Behavior.extend({
+      ui: {
+        action: '.action',
+      },
+      initialize() {
+        behavior = this;
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        return '<button class="action inside"></button>';
+      },
+    });
+    const view = new TestView({ el: document.querySelector('#behavior-host') });
+    view.render();
+
+    expect(document.querySelectorAll('.action')).to.have.length(2);
+    expect(behavior.ui.action).to.have.length(1);
+    expect(behavior.ui.action[0]).to.equal(view.el.querySelector('.inside'));
+    expect(behavior.ui.action[0]).to.not.equal(document.querySelector('.outside'));
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
Related #133

## What

- Specify when a Behavior captures its own and its host's `ui` values, including host-wins key collisions and dynamic host-function divergence.
- Define selector-to-element binding for template-rendered Views, CollectionViews with and without templates, rerenders, and host-scoped lookup.
- Add focused executable coverage for construction timing, binding, rebinding, and DOM scope.

## Why

Behavior UI ownership is currently spread across constructor, host, and UI-mixin internals. Agents need a public contract for which selectors win, when values are captured, and when `behavior.ui` contains selectors versus bound elements.

## Scope

- Documentation and characterization tests only; no runtime or public API implementation changes.
- Covers the stable empty-host View path and CollectionView template/manual-binding paths.
- Pins only the ordering for a View initialized around pre-rendered content. Its current mixed Behavior UI representation remains intentionally unresolved under #133 and must not be relied upon.
- No GitHub rules/settings, website publication, package publication, or release changes.

## Deployment Impact

No application redeploy, npm publication, website publication, or release action is required.

## Testing

- `npm run coverage` (66 Vitest files / 1,158 tests at 100% coverage, then 19 agent-contract tests)
- `npm run docs:check` (29 pages built; 30 HTML files and 288 internal links validated)
- `npm run lint:ci`
- `git diff --check marionettejs/master...HEAD`

Focused preflight before the full run covered the new Behavior contract plus existing Behavior and CollectionView suites: 6 files / 139 tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and pins the Behavior UI resolution contract for agents through docs and characterization tests, with no runtime or API changes.

**Contract highlights**

- Behavior captures merged UI selectors during host construction, with host keys winning collisions, before the host's `initialize` and before UI binding.
- `behavior.ui` holds selector strings until render, then host-scoped element collections; rerenders rebind to replacement elements, so code must read current values.
- `CollectionView` binds Behavior UI automatically only when rendering a template; otherwise call `bindUIElements()`.
- The pre-rendered-host path pins only construction ordering; its mixed Behavior UI representation stays unresolved under #133.

<sup>Written for commit 01bd6b5c349c14b72b9fecb99206a4e3876aa3b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how Behavior and host view UI selectors are merged and resolved.

* **Tests**
  * Added coverage for UI binding across construction, rendering, rerendering, and replacement elements.
  * Verified behavior UI remains scoped to its host and supports both templated and template-less views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->