### PR TITLE
docs(benchmark): define cross-revision comparability

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,31 +138,48 @@ budget.
   composing Regions and Applications, repairing lifecycle bugs, adding Behaviors,
   implementing an overlay through a shared host Region, using communication
   boundaries, and proving cleanup.
-- The model version, agent harness, prompt, repository revision, commands, evaluator,
-  and expected outcomes are pinned for each benchmark series.
-- The stable-v5 benchmark uses at least 10 tasks. A Phase 0 pilot predeclares the
-  paired-run count for each task; each count is at least 10 and provides at least 80
+- The model version, agent harness, permissions, commands, evaluator, expected
+  outcomes, repository revisions, and task classification are pinned for each
+  benchmark series.
+- Every task is assigned to one of two strata before its pilot or scored runs. A
+  paired-comparable task uses byte-identical prompts, visible workspaces, hidden
+  acceptance tests, commands, and evaluator rules for the Phase 0 revision and release
+  candidate; only the installed Marionette revision differs, and the objective is
+  achievable through public APIs in both revisions. A candidate-only task is allowed
+  only when its acceptance criteria necessarily exercise an accepted public contract
+  absent from Phase 0. A poor or failed Phase 0 result never justifies reclassification.
+- The stable-v5 benchmark uses at least 10 paired-comparable tasks. Candidate-only
+  tasks do not count toward that floor. Across the full candidate corpus, every named
+  capability area is exercised by at least two independently scored tasks. One task
+  may cover multiple areas, but no single task certifies an area.
+- The classification and run count for every task are predeclared, and every count is
+  at least 10. A Phase 0 pilot sets each paired-comparable task's count with at least 80
   percent power to detect an absolute regression of 15 percentage points. Release
   decisions use one-sided exact McNemar tests and control family-wise error at 0.05
   with the Holm correction. Sample-size planning uses the conservative Bonferroni
-  level of 0.05 divided by the task count and the pilot's one-sided 95 percent upper
-  confidence bound for discordant pairs under that regression alternative. The
-  executable power calculation and inputs are published before candidate runs.
-- Every named capability area is exercised by at least two independently scored
-  tasks. One task may cover multiple areas, but no single task certifies an area.
-- The aggregate fully-correct rate has a 95 percent Wilson lower bound of at least
-  80 percent, and no individual task has a fully-correct point estimate below 60
-  percent. Aborted runs count as not fully correct.
-- Relative to the Phase 0 baseline on the same pinned harness, the fully-correct point
-  estimate does not regress and either improves by at least 20 percentage points or
-  reaches at least 95 percent. Cataloged framework-architecture violations per 100
-  attempted runs fall by at least 50 percent. Violations found before an aborted run
-  still count.
-- No individual task has a statistically significant paired regression after the
-  predeclared multiple-comparison correction.
-- A model or harness change starts a new benchmark series and requires rerunning both
-  the Phase 0 revision and release candidate. Results are not compared across unlike
-  series.
+  level of 0.05 divided by the paired-comparable task count and the pilot's one-sided
+  95 percent upper confidence bound for discordant pairs under that regression
+  alternative. Candidate-only counts, the executable power calculation, and all
+  inputs are published before candidate runs.
+- Across the full candidate corpus, including both strata, the aggregate fully-correct
+  rate has a 95 percent Wilson lower bound of at least 80 percent, and no individual
+  task has a fully-correct point estimate below 60 percent. Aborted runs count as not
+  fully correct.
+- Only the paired-comparable stratum supports relative claims. Relative to its Phase 0
+  baseline on the same pinned harness, the candidate's fully-correct point estimate
+  does not regress and either improves by at least 20 percentage points or reaches at
+  least 95 percent. Cataloged framework-architecture violations per 100 attempted
+  paired-comparable runs fall by at least 50 percent, and no paired-comparable task has
+  a statistically significant regression after the predeclared correction. Violations
+  found before an aborted run still count. Candidate-only results and violations are
+  reported separately and never enter a comparative denominator.
+- A model, harness, permissions, paired task artifact, evaluator, pairing,
+  classification, or statistical-procedure change starts a new benchmark series and
+  requires rerunning both the Phase 0 revision and release candidate. Candidate-only
+  tasks are frozen after their public contracts are accepted and before candidate
+  collection; changing one after collection invalidates the full-corpus candidate
+  result and requires a fresh candidate evaluation. Results are not compared across
+  unlike series.
 
 ## Architecture boundaries
 

--- a/benchmarks/agent/README.md
+++ b/benchmarks/agent/README.md
@@ -40,11 +40,43 @@ abort.
 ## Capability coverage
 
 `capabilities.json` is the canonical vocabulary derived from the capability areas in
-ROADMAP.md and issue #128. A complete corpus contains at least ten real tasks and
-exercises every capability through at least two independently scored tasks. One task
-may exercise several capabilities, but no single task certifies a capability.
+ROADMAP.md and issue #128. A complete corpus contains at least ten paired-comparable
+tasks and exercises every capability through at least two independently scored tasks
+across the full candidate corpus. One task may exercise several capabilities, but no
+single task certifies a capability. Candidate-only tasks do not count toward the
+paired-comparable task floor.
 
-The initial contract deliberately does not select a model or harness, set run counts
-or budgets, define a fallback, or claim benchmark completeness. Those decisions and
-the corpus, profile, evaluator, pilot, results, and rerun instructions are separate
-follow-up evidence.
+## Evaluation strata
+
+The frozen benchmark profile classifies every task before that task's pilot or scored
+runs. The classification and predeclared run count are evaluation inputs; the current
+task metadata schema does not infer either one from a prompt or fixture.
+
+- A **paired-comparable** task uses byte-identical prompts, visible workspaces, hidden
+  acceptance tests, commands, and evaluator rules against the Phase 0 revision and the
+  release candidate. Only the installed Marionette revision differs, and both revisions
+  can complete the objective using their public APIs.
+- A **candidate-only** task is permitted only when its acceptance criteria necessarily
+  exercise an accepted public contract absent from Phase 0. It is not a fallback for a
+  weak baseline result. Its classification and run count are frozen after that public
+  contract is accepted and before candidate results are collected.
+
+Every task receives at least ten predeclared runs. The Phase 0 pilot powers counts for
+the paired-comparable stratum; candidate-only counts are still fixed before collection
+and included in the published run, spend, and elapsed-time envelope.
+
+The absolute fully-correct Wilson gate and per-task floor apply to the full candidate
+corpus, including both strata. Improvement, McNemar non-regression, and relative
+architecture-violation claims use only paired-comparable runs. Candidate-only results
+and violations are reported separately and never improve a comparative denominator.
+
+Changes to the pinned model, harness, permissions, paired task artifacts, evaluator,
+pairing, classification, or statistical procedure start a new series and require a new
+Phase 0 and candidate comparison. Changing a frozen candidate-only task after candidate
+collection invalidates the full-corpus candidate result and requires a fresh candidate
+evaluation. Results from unlike series are not compared.
+
+The initial contract deliberately does not select a model or harness, classify real
+tasks, set run counts or budgets, define a fallback, or claim benchmark completeness.
+Those decisions and the corpus, profile, evaluator, pilot, results, and rerun
+instructions are separate follow-up evidence.


### PR DESCRIPTION
Related #128

## What

- Split the agent benchmark into frozen `paired-comparable` and `candidate-only` evaluation strata.
- Apply absolute candidate-quality gates to the full corpus while limiting improvement, McNemar, and relative architecture-violation claims to the paired stratum.
- Define preclassification, minimum task/run counts, and the changes that invalidate a benchmark series.

## Agent-development failure addressed

New v5 capabilities absent from Phase 0 cannot be scored as though their baseline failure were a comparable regression, while candidate-only successes must not inflate claims that Marionette improved on work both revisions could perform.

## Public behavior contract

- Canonical behavior after this PR: every task is preclassified; at least 10 tasks are genuinely pairable; candidate-only work supports absolute conformance evidence but never comparative claims.
- Superseded behavior removed, if any: the roadmap no longer treats every future benchmark task as implicitly pairable with Phase 0.
- Compatibility exception and removal condition, if any: none; runtime and package APIs are unchanged.

## Runtime cost

- [x] Static or documentation only
- [ ] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: unchanged at 49.82 kB aggregate against the 51.98 kB ceiling.
- Startup/hot path: unchanged; no runtime source is modified.
- Allocations/retention: unchanged; no runtime source is modified.

## Scope

- `ROADMAP.md` measured-agent-outcomes policy.
- `benchmarks/agent/README.md` corpus and evaluation-strata guidance.
- No task schema, capability vocabulary, validator, runtime, workflow, issue status, package, release, website, or repository-settings change.

## Deployment Impact

No package, application, documentation-site, or form deployment is required. Pages publication remains disabled.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npm ci
npm run docs:check
npm run test:agent-benchmark-contract
npm run size
git diff --check
```

Results: 357 locked packages installed with zero vulnerabilities; 29 pages built and 288 internal links validated; 19/19 benchmark-contract tests passed; production size remained 49.82 kB with graphs 40/1/1; the diff check passed.

## Testing

The documentation build/link validator, agent benchmark contract tests, deterministic production size/graph/resource checks, and diff check all passed locally. No browser behavior changed.

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: none.
- Production/dev/test module-graph impact: none.

## Rollback or deprecation

Revert this policy before collecting pilot results if the two-strata model cannot be evaluated consistently; never mix results from the reverted and replacement series.

## Review notes

The future benchmark profile should make classification and run counts machine-readable. This PR intentionally does not change `task.schema.json` because comparability depends on the frozen revision pair rather than task metadata alone.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the agent benchmark into paired-comparable and candidate-only task strata so new-revision-only capabilities aren't scored as regressions against Phase 0 and candidate-only successes can't inflate comparative claims. Relates to #128.

- Every task is now preclassified before pilot or scored runs; at least 10 tasks must be genuinely pairable with Phase 0.
- Relative claims (improvement, McNemar non-regression, architecture-violation reduction) use only paired-comparable runs; candidate-only results are reported separately.
- Absolute quality gates (Wilson lower bound, per-task floor) still apply across the full corpus.
- Changes to the pinned model, harness, permissions, paired task artifacts, evaluator, pairing, classification, or statistical procedure start a new series; changing a frozen candidate-only task invalidates the full-corpus result.
- Documentation-only change; runtime and package APIs are unchanged.

<sup>Written for commit 316279ea289cffc32632d7fa0503e52322991e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

