### PR TITLE
test(behavior): specify dependency access contract

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -204,9 +204,10 @@ const MyView = View.extend({
 });
 ```
 
-Use `this.view` for dependencies owned by the host, such as its model or
-collection. A nested Behavior receives its own definition options while sharing
-the same host View as the Behavior that declared it.
+`getOption()` does not fall back to options on the host. Use `this.view` for
+dependencies owned by the host, such as its model or collection. A nested
+Behavior receives its own definition options while sharing the same host View
+as the Behavior that declared it.
 
 When a Behavior is removed directly or its host is destroyed, Marionette removes
 subscriptions created by that Behavior with `listenTo()`. It does not destroy or

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -171,6 +171,48 @@ Using an object, we must define the `behaviorClass` attribute to refer to our
 behaviors and then add any extra options with keys matching the option we want
 to override. Any passed options will override the values from `options` property.
 
+Behavior options can also provide collaborators that the Behavior needs. These
+values are selected during construction and retained by reference. Read an
+arbitrary collaborator with `getOption()` so that a class default and an
+attachment override follow the same option precedence; arbitrary option names
+are not copied directly onto the Behavior instance.
+
+```javascript
+const SelectionBehavior = Behavior.extend({
+  options: {
+    service: defaultSelectionService
+  },
+
+  initialize(options, hostView) {
+    const service = this.getOption('service');
+    this.listenTo(service, 'selection:change', this.onSelectionChange);
+
+    // The second argument and this.view are the same host View.
+    console.log(hostView === this.view); // true
+  },
+
+  onSelectionChange(selection) {
+    // ...
+  }
+});
+
+const MyView = View.extend({
+  behaviors: [{
+    behaviorClass: SelectionBehavior,
+    service: applicationSelectionService
+  }]
+});
+```
+
+Use `this.view` for dependencies owned by the host, such as its model or
+collection. A nested Behavior receives its own definition options while sharing
+the same host View as the Behavior that declared it.
+
+When a Behavior is removed directly or its host is destroyed, Marionette removes
+subscriptions created by that Behavior with `listenTo()`. It does not destroy or
+dispose arbitrary values passed through Behavior options, and unrelated listeners
+on those collaborators remain active.
+
 **Errors** An error will be thrown if the `Behavior` class is not passed.
 
 ## Nesting Behaviors

--- a/test/unit/behavior-dependencies-contract.spec.js
+++ b/test/unit/behavior-dependencies-contract.spec.js
@@ -39,6 +39,41 @@ describe('Behavior dependency contract', function() {
     injectedService.destroy();
   });
 
+  it('uses its own defaults without falling back to host options', function() {
+    const defaultService = new MnObject();
+    const hostService = new MnObject();
+    let behaviorService;
+    let behaviorHostOnly;
+    let hostOnly;
+
+    const TestBehavior = Behavior.extend({
+      options: {
+        service: defaultService,
+      },
+      initialize() {
+        behaviorService = this.getOption('service');
+        behaviorHostOnly = this.getOption('hostOnly');
+        hostOnly = this.view.getOption('hostOnly');
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+    });
+    const view = new TestView({
+      hostOnly: hostService,
+      service: hostService,
+    });
+
+    expect(behaviorService).to.equal(defaultService);
+    expect(behaviorService).to.not.equal(hostService);
+    expect(behaviorHostOnly).to.be.undefined;
+    expect(hostOnly).to.equal(hostService);
+
+    view.destroy();
+    defaultService.destroy();
+    hostService.destroy();
+  });
+
   it('gives nested Behaviors their own options and the same host', function() {
     const parentService = new MnObject();
     const nestedService = new MnObject();

--- a/test/unit/behavior-dependencies-contract.spec.js
+++ b/test/unit/behavior-dependencies-contract.spec.js
@@ -1,0 +1,166 @@
+import Behavior from '../../modules/behavior';
+import MnObject from '../../modules/object';
+import View from '../../modules/view';
+
+describe('Behavior dependency contract', function() {
+  it('resolves an injected collaborator and exact host during initialize', function() {
+    const defaultService = new MnObject();
+    const injectedService = new MnObject();
+    let behavior;
+    let initializedHost;
+    let initializedService;
+
+    const TestBehavior = Behavior.extend({
+      options: {
+        service: defaultService,
+      },
+      initialize(options, hostView) {
+        behavior = this;
+        initializedHost = hostView;
+        initializedService = this.getOption('service');
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [{
+        behaviorClass: TestBehavior,
+        service: injectedService,
+      }],
+    });
+    const view = new TestView();
+
+    expect(initializedService).to.equal(injectedService);
+    expect(initializedService).to.not.equal(defaultService);
+    expect(initializedHost).to.equal(view);
+    expect(behavior.view).to.equal(view);
+    expect(behavior).to.not.have.property('service');
+
+    view.destroy();
+    defaultService.destroy();
+    injectedService.destroy();
+  });
+
+  it('gives nested Behaviors their own options and the same host', function() {
+    const parentService = new MnObject();
+    const nestedService = new MnObject();
+    let parentObservation;
+    let nestedObservation;
+
+    const NestedBehavior = Behavior.extend({
+      initialize(options, hostView) {
+        nestedObservation = {
+          hostView,
+          service: this.getOption('service'),
+          view: this.view,
+        };
+      },
+    });
+    const ParentBehavior = Behavior.extend({
+      behaviors: [{
+        behaviorClass: NestedBehavior,
+        service: nestedService,
+      }],
+      initialize(options, hostView) {
+        parentObservation = {
+          hostView,
+          service: this.getOption('service'),
+          view: this.view,
+        };
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [{
+        behaviorClass: ParentBehavior,
+        service: parentService,
+      }],
+    });
+    const view = new TestView();
+
+    expect(parentObservation).to.deep.equal({
+      hostView: view,
+      service: parentService,
+      view,
+    });
+    expect(nestedObservation).to.deep.equal({
+      hostView: view,
+      service: nestedService,
+      view,
+    });
+
+    view.destroy();
+    parentService.destroy();
+    nestedService.destroy();
+  });
+
+  it('removes only its own collaborator subscription on direct destroy', function() {
+    const service = new MnObject();
+    const behaviorListener = this.sinon.spy();
+    const unrelatedListener = this.sinon.spy();
+    let behavior;
+
+    service.on('change', unrelatedListener);
+
+    const TestBehavior = Behavior.extend({
+      initialize() {
+        behavior = this;
+        this.listenTo(this.getOption('service'), 'change', behaviorListener);
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [{
+        behaviorClass: TestBehavior,
+        service,
+      }],
+    });
+    const view = new TestView();
+
+    service.trigger('change');
+    expect(behaviorListener).to.have.been.calledOnce;
+    expect(unrelatedListener).to.have.been.calledOnce;
+
+    behavior.destroy();
+    service.trigger('change');
+
+    expect(behaviorListener).to.have.been.calledOnce;
+    expect(unrelatedListener).to.have.been.calledTwice;
+    expect(service.isDestroyed()).to.be.false;
+
+    view.destroy();
+    service.off();
+    service.destroy();
+  });
+
+  it('removes only its own collaborator subscription on host destroy', function() {
+    const service = new MnObject();
+    const behaviorListener = this.sinon.spy();
+    const unrelatedListener = this.sinon.spy();
+
+    service.on('change', unrelatedListener);
+
+    const TestBehavior = Behavior.extend({
+      initialize() {
+        this.listenTo(this.getOption('service'), 'change', behaviorListener);
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [{
+        behaviorClass: TestBehavior,
+        service,
+      }],
+    });
+    const view = new TestView();
+
+    service.trigger('change');
+    expect(behaviorListener).to.have.been.calledOnce;
+    expect(unrelatedListener).to.have.been.calledOnce;
+
+    view.destroy();
+    service.trigger('change');
+
+    expect(behaviorListener).to.have.been.calledOnce;
+    expect(unrelatedListener).to.have.been.calledTwice;
+    expect(service.isDestroyed()).to.be.false;
+
+    service.off();
+    service.destroy();
+  });
+});


### PR DESCRIPTION
Related #133

## What

- Document Behavior collaborator injection through attachment options, `getOption()` precedence, and exact host access through `view`.
- Specify that nested Behaviors keep their own definition options while sharing the same host.
- Add contract tests proving Behavior-owned `listenTo()` subscriptions are removed without destroying injected collaborators or unrelated listeners.

## Why

Behavior dependency access and cleanup are currently inferable only by reading construction and teardown internals. This slice makes the valid public path explicit so agents can inject collaborators and assign subscription ownership without inventing instance fields, service containers, or disposal behavior.

## Scope

This changes Behavior documentation and tests only. It does not change runtime source, package exports, generated artifacts, the documentation website, workflows, releases, or GitHub settings/rules. Dependency validation, dynamic replacement, dependency containers, repeated entity-event delegation, invalid UI references, and new diagnostic codes remain outside this slice of #133.

## Deployment Impact

No deployment or consumer redeploy is required. This PR changes no runtime or published artifact.

## Testing

- `npm run coverage` — 68 test files and 1,166 tests passed with 100% statements, branches, functions, and lines; all 19 agent benchmark contract tests passed.
- `npx vitest run test/unit/behavior-dependencies-contract.spec.js --reporter=verbose` — 4 focused tests passed.
- `npm run docs:check` — 29 documentation pages built; 30 HTML files and 288 internal links validated.
- `npx eslint test/unit/behavior-dependencies-contract.spec.js` — passed.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and contract-tests the Behavior dependency access pattern: collaborators injected via attachment options, `getOption()` precedence, and direct host access through `view`. Pins that `getOption()` doesn't fall back to host options and that Behavior-owned `listenTo()` subscriptions are cleaned up without destroying injected collaborators or affecting unrelated listeners. No runtime changes; this is docs and tests only.

<sup>Written for commit 90547161b9739651adea0d595823ec76ad577f55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

