### PR TITLE
test(behavior): specify DOM boundary contract

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -401,8 +401,8 @@ const FirstView = View.extend({
 
 The host View owns the DOM boundary for each attached Behavior. A Behavior's
 `el` is the host's current `el`, and its `$()` lookup delegates to the host so
-that results stay scoped to that element. The native DOM API does not add a
-`$el` property to Behaviors.
+that results stay scoped to that element. Behaviors do not have a `$el`
+property.
 
 Calling the host View's `setElement()` automatically moves its Behaviors to the
 new element. Their delegated DOM handlers are removed from the old element and

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -399,16 +399,16 @@ const FirstView = View.extend({
 
 ### Host DOM boundary
 
-The host View owns the DOM boundary for each attached Behavior. A Behavior's
-`el` is the host's current `el`, and its `$()` lookup delegates to the host so
-that results stay scoped to that element. Behaviors do not have a `$el`
-property.
+The host View or CollectionView owns the DOM boundary for each attached
+Behavior. A Behavior's `el` is the host's current `el`, and its `$()` lookup
+delegates to the host so that results stay scoped to that element. Behaviors do
+not have a `$el` property.
 
-Calling the host View's `setElement()` automatically moves its Behaviors to the
-new element. Their delegated DOM handlers are removed from the old element and
+Calling the host's `setElement()` automatically moves its Behaviors to the new
+element. Their delegated DOM handlers are removed from the old element and
 attached once to the current element, including after repeated calls or swaps.
-Destroying the host removes the final delegated handlers. Application code does
-not need to retarget the Behavior separately.
+Destroying the host removes the final delegated handlers. Application code
+does not need to retarget the Behavior separately.
 
 Each Behavior can also reference its host through the `view` attribute:
 

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -397,17 +397,20 @@ const FirstView = View.extend({
 });
 ```
 
-### View DOM proxies
+### Host DOM boundary
 
-The `Behavior` has a number of proxies attributes that directly refer to the
-related attribute on a view:
+The host View owns the DOM boundary for each attached Behavior. A Behavior's
+`el` is the host's current `el`, and its `$()` lookup delegates to the host so
+that results stay scoped to that element. The native DOM API does not add a
+`$el` property to Behaviors.
 
-* `$`
-* `el`
-* `$el`
+Calling the host View's `setElement()` automatically moves its Behaviors to the
+new element. Their delegated DOM handlers are removed from the old element and
+attached once to the current element, including after repeated calls or swaps.
+Destroying the host removes the final delegated handlers. Application code does
+not need to retarget the Behavior separately.
 
-In addition, each behavior is able to reference the view they are attached to
-through the `view` attribute:
+Each Behavior can also reference its host through the `view` attribute:
 
 ```javascript
 import { Behavior } from 'backbone.marionette';
@@ -415,17 +418,13 @@ import { Behavior } from 'backbone.marionette';
 const ViewBehavior = Behavior.extend({
   onRender() {
     const shouldHighlight = this.view.model.get('selected');
-    this.$el.toggleClass('highlight', shouldHighlight);
-    this.$('.view-class').addClass('highlighted-icon');
+    this.el.classList.toggle('highlight', shouldHighlight);
+    Array.from(this.$('.view-class')).forEach(element => {
+      element.classList.add('highlighted-icon');
+    });
   }
 });
 ```
-
-[Live example](https://jsfiddle.net/marionettejs/8dmk30Lq/)
-
-**Note** in rare cases when a view's `el` is modified via `setElement` if utilizing
-these proxies they will need to be manually updated by calling
-`myBehavior.proxyViewProperties();`
 
 ## Behavior Lifecycle
 

--- a/test/unit/behavior-dom-delegation-contract.spec.js
+++ b/test/unit/behavior-dom-delegation-contract.spec.js
@@ -25,6 +25,7 @@ describe('Behavior DOM delegation contract', function() {
       const host = new TestHost({ el: firstHost });
 
       expect(behavior.el).to.equal(firstHost);
+      expect(behavior).to.not.have.property('$el');
       expect(behavior.$('.action')[0]).to.equal(firstHost.querySelector('.first'));
 
       host.setElement(secondHost);

--- a/test/unit/behavior-dom-delegation-contract.spec.js
+++ b/test/unit/behavior-dom-delegation-contract.spec.js
@@ -1,0 +1,83 @@
+import Behavior from '../../modules/behavior';
+import CollectionView from '../../modules/collection-view';
+import View from '../../modules/view';
+
+describe('Behavior DOM delegation contract', function() {
+  [
+    ['View', View],
+    ['CollectionView', CollectionView],
+  ].forEach(([hostName, Host]) => {
+    it(`keeps DOM access scoped to the current ${hostName} element`, function() {
+      const firstHost = document.createElement('section');
+      const secondHost = document.createElement('section');
+      firstHost.innerHTML = '<button class="action first">First</button>';
+      secondHost.innerHTML = '<button class="action second">Second</button>';
+      let behavior;
+
+      const TestBehavior = Behavior.extend({
+        initialize() {
+          behavior = this;
+        },
+      });
+      const TestHost = Host.extend({
+        behaviors: [TestBehavior],
+      });
+      const host = new TestHost({ el: firstHost });
+
+      expect(behavior.el).to.equal(firstHost);
+      expect(behavior.$('.action')[0]).to.equal(firstHost.querySelector('.first'));
+
+      host.setElement(secondHost);
+
+      expect(behavior.el).to.equal(secondHost);
+      expect(behavior.el).to.equal(host.el);
+      expect(behavior.$('.action')).to.have.length(1);
+      expect(behavior.$('.action')[0]).to.equal(secondHost.querySelector('.second'));
+      expect(behavior.$('.action')[0]).to.not.equal(firstHost.querySelector('.first'));
+
+      host.destroy();
+    });
+
+    it(`moves one delegated handler with repeated ${hostName} element changes and removes it on destroy`, function() {
+      const firstHost = document.createElement('section');
+      const secondHost = document.createElement('section');
+      firstHost.innerHTML = '<button class="action first">First</button>';
+      secondHost.innerHTML = '<button class="action second">Second</button>';
+      const onAction = this.sinon.spy();
+
+      const TestBehavior = Behavior.extend({
+        events: {
+          'click .action': 'onAction',
+        },
+        onAction,
+      });
+      const TestHost = Host.extend({
+        behaviors: [TestBehavior],
+      });
+      const host = new TestHost({ el: firstHost });
+      const firstAction = firstHost.querySelector('.first');
+      const secondAction = secondHost.querySelector('.second');
+
+      firstAction.click();
+      expect(onAction).to.have.been.calledOnce;
+
+      host.setElement(secondHost);
+      firstAction.click();
+      secondAction.click();
+      expect(onAction).to.have.been.calledTwice;
+
+      host.setElement(secondHost);
+      secondAction.click();
+      expect(onAction).to.have.been.calledThrice;
+
+      host.setElement(firstHost);
+      secondAction.click();
+      firstAction.click();
+      expect(onAction).to.have.callCount(4);
+
+      host.destroy();
+      firstAction.click();
+      expect(onAction).to.have.callCount(4);
+    });
+  });
+});


### PR DESCRIPTION
Related #133

## What

- Document that a Behavior shares its host View or CollectionView DOM boundary and follows public `setElement()` calls automatically.
- Add contract coverage for scoped DOM lookup and delegated-event retargeting across element swaps, repeated same-element calls, and host destruction.
- Remove obsolete `Behavior#$el`, `proxyViewProperties()`, and the linked jQuery-era JSFiddle guidance.

## Why

The current Behavior guide describes APIs that do not exist in the v5 native runtime and tells applications to retarget Behaviors manually. The runtime already owns that work. This PR makes the public contract explicit and protects both independent host implementations from event leaks or duplicate delegation.

## Scope

This changes Behavior documentation and tests only. It does not change runtime source, package exports, generated artifacts, the documentation website, release behavior, workflows, or GitHub settings/rules. Broader Behavior dependency ownership, dynamic Behavior mutation, entity-event redelegation, and diagnostics remain outside this slice of #133.

## Deployment Impact

No deployment or consumer redeploy is required. This PR changes no runtime or published artifact.

## Testing

- `npm run coverage` — 67 test files and 1,162 tests passed with 100% statements, branches, functions, and lines; all 19 agent benchmark contract tests passed.
- `npx vitest run test/unit/behavior-dom-delegation-contract.spec.js --reporter=verbose` — 4 focused tests passed across View and CollectionView.
- `npm run docs:check` — 29 documentation pages built; 30 HTML files and 288 internal links validated.
- `npx eslint test/unit/behavior-dom-delegation-contract.spec.js` — passed.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Related to #133. Specifies the Behavior DOM boundary contract in docs and tests, so applications no longer need to manually retarget Behaviors after `setElement()`.

- Documents that a Behavior shares its host View or CollectionView's current `el` and `$()` scope.
- Removes obsolete `Behavior#$el`, `proxyViewProperties()`, and the linked JSFiddle guidance.
- Adds contract tests for scoped DOM lookup, the absent `$el` property, and delegated-event retargeting across element swaps, repeated same-element calls, and host destruction.
- Does not change runtime code, package exports, or published artifacts; no deployment or consumer redeploy required.

<sup>Written for commit b429602d98b4b6f5fcc5f8625b03e05c45beedab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Behaviors interact with their host element, including scoped DOM queries and the absence of `$el`.
  * Documented how Behaviors follow host element changes and manage delegated event handlers.

* **Tests**
  * Added coverage for DOM delegation across `View` and `CollectionView` hosts.
  * Verified handler movement during element changes and cleanup on destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->