### PR TITLE
test(behavior): specify communication contract

### DIFF
--- a/docs/events.class.md
+++ b/docs/events.class.md
@@ -97,7 +97,7 @@ The `Application` class also triggers [Destroy Events](#destroy-and-beforedestro
 
 ### `initialize` event
 
-After the view and behavior are [constructed and initialized](./marionette.behavior.md#events--initialize-order),
+After the view and behavior are [constructed and initialized](./marionette.behavior.md#initialize-order),
 the last event to occur is an `initialize` event on the behavior which is passed
 the view instance and any options passed to the view at instantiation.
 

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -23,12 +23,12 @@ Instead a `Behavior` should be instantiated by the view it is related to by
   * [Behavior Options](#behavior-options)
 * [Nesting Behaviors](#nesting-behaviors)
 * [The Behavior's `view`](#the-behaviors-view)
-* [View Proxy](#view-proxy)
-  * [Listening to View Events](#listening-to-view-events)
+* [Host Communication and Event Proxies](#host-communication-and-event-proxies)
+  * [Host and Behavior Events](#host-and-behavior-events)
   * [Proxy Handlers](#proxy-handlers)
-  * [Events / Initialize Order](#events--initialize-order)
+  * [Initialize Order](#initialize-order)
   * [Using `ui`](#using-ui)
-  * [View DOM proxies](#view-dom-proxies)
+  * [Host DOM Boundary](#host-dom-boundary)
 * [Behavior Lifecycle](#behavior-lifecycle)
 * [Destroying a Behavior](#destroying-a-behavior)
 
@@ -254,29 +254,43 @@ Behavior.extend({
 
 [Live example](https://jsfiddle.net/marionettejs/p8vymo4j/)
 
-## View Proxy
+## Host Communication and Event Proxies
 
-The `Behavior` class provides proxies for a selection of `View` functionality.
-This includes [listening to events on the view](), being able to [handle events on
-models and collections](), and being able to directly [interact with the attached
-template]().
+A Behavior is an event-capable object attached to one host View. It can handle
+host events, DOM events, and host entity events while keeping its own events
+separate from the host.
 
-### Listening to View Events
+### Host and Behavior Events
 
-Behaviors are powered by an event proxy. This means that any events that are
-triggered on a `View` are passed to all attached `behaviors`. This includes:
+When the host calls `triggerMethod()`, the host's corresponding `onEvent` method
+runs first. The event is then broadcast with the same arguments to every attached
+Behavior, where the corresponding method runs with that Behavior as its context.
+Nested Behaviors participate directly in the same host broadcast. Do not rely on
+an ordering among Behavior handlers.
 
-* Events fired by `triggerMethod`
-* Events fired from `triggers`
-* Events fired by `childViewTriggers`
-* Events fired from `childView`
+Host broadcasts include events produced by:
 
-These handlers work exactly as they do on `View` -
-[see the `View` documentation](./marionette.view.md#events)
+* Calls to `triggerMethod()`
+* DOM `triggers`
+* `childViewTriggers`
+* Child events forwarded through a non-false `childViewEventPrefix`
 
-> Be default all events triggered on the behavior come from the view or the view's entities.
-> Events triggered in the behavior instance are not executed in the view. To notify
-> the view, the behavior must trigger an event in its view property, e.g, `this.view.trigger('my:event')`
+`childViewEvents` calls the configured host handler directly. It becomes a host
+broadcast only if that handler explicitly calls `triggerMethod()`.
+
+A call to `behavior.triggerMethod()` stays local to that Behavior. It does not
+invoke the host or sibling Behaviors. To request host work, call an appropriate
+public host method or explicitly use `this.view.triggerMethod()`. The latter is a
+host broadcast, so every attached Behavior receives it, including the Behavior
+that sent it. Do not re-emit the same host event from that Behavior's corresponding
+handler, as doing so would recurse.
+
+A Behavior's DOM [`triggers`](./dom.interactions.md#view-triggers) are emitted on
+the host automatically. The host method runs first, and all attached Behaviors,
+including the Behavior that declared the trigger, receive the broadcast.
+
+For general event naming and handler conversion, see
+[`triggerMethod`](./events.md#triggermethod).
 
 ### Proxy Handlers
 
@@ -319,10 +333,7 @@ Behavior.extend({
 });
 ```
 
-### Events / Initialize Order
-
-If both view and behavior are listening for the same event, this will be executed
-first in the view then in the behavior as below.
+### Initialize Order
 
 The View + Behavior initialize process is as follows:
 

--- a/test/unit/behavior-communication-contract.spec.js
+++ b/test/unit/behavior-communication-contract.spec.js
@@ -146,6 +146,46 @@ describe('Behavior communication contract', function() {
     view.destroy();
   });
 
+  it('keeps childViewEvents handlers local to the host unless they explicitly broadcast', function() {
+    const payload = { value: 'child' };
+    const hostHandler = this.sinon.spy();
+    const behaviorHandler = this.sinon.spy();
+
+    const TestBehavior = Behavior.extend({
+      onChildBoom: behaviorHandler,
+    });
+    const ChildView = View.extend({
+      template() {
+        return '';
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      template() {
+        return '<div class="child"></div>';
+      },
+      regions: {
+        child: '.child',
+      },
+      childViewEvents: {
+        'child:boom': 'handleChildBoom',
+      },
+      handleChildBoom: hostHandler,
+    });
+    const view = new TestView();
+    const childView = new ChildView();
+    view.render();
+    view.showChildView('child', childView);
+
+    childView.triggerMethod('child:boom', payload);
+
+    expect(hostHandler).to.have.been.calledOnce.and.calledOn(view);
+    expect(hostHandler).to.have.been.calledWithExactly(payload);
+    expect(behaviorHandler).to.not.have.been.called;
+
+    view.destroy();
+  });
+
   it('emits Behavior DOM triggers on the host and broadcasts them to all Behaviors', function() {
     const sequence = [];
     const hostHandler = this.sinon.spy(function() {

--- a/test/unit/behavior-communication-contract.spec.js
+++ b/test/unit/behavior-communication-contract.spec.js
@@ -1,0 +1,218 @@
+import Behavior from '../../modules/behavior';
+import View from '../../modules/view';
+
+describe('Behavior communication contract', function() {
+  it('broadcasts host triggerMethod calls to top-level and nested Behaviors after the host method', function() {
+    const sequence = [];
+    const payload = { value: 'status' };
+    const hostHandler = this.sinon.spy(function() {
+      sequence.push('host');
+    });
+    const parentHandler = this.sinon.spy(function() {
+      sequence.push('parent');
+    });
+    const nestedHandler = this.sinon.spy(function() {
+      sequence.push('nested');
+    });
+    const siblingHandler = this.sinon.spy(function() {
+      sequence.push('sibling');
+    });
+    let parentBehavior;
+    let nestedBehavior;
+    let siblingBehavior;
+
+    const NestedBehavior = Behavior.extend({
+      initialize() {
+        nestedBehavior = this;
+      },
+      onStatusChanged: nestedHandler,
+    });
+    const ParentBehavior = Behavior.extend({
+      behaviors: [NestedBehavior],
+      initialize() {
+        parentBehavior = this;
+      },
+      onStatusChanged: parentHandler,
+    });
+    const SiblingBehavior = Behavior.extend({
+      initialize() {
+        siblingBehavior = this;
+      },
+      onStatusChanged: siblingHandler,
+    });
+    const TestView = View.extend({
+      behaviors: [ParentBehavior, SiblingBehavior],
+      onStatusChanged: hostHandler,
+    });
+    const view = new TestView();
+
+    view.triggerMethod('status:changed', payload, 'extra');
+
+    expect(sequence[0]).to.equal('host');
+    expect(sequence.slice(1)).to.have.members(['parent', 'nested', 'sibling']);
+    [
+      [hostHandler, view],
+      [parentHandler, parentBehavior],
+      [nestedHandler, nestedBehavior],
+      [siblingHandler, siblingBehavior],
+    ].forEach(([handler, context]) => {
+      expect(handler).to.have.been.calledOnce;
+      expect(handler.firstCall.args).to.deep.equal([payload, 'extra']);
+      expect(handler.firstCall.thisValue).to.equal(context);
+    });
+
+    view.destroy();
+  });
+
+  it('keeps Behavior triggerMethod calls local to that Behavior', function() {
+    const payload = { value: 'local' };
+    const senderHandler = this.sinon.spy();
+    const senderEvent = this.sinon.spy();
+    const siblingHandler = this.sinon.spy();
+    const hostHandler = this.sinon.spy();
+    const hostEvent = this.sinon.spy();
+    let senderBehavior;
+
+    const SenderBehavior = Behavior.extend({
+      initialize() {
+        senderBehavior = this;
+      },
+      onLocalChange: senderHandler,
+    });
+    const SiblingBehavior = Behavior.extend({
+      onLocalChange: siblingHandler,
+    });
+    const TestView = View.extend({
+      behaviors: [SenderBehavior, SiblingBehavior],
+      onLocalChange: hostHandler,
+    });
+    const view = new TestView();
+    senderBehavior.on('local:change', senderEvent);
+    view.on('local:change', hostEvent);
+
+    senderBehavior.triggerMethod('local:change', payload);
+
+    expect(senderHandler).to.have.been.calledOnce;
+    expect(senderHandler.firstCall.args).to.deep.equal([payload]);
+    expect(senderHandler.firstCall.thisValue).to.equal(senderBehavior);
+    expect(senderEvent).to.have.been.calledOnce.and.calledWithExactly(payload);
+    expect(siblingHandler).to.not.have.been.called;
+    expect(hostHandler).to.not.have.been.called;
+    expect(hostEvent).to.not.have.been.called;
+
+    view.destroy();
+  });
+
+  it('broadcasts an explicit host triggerMethod call back to every Behavior including the sender', function() {
+    const sequence = [];
+    const payload = { value: 'save' };
+    const hostHandler = this.sinon.spy(function() {
+      sequence.push('host');
+    });
+    const senderHandler = this.sinon.spy(function() {
+      sequence.push('sender');
+    });
+    const siblingHandler = this.sinon.spy(function() {
+      sequence.push('sibling');
+    });
+    let senderBehavior;
+
+    const SenderBehavior = Behavior.extend({
+      initialize() {
+        senderBehavior = this;
+      },
+      onSaveRequested: senderHandler,
+    });
+    const SiblingBehavior = Behavior.extend({
+      onSaveRequested: siblingHandler,
+    });
+    const TestView = View.extend({
+      behaviors: [SenderBehavior, SiblingBehavior],
+      onSaveRequested: hostHandler,
+    });
+    const view = new TestView();
+
+    senderBehavior.view.triggerMethod('save:requested', payload);
+
+    expect(sequence[0]).to.equal('host');
+    expect(sequence.slice(1)).to.have.members(['sender', 'sibling']);
+    expect(hostHandler).to.have.been.calledOnce.and.calledOn(view);
+    expect(senderHandler).to.have.been.calledOnce.and.calledOn(senderBehavior);
+    expect(siblingHandler).to.have.been.calledOnce;
+    [hostHandler, senderHandler, siblingHandler].forEach(handler => {
+      expect(handler.firstCall.args).to.deep.equal([payload]);
+    });
+
+    view.destroy();
+  });
+
+  it('emits Behavior DOM triggers on the host and broadcasts them to all Behaviors', function() {
+    const sequence = [];
+    const hostHandler = this.sinon.spy(function() {
+      sequence.push('host');
+    });
+    const sourceHandler = this.sinon.spy(function() {
+      sequence.push('source');
+    });
+    const nestedHandler = this.sinon.spy(function() {
+      sequence.push('nested');
+    });
+    const siblingHandler = this.sinon.spy(function() {
+      sequence.push('sibling');
+    });
+    let sourceBehavior;
+    let nestedBehavior;
+    let siblingBehavior;
+
+    const NestedBehavior = Behavior.extend({
+      initialize() {
+        nestedBehavior = this;
+      },
+      onSaveRequested: nestedHandler,
+    });
+    const SourceBehavior = Behavior.extend({
+      behaviors: [NestedBehavior],
+      triggers: {
+        'click .save': 'save:requested',
+      },
+      initialize() {
+        sourceBehavior = this;
+      },
+      onSaveRequested: sourceHandler,
+    });
+    const SiblingBehavior = Behavior.extend({
+      initialize() {
+        siblingBehavior = this;
+      },
+      onSaveRequested: siblingHandler,
+    });
+    const TestView = View.extend({
+      behaviors: [SourceBehavior, SiblingBehavior],
+      template() {
+        return '<button class="save">Save</button>';
+      },
+      onSaveRequested: hostHandler,
+    });
+    const view = new TestView();
+    view.render();
+
+    view.el.querySelector('.save').click();
+
+    expect(sequence[0]).to.equal('host');
+    expect(sequence.slice(1)).to.have.members(['source', 'nested', 'sibling']);
+    const event = hostHandler.firstCall.args[1];
+    [
+      [hostHandler, view],
+      [sourceHandler, sourceBehavior],
+      [nestedHandler, nestedBehavior],
+      [siblingHandler, siblingBehavior],
+    ].forEach(([handler, context]) => {
+      expect(handler).to.have.been.calledOnce;
+      expect(handler.firstCall.args).to.deep.equal([view, event]);
+      expect(handler.firstCall.thisValue).to.equal(context);
+    });
+    expect(event.type).to.equal('click');
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
Related #133

## What

- Document the distinction between Behavior-local events and host broadcasts.
- Specify host-first delivery, nested Behavior participation, sender inclusion, and child-view forwarding rules.
- Add contract tests for host `triggerMethod()`, Behavior-local `triggerMethod()`, explicit host sends, and Behavior DOM triggers.

## Why

Behavior communication direction was previously described with incomplete and partly inaccurate proxy language. This slice makes the existing runtime behavior explicit and executable so agents can choose local versus host communication without relying on implementation details.

## Scope

- Documentation and unit-test coverage for Behavior communication only.
- No runtime source, public API, workflow, release, website publishing, or repository-settings changes.
- No ordering guarantee is introduced among sibling or nested Behavior handlers.

## Deployment Impact

No package or application redeploy is required. The documentation workflow validates this change, but Pages publication remains disabled.

## Testing

- `npx vitest run test/unit/behavior-communication-contract.spec.js --coverage.enabled=false` — 4 tests passed.
- `npx eslint test/unit/behavior-communication-contract.spec.js --max-warnings=0` — passed.
- `npm run docs:check` — 29 pages built; 30 HTML files and 288 internal links validated.
- `npm run coverage` — 69 files and 1,171 tests passed at 100% statements, branches, functions, and lines; 19 agent benchmark contract tests passed.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and tests the Behavior communication contract so Behavior-local events stay local and host broadcasts reach every attached Behavior.

- Relates to #133.
- Specifies host-first delivery, nested Behavior participation, sender inclusion, child-view forwarding, and `childViewEvents` host-only handling.
- Adds contract tests for host `triggerMethod()`, Behavior-local `triggerMethod()`, explicit host sends, Behavior DOM triggers, and `childViewEvents` isolation.
- No runtime, API, or deployment changes; docs and unit tests only.

<sup>Written for commit 12f6a63e4eb93f9f560d729df35c9ff7ad9dab14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

