### PR TITLE
feat(performance): enforce two-stage budget amendments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,10 +5,13 @@
 /config/check-diagnostic-catalog.mjs @paulfalgout @marionettejs/marionette-core
 /.github/workflows/docs-pages.yml @paulfalgout @marionettejs/marionette-core
 /config/performance.json @paulfalgout @marionettejs/marionette-core
+/config/release/performance-budget-amendments.json @paulfalgout @marionettejs/marionette-core
+/config/release/performance-budget-amendments.mjs @paulfalgout @marionettejs/marionette-core
 /config/bundle-size.mjs @paulfalgout @marionettejs/marionette-core
 /config/performance-growth-approval.mjs @paulfalgout @marionettejs/marionette-core
 /config/performance-resources.mjs @paulfalgout @marionettejs/marionette-core
 /benchmarks/ @paulfalgout @marionettejs/marionette-core
+/evidence/performance-budget-amendments/ @paulfalgout @marionettejs/marionette-core
 /test/performance/ @paulfalgout @marionettejs/marionette-core
 /.github/workflows/ci.yml @paulfalgout @marionettejs/marionette-core
 /.github/workflows/performance-approval-refresh.yml @paulfalgout @marionettejs/marionette-core

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -18,7 +18,9 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
           (
             contains(github.event.comment.body, '<!-- marionette-performance-growth-approval:v1 -->') ||
-            contains(github.event.changes.body.from, '<!-- marionette-performance-growth-approval:v1 -->')
+            contains(github.event.changes.body.from, '<!-- marionette-performance-growth-approval:v1 -->') ||
+            contains(github.event.comment.body, '<!-- marionette-performance-budget-amendment:v1 -->') ||
+            contains(github.event.changes.body.from, '<!-- marionette-performance-budget-amendment:v1 -->')
           )
         ) ||
         (
@@ -85,7 +87,7 @@ jobs:
                     . as $comment |
                     (($comment.body // "") |
                       gsub("\r\n"; "\n") |
-                      capture("(?s)^<!-- marionette-performance-growth-approval:v1 -->\\n```json\\n(?<record>.+)\\n```\\n?$")? |
+                      capture("(?s)^<!-- marionette-performance-(?:growth-approval|budget-amendment):v1 -->\\n```json\\n(?<record>.+)\\n```\\n?$")? |
                       .record | fromjson?) as $approval |
                     (($approval.evidenceUrls? | type) == "array") and
                     ($approval.evidenceUrls | index($evidence_url) != null) and

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
-import { relative, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { isDeepStrictEqual, promisify } from 'node:util';
@@ -16,6 +16,10 @@ import {
   resourceReportRows,
   validateCandidateResourceContract,
 } from './performance-resources.mjs';
+import {
+  parseBudgetAmendmentLedger,
+  validateBudgetAmendmentLedger,
+} from './release/performance-budget-amendments.mjs';
 
 const compress = promisify(brotliCompress);
 
@@ -113,7 +117,7 @@ function difference(left, right) {
   return left.filter(value => !rightSet.has(value));
 }
 
-export function validateContract(contract, packageJson, runtimeFiles) {
+export function validateContract(contract, packageJson, runtimeFiles, budgetAmendments = null) {
   const violations = [];
   if (contract.schemaVersion !== 1) {
     violations.push(`Unsupported performance schemaVersion ${contract.schemaVersion}`);
@@ -127,11 +131,15 @@ export function validateContract(contract, packageJson, runtimeFiles) {
     violations.push(`Artifact baselines total ${baselineTotal}; expected ${contract.baseline.totalBrotliBytes}`);
   }
 
-  const expectedCeiling = Math.floor(
-    baselineTotal * (1 + contract.thresholds.cumulativeGrowthPercent / 100)
-  );
-  if (contract.baseline.absoluteCeilingBytes !== expectedCeiling) {
-    violations.push(`Absolute ceiling is ${contract.baseline.absoluteCeilingBytes}; expected ${expectedCeiling}`);
+  if (budgetAmendments) {
+    violations.push(...validateBudgetAmendmentLedger(budgetAmendments, contract));
+  } else {
+    const expectedCeiling = Math.floor(
+      baselineTotal * (1 + contract.thresholds.cumulativeGrowthPercent / 100)
+    );
+    if (contract.baseline.absoluteCeilingBytes !== expectedCeiling) {
+      violations.push(`Absolute ceiling is ${contract.baseline.absoluteCeilingBytes}; expected ${expectedCeiling}`);
+    }
   }
 
   const declaredPaths = collectRuntimePaths({
@@ -356,11 +364,26 @@ async function measureArtifact(root, quality, artifact) {
 export async function measure({
   root = '.',
   configPath = 'config/performance.json',
+  budgetAmendmentsPath,
   checkToolchain = true,
 } = {}) {
   const resolvedRoot = resolve(root);
   const resolvedConfigPath = resolve(configPath);
   const contract = await readJson(resolvedConfigPath);
+  const resolvedBudgetAmendmentsPath = resolve(
+    budgetAmendmentsPath || dirname(resolvedConfigPath),
+    budgetAmendmentsPath ? '' : 'release/performance-budget-amendments.json'
+  );
+  let budgetAmendments = null;
+  try {
+    budgetAmendments = parseBudgetAmendmentLedger(
+      await readFile(resolvedBudgetAmendmentsPath, 'utf8')
+    );
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
   const packageJson = await readJson(resolve(resolvedRoot, 'package.json'));
   const runtimeFiles = await listRuntimeFiles(resolve(resolvedRoot, 'dist')).catch(error => {
     if (error.code !== 'ENOENT') {
@@ -368,7 +391,7 @@ export async function measure({
     }
     return [];
   });
-  const violations = validateContract(contract, packageJson, runtimeFiles);
+  const violations = validateContract(contract, packageJson, runtimeFiles, budgetAmendments);
   if (checkToolchain) {
     violations.push(...await validateToolchain(contract, resolvedRoot));
   }
@@ -836,6 +859,7 @@ export async function main(args = process.argv.slice(2)) {
   const result = await measure({
     root: getArgument(args, '--root', '.'),
     configPath: getArgument(args, '--config', 'config/performance.json'),
+    budgetAmendmentsPath: getArgument(args, '--budget-amendments'),
     checkToolchain: !args.includes('--artifact-graph-only'),
   });
   writeMeasurement(result, args.includes('--json'));

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -1,9 +1,13 @@
 import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { isDeepStrictEqual, promisify } from 'node:util';
+import {
+  evaluateBudgetAmendmentFromCheckouts,
+  validateBudgetAmendmentScope,
+} from './release/performance-budget-amendments.mjs';
 
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
 const requiredRecordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
@@ -309,7 +313,7 @@ function exactObjectFields(value, fields) {
     isDeepStrictEqual(Object.keys(value).sort(), [...fields].sort());
 }
 
-export function validateCandidateGrowthContract(authority, candidate) {
+export function validateCandidateGrowthContract(authority, candidate, { budgetAmendment } = {}) {
   const violations = [];
   if (!authority || typeof authority !== 'object' || !candidate || typeof candidate !== 'object') {
     return ['Authority and candidate performance contracts must be objects'];
@@ -321,6 +325,18 @@ export function validateCandidateGrowthContract(authority, candidate) {
   }
   for (const key of authorityKeys) {
     if (key === 'runtimeArtifacts' || key === 'productionGraphs') {
+      continue;
+    }
+    if (key === 'baseline' && budgetAmendment?.status === 'accepted' &&
+        budgetAmendment.mode === 'consume') {
+      const authorityBaseline = { ...authority.baseline };
+      const candidateBaseline = { ...candidate.baseline };
+      delete authorityBaseline.absoluteCeilingBytes;
+      delete candidateBaseline.absoluteCeilingBytes;
+      if (!isDeepStrictEqual(authorityBaseline, candidateBaseline) ||
+          candidate.baseline.absoluteCeilingBytes !== budgetAmendment.activeCeilingBytes) {
+        violations.push('Candidate performance contract changes exact-base baseline beyond the authorized ceiling');
+      }
       continue;
     }
     if (!isDeepStrictEqual(authority[key], candidate[key])) {
@@ -387,7 +403,8 @@ function reportContractViolations(
   report,
   expectedContract,
   authority,
-  label
+  label,
+  expectedCeiling = authority?.baseline?.absoluteCeilingBytes
 ) {
   const violations = [];
   if (report?.schemaVersion !== 1) {
@@ -397,7 +414,7 @@ function reportContractViolations(
       report?.brotliQuality !== authority?.baseline?.brotliQuality ||
       !isDeepStrictEqual(report?.thresholds, authority?.thresholds) ||
       report?.cumulative?.baselineSize !== authority?.baseline?.totalBrotliBytes ||
-      report?.cumulative?.absoluteCeiling !== authority?.baseline?.absoluteCeilingBytes) {
+      report?.cumulative?.absoluteCeiling !== expectedCeiling) {
     violations.push(`${label} report does not use the exact-base performance authority`);
   }
   if (!Array.isArray(report?.violations)) {
@@ -448,8 +465,10 @@ function reportContractViolations(
   if (!Number.isInteger(report?.cumulative?.size) || report.cumulative.size !== artifactTotal) {
     violations.push(`${label} cumulative size does not equal the complete measured artifact set`);
   }
-  if (artifactTotal > authority?.baseline?.absoluteCeilingBytes) {
-    violations.push(`${label} cumulative size ${artifactTotal} exceeds the exact-base cumulative ceiling ${authority?.baseline?.absoluteCeilingBytes}`);
+  if (artifactTotal > expectedCeiling) {
+    const ceilingAuthority = expectedCeiling === authority?.baseline?.absoluteCeilingBytes ?
+      'exact-base' : 'active';
+    violations.push(`${label} cumulative size ${artifactTotal} exceeds the ${ceilingAuthority} cumulative ceiling ${expectedCeiling}`);
   }
 
   const missingGraphs = [...expectedGraphs.map.keys()]
@@ -516,6 +535,7 @@ export function newProductionReportDelta(baseReport, currentReport) {
 export function requiredNewProductionApproval({
   authorityContract,
   baseReport,
+  budgetAmendment,
   candidateContract,
   currentReport,
 }) {
@@ -529,7 +549,9 @@ export function requiredNewProductionApproval({
     throw new Error(baseViolations.join('; '));
   }
   const effectiveContract = candidateContract || authorityContract;
-  const contractViolations = validateCandidateGrowthContract(authorityContract, effectiveContract);
+  const contractViolations = validateCandidateGrowthContract(authorityContract, effectiveContract, {
+    budgetAmendment,
+  });
   if (contractViolations.length) {
     throw new Error(contractViolations.join('; '));
   }
@@ -537,7 +559,8 @@ export function requiredNewProductionApproval({
     currentReport,
     effectiveContract,
     authorityContract,
-    'Pull request'
+    'Pull request',
+    effectiveContract?.baseline?.absoluteCeilingBytes
   );
   if (currentViolations.length) {
     throw new Error(currentViolations.join('; '));
@@ -625,6 +648,7 @@ export function requiredArtifactGrowth(baseReport, currentReport, thresholdPerce
 export function validateGrowthApproval({
   authorityContract,
   baseReport,
+  budgetAmendment,
   candidateContract,
   comments,
   currentReport,
@@ -639,12 +663,25 @@ export function validateGrowthApproval({
   let newProductionEnforced = false;
   let newSubpaths = [];
   const diagnostics = validateGrowthApprovalPolicy(policy);
+  const consumingBudget = budgetAmendment?.status === 'accepted' &&
+    budgetAmendment.mode === 'consume';
+  if (budgetAmendment && budgetAmendment.status !== 'accepted') {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_BUDGET_AMENDMENT',
+      `Budget-amendment validation failed: ${budgetAmendment.diagnostics?.join('; ') || 'unknown error'}`
+    ));
+  }
   try {
-    required = requiredArtifactGrowth(baseReport, currentReport, thresholdPercent);
+    required = requiredArtifactGrowth(
+      baseReport,
+      currentReport,
+      consumingBudget ? 0 : thresholdPercent
+    );
     if (authorityContract) {
       const validated = requiredNewProductionApproval({
         authorityContract,
         baseReport,
+        budgetAmendment,
         candidateContract,
         currentReport,
       });
@@ -656,11 +693,21 @@ export function validateGrowthApproval({
       newArtifacts = newProduction.artifacts;
       newSubpaths = newProduction.subpaths;
     }
+    if (consumingBudget) {
+      const scopeViolations = validateBudgetAmendmentScope(
+        budgetAmendment.amendment,
+        [...required.map(({ path }) => path), ...newArtifacts.map(({ path }) => path)].sort(),
+        newSubpaths
+      );
+      diagnostics.push(...scopeViolations.map(message =>
+        diagnostic('GROWTH_APPROVAL_BUDGET_SCOPE', message)));
+    }
   } catch (error) {
     diagnostics.push(diagnostic('GROWTH_APPROVAL_REPORT', error.message));
   }
   const result = {
     approval: null,
+    budgetAmendment: budgetAmendment || null,
     diagnostics,
     headSha,
     ignored: [],
@@ -896,6 +943,23 @@ function parsePullRequestNumber(value) {
   return number;
 }
 
+async function pullRequestIdentity(headSha, pullRequestNumber) {
+  if (!process.env.GITHUB_EVENT_PATH) {
+    if (process.env.GITHUB_ACTIONS === 'true') {
+      throw new Error('GITHUB_EVENT_PATH is required for exact-base amendment validation');
+    }
+    return null;
+  }
+  const event = await readJson(process.env.GITHUB_EVENT_PATH);
+  const baseSha = event?.pull_request?.base?.sha;
+  const eventHeadSha = event?.pull_request?.head?.sha;
+  if (!/^[a-f\d]{40}$/.test(baseSha || '') || eventHeadSha !== headSha ||
+      event?.pull_request?.number !== pullRequestNumber) {
+    throw new Error('GitHub pull request event does not match the requested base, head, and number');
+  }
+  return { baseSha };
+}
+
 function blockedResult(error, headSha = null) {
   return {
     approval: null,
@@ -922,20 +986,56 @@ export async function main(args = process.argv.slice(2)) {
       throw new Error(`Requested head SHA ${headSha} does not match checkout ${checkoutHeadSha}`);
     }
     const pullRequestNumber = parsePullRequestNumber(getArgument(args, '--pull-request'));
+    const identity = await pullRequestIdentity(headSha, pullRequestNumber);
     const candidateContractPath = args.includes('--candidate-contract') ?
       getArgument(args, '--candidate-contract') : null;
-    const [contract, candidateContract, baseReport, currentReport, comments, evidenceComments] =
+    const authorityContractPath = getArgument(args, '--contract');
+    const [
+      contract,
+      candidateContract,
+      baseReport,
+      currentReport,
+      comments,
+      evidenceComments,
+    ] =
       await Promise.all([
-        readJson(getArgument(args, '--contract')),
+        readJson(authorityContractPath),
         candidateContractPath ? readJson(candidateContractPath) : null,
         readJson(getArgument(args, '--base-report')),
         readJson(getArgument(args, '--current-report')),
         readJson(getArgument(args, '--comments')),
         readJson(getArgument(args, '--evidence-comments')),
       ]);
+    let hasBudgetAmendmentAuthority = Boolean(identity);
+    try {
+      await readFile(resolve(
+        dirname(authorityContractPath),
+        'release/performance-budget-amendments.json'
+      ));
+      hasBudgetAmendmentAuthority = true;
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    const budgetAmendment = candidateContractPath && hasBudgetAmendmentAuthority ?
+      await evaluateBudgetAmendmentFromCheckouts({
+        approvalComments: comments,
+        authorityContract: contract,
+        authorityContractPath,
+        baseReport,
+        candidateContract,
+        candidateContractPath,
+        currentReport,
+        evidenceComments,
+        expectedBaseHead: identity?.baseSha,
+        headSha,
+        pullRequestNumber,
+      }) : null;
     result = validateGrowthApproval({
       authorityContract: contract,
       baseReport,
+      budgetAmendment,
       candidateContract,
       comments,
       currentReport,

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -334,7 +334,8 @@ export function validateCandidateGrowthContract(authority, candidate, { budgetAm
       delete authorityBaseline.absoluteCeilingBytes;
       delete candidateBaseline.absoluteCeilingBytes;
       if (!isDeepStrictEqual(authorityBaseline, candidateBaseline) ||
-          candidate.baseline.absoluteCeilingBytes !== budgetAmendment.activeCeilingBytes) {
+          candidate.baseline.absoluteCeilingBytes !==
+            budgetAmendment.amendment?.proposedCeilingBytes) {
         violations.push('Candidate performance contract changes exact-base baseline beyond the authorized ceiling');
       }
       continue;
@@ -407,6 +408,8 @@ function reportContractViolations(
   expectedCeiling = authority?.baseline?.absoluteCeilingBytes
 ) {
   const violations = [];
+  const ceilingAuthority = expectedCeiling === authority?.baseline?.absoluteCeilingBytes ?
+    'exact-base' : 'active';
   if (report?.schemaVersion !== 1) {
     violations.push(`${label} report schemaVersion must be 1`);
   }
@@ -415,7 +418,7 @@ function reportContractViolations(
       !isDeepStrictEqual(report?.thresholds, authority?.thresholds) ||
       report?.cumulative?.baselineSize !== authority?.baseline?.totalBrotliBytes ||
       report?.cumulative?.absoluteCeiling !== expectedCeiling) {
-    violations.push(`${label} report does not use the exact-base performance authority`);
+    violations.push(`${label} report does not use the ${ceilingAuthority} performance authority`);
   }
   if (!Array.isArray(report?.violations)) {
     violations.push(`${label} report violations must be an array`);
@@ -466,8 +469,6 @@ function reportContractViolations(
     violations.push(`${label} cumulative size does not equal the complete measured artifact set`);
   }
   if (artifactTotal > expectedCeiling) {
-    const ceilingAuthority = expectedCeiling === authority?.baseline?.absoluteCeilingBytes ?
-      'exact-base' : 'active';
     violations.push(`${label} cumulative size ${artifactTotal} exceeds the ${ceilingAuthority} cumulative ceiling ${expectedCeiling}`);
   }
 
@@ -953,11 +954,13 @@ async function pullRequestIdentity(headSha, pullRequestNumber) {
   const event = await readJson(process.env.GITHUB_EVENT_PATH);
   const baseSha = event?.pull_request?.base?.sha;
   const eventHeadSha = event?.pull_request?.head?.sha;
+  const authorLogin = event?.pull_request?.user?.login;
   if (!/^[a-f\d]{40}$/.test(baseSha || '') || eventHeadSha !== headSha ||
-      event?.pull_request?.number !== pullRequestNumber) {
+      event?.pull_request?.number !== pullRequestNumber ||
+      typeof authorLogin !== 'string' || !authorLogin) {
     throw new Error('GitHub pull request event does not match the requested base, head, and number');
   }
-  return { baseSha };
+  return { authorLogin: authorLogin.toLowerCase(), baseSha };
 }
 
 function blockedResult(error, headSha = null) {
@@ -1030,6 +1033,7 @@ export async function main(args = process.argv.slice(2)) {
         evidenceComments,
         expectedBaseHead: identity?.baseSha,
         headSha,
+        pullRequestAuthorLogin: identity?.authorLogin,
         pullRequestNumber,
       }) : null;
     result = validateGrowthApproval({

--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "entries": []
+}

--- a/config/release/performance-budget-amendments.mjs
+++ b/config/release/performance-budget-amendments.mjs
@@ -1,0 +1,1123 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import { isDeepStrictEqual, promisify } from 'node:util';
+
+const ledgerFields = ['entries', 'schemaVersion'];
+const amendmentFields = [
+  'approvalUrls',
+  'authorizedArtifactPaths',
+  'authorizedNewSubpaths',
+  'evidenceUrls',
+  'id',
+  'implementationIssueUrl',
+  'kind',
+  'previousCeilingBytes',
+  'proposedCeilingBytes',
+  'prototypeBaseCommit',
+  'prototypeCommit',
+  'prototypeContract',
+  'rationale',
+  'reports',
+  'rollbackCondition',
+  'target',
+];
+const revocationFields = [
+  'amendmentId',
+  'approvalUrls',
+  'evidenceUrls',
+  'id',
+  'kind',
+  'rationale',
+];
+const reportFields = ['path', 'role', 'sha256'];
+const prototypeContractFields = ['path', 'sha256'];
+const ledgerPath = 'config/release/performance-budget-amendments.json';
+const documentationPath = 'docs/performance-baselines.md';
+const maximumRecords = 100;
+const maximumScopeEntries = 100;
+const maximumUrls = 20;
+const execFileAsync = promisify(execFile);
+const allowedAuthorAssociations = new Set(['COLLABORATOR', 'MEMBER', 'OWNER']);
+const approvalMarker = '<!-- marionette-performance-budget-amendment:v1 -->';
+
+function exactFields(value, fields) {
+  return value && typeof value === 'object' && !Array.isArray(value) &&
+    isDeepStrictEqual(Object.keys(value).sort(), [...fields].sort());
+}
+
+function uniqueSortedStrings(values, maximum, allowEmpty = false) {
+  return Array.isArray(values) && values.length <= maximum &&
+    (allowEmpty || values.length > 0) &&
+    values.every(value => typeof value === 'string' && value.length > 0) &&
+    values.every((value, index) => index === 0 || values[index - 1] < value);
+}
+
+function validArtifactPath(path) {
+  return typeof path === 'string' &&
+    /^dist\/[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:c|m)?js$/.test(path) &&
+    !path.includes('//') && !path.split('/').includes('..');
+}
+
+function validSubpath(subpath) {
+  return typeof subpath === 'string' &&
+    /^\.\/[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(subpath) &&
+    !subpath.includes('//') && !subpath.split('/').includes('..');
+}
+
+function repositoryUrl(repository, suffix) {
+  const escaped = repository.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^https://github\\.com/${escaped}/${suffix}$`);
+}
+
+function issueUrl(repository, value) {
+  return typeof value === 'string' &&
+    repositoryUrl(repository, 'issues/[1-9]\\d*').test(value);
+}
+
+function issueCommentUrl(repository, value) {
+  return typeof value === 'string' &&
+    repositoryUrl(repository, 'issues/[1-9]\\d*#issuecomment-[1-9]\\d*').test(value);
+}
+
+function pullRequestCommentUrl(repository, value) {
+  return typeof value === 'string' &&
+    repositoryUrl(repository, 'pull/[1-9]\\d*#issuecomment-[1-9]\\d*').test(value);
+}
+
+function trackingIssueCommentUrl(contract, value) {
+  return typeof contract?.pullRequestGrowthApproval?.trackingIssueUrl === 'string' &&
+    new RegExp(`^${contract.pullRequestGrowthApproval.trackingIssueUrl.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&'
+    )}#issuecomment-[1-9]\\d*$`).test(value);
+}
+
+function phase0Ceiling(contract) {
+  const total = contract?.baseline?.totalBrotliBytes;
+  const percent = contract?.thresholds?.cumulativeGrowthPercent;
+  if (!Number.isSafeInteger(total) || total < 0 || !Number.isFinite(percent) || percent < 0) {
+    return null;
+  }
+  const ceiling = Math.floor(total * (1 + percent / 100));
+  return Number.isSafeInteger(ceiling) ? ceiling : null;
+}
+
+function immutableBaseline(contract) {
+  return {
+    sourceCommit: contract?.baseline?.sourceCommit,
+    brotliQuality: contract?.baseline?.brotliQuality,
+    totalBrotliBytes: contract?.baseline?.totalBrotliBytes,
+  };
+}
+
+function validateAuthorization(record, identifier, contract) {
+  const violations = [];
+  const repository = contract?.pullRequestGrowthApproval?.repository || 'invalid/invalid';
+  const expectedId = `BA${String(identifier).padStart(4, '0')}`;
+  if (!exactFields(record, amendmentFields)) {
+    violations.push(`${expectedId} fields do not match the budget-amendment contract`);
+  }
+  if (record.kind !== 'authorization') {
+    violations.push(`${expectedId} kind must be authorization`);
+  }
+  if (record.id !== expectedId) {
+    violations.push(`Budget amendment identifier ${record.id} must be ${expectedId}`);
+  }
+  if (record.target !== 'aggregate-shipped-package') {
+    violations.push(`${record.id} target must be aggregate-shipped-package`);
+  }
+  if (!Number.isSafeInteger(record.previousCeilingBytes) || record.previousCeilingBytes < 0 ||
+      !Number.isSafeInteger(record.proposedCeilingBytes) ||
+      record.proposedCeilingBytes <= record.previousCeilingBytes) {
+    violations.push(`${record.id} must raise a non-negative integer previous ceiling`);
+  }
+  if (typeof record.prototypeCommit !== 'string' ||
+      !/^[a-f\d]{40}$/.test(record.prototypeCommit)) {
+    violations.push(`${record.id} prototypeCommit must be a lowercase full commit SHA`);
+  }
+  if (typeof record.prototypeBaseCommit !== 'string' ||
+      !/^[a-f\d]{40}$/.test(record.prototypeBaseCommit) ||
+      record.prototypeBaseCommit === record.prototypeCommit) {
+    violations.push(`${record.id} prototypeBaseCommit must be a distinct lowercase full commit SHA`);
+  }
+  if (!issueUrl(repository, record.implementationIssueUrl)) {
+    violations.push(`${record.id} implementationIssueUrl must be a repository issue URL`);
+  }
+  if (!uniqueSortedStrings(record.authorizedArtifactPaths, maximumScopeEntries, true) ||
+      !record.authorizedArtifactPaths.every(validArtifactPath)) {
+    violations.push(`${record.id} authorizedArtifactPaths must be sorted safe runtime paths`);
+  }
+  if (!uniqueSortedStrings(record.authorizedNewSubpaths, maximumScopeEntries, true) ||
+      !record.authorizedNewSubpaths.every(validSubpath)) {
+    violations.push(`${record.id} authorizedNewSubpaths must be sorted safe package subpaths`);
+  }
+  if (Array.isArray(record.authorizedArtifactPaths) &&
+      Array.isArray(record.authorizedNewSubpaths) &&
+      !record.authorizedArtifactPaths.length && !record.authorizedNewSubpaths.length) {
+    violations.push(`${record.id} must authorize at least one artifact path or new subpath`);
+  }
+  if (!Array.isArray(record.reports) || !record.reports.length ||
+      record.reports.length > maximumUrls) {
+    violations.push(`${record.id} reports must contain measured report hashes`);
+  } else {
+    const expectedPrefix = `evidence/performance-budget-amendments/${record.id}/`;
+    let previousPath = null;
+    const roles = [];
+    for (const report of record.reports) {
+      if (!exactFields(report, reportFields) || typeof report.path !== 'string' ||
+          !report.path.startsWith(expectedPrefix) ||
+          !/^[A-Za-z0-9][A-Za-z0-9._/-]*\.json$/.test(report.path.slice(expectedPrefix.length)) ||
+          report.path.includes('//') || report.path.split('/').includes('..') ||
+          !['base', 'prototype'].includes(report.role) ||
+          typeof report.sha256 !== 'string' || !/^[a-f\d]{64}$/.test(report.sha256)) {
+        violations.push(`${record.id} reports must use safe immutable JSON paths and SHA-256 hashes`);
+        continue;
+      }
+      if (previousPath !== null && previousPath >= report.path) {
+        violations.push(`${record.id} reports must be sorted with unique paths`);
+      }
+      previousPath = report.path;
+      roles.push(report.role);
+    }
+    if (!isDeepStrictEqual([...roles].sort(), ['base', 'prototype'])) {
+      violations.push(`${record.id} reports must contain exactly one base and one prototype report`);
+    }
+  }
+  const expectedContractPrefix = `evidence/performance-budget-amendments/${record.id}/`;
+  if (!exactFields(record.prototypeContract, prototypeContractFields) ||
+      typeof record.prototypeContract?.path !== 'string' ||
+      !record.prototypeContract.path.startsWith(expectedContractPrefix) ||
+      !record.prototypeContract.path.endsWith('.json') ||
+      record.prototypeContract.path.includes('//') ||
+      record.prototypeContract.path.split('/').includes('..') ||
+      !/^[a-f\d]{64}$/.test(record.prototypeContract?.sha256 || '')) {
+    violations.push(`${record.id} prototypeContract must use a safe immutable JSON path and SHA-256`);
+  }
+  if (!uniqueSortedStrings(record.approvalUrls, 1) ||
+      !record.approvalUrls.every(value => pullRequestCommentUrl(repository, value))) {
+    violations.push(`${record.id} approvalUrls must contain one pull-request comment URL`);
+  }
+  if (!uniqueSortedStrings(record.evidenceUrls, maximumUrls) ||
+      !record.evidenceUrls.every(value => issueCommentUrl(repository, value) &&
+        trackingIssueCommentUrl(contract, value))) {
+    violations.push(`${record.id} evidenceUrls must contain sorted tracking-issue comment URLs`);
+  }
+  for (const field of ['rationale', 'rollbackCondition']) {
+    if (typeof record[field] !== 'string' || !record[field].trim() || record[field].length > 1000) {
+      violations.push(`${record.id} ${field} must be a non-empty string of at most 1000 characters`);
+    }
+  }
+  return violations;
+}
+
+function validateGovernanceUrls(record, contract, identifier) {
+  const repository = contract?.pullRequestGrowthApproval?.repository || 'invalid/invalid';
+  const violations = [];
+  if (!uniqueSortedStrings(record?.approvalUrls, 1) ||
+      !record.approvalUrls.every(value => pullRequestCommentUrl(repository, value))) {
+    violations.push(`${identifier} approvalUrls must contain one pull-request comment URL`);
+  }
+  if (!uniqueSortedStrings(record?.evidenceUrls, maximumUrls) ||
+      !record.evidenceUrls.every(value => issueCommentUrl(repository, value) &&
+        trackingIssueCommentUrl(contract, value))) {
+    violations.push(`${identifier} evidenceUrls must contain sorted tracking-issue comment URLs`);
+  }
+  return violations;
+}
+
+function validateRevocation(record, identifier, contract) {
+  const expectedId = `BR${String(identifier).padStart(4, '0')}`;
+  const violations = [];
+  if (!exactFields(record, revocationFields)) {
+    violations.push(`${expectedId} fields do not match the budget-revocation contract`);
+  }
+  if (record?.kind !== 'revocation') {
+    violations.push(`${expectedId} kind must be revocation`);
+  }
+  if (record?.id !== expectedId) {
+    violations.push(`Budget revocation identifier ${record?.id} must be ${expectedId}`);
+  }
+  if (typeof record?.amendmentId !== 'string' || !/^BA\d{4}$/.test(record.amendmentId)) {
+    violations.push(`${expectedId} amendmentId must reference a budget authorization`);
+  }
+  violations.push(...validateGovernanceUrls(record, contract, expectedId));
+  if (typeof record?.rationale !== 'string' || !record.rationale.trim() ||
+      record.rationale.length > 1000) {
+    violations.push(`${expectedId} rationale must be a non-empty string of at most 1000 characters`);
+  }
+  return violations;
+}
+
+function validateLedger(ledger, contract, label) {
+  const violations = [];
+  if (!exactFields(ledger, ledgerFields) || ledger.schemaVersion !== 1 ||
+      !Array.isArray(ledger.entries) || ledger.entries.length > maximumRecords) {
+    return {
+      pending: null,
+      violations: [`${label} budget-amendment ledger is malformed`],
+    };
+  }
+  const repository = contract?.pullRequestGrowthApproval?.repository;
+  if (typeof repository !== 'string' ||
+      !/^[A-Za-z\d_.-]+\/[A-Za-z\d_.-]+$/.test(repository)) {
+    violations.push(`${label} performance contract repository is malformed`);
+  }
+  const initialCeiling = phase0Ceiling(contract);
+  if (initialCeiling === null) {
+    violations.push(`${label} Phase 0 aggregate ceiling cannot be derived`);
+  }
+  let chainCeiling = initialCeiling;
+  let pending = null;
+  const activeCeiling = contract?.baseline?.absoluteCeilingBytes;
+  let authorizationCount = 0;
+  let revocationCount = 0;
+  for (const [index, entry] of ledger.entries.entries()) {
+    if (entry?.kind === 'authorization') {
+      authorizationCount += 1;
+      violations.push(...validateAuthorization(entry, authorizationCount, contract));
+      if (pending) {
+        if (entry.previousCeilingBytes === pending.proposedCeilingBytes) {
+          chainCeiling = pending.proposedCeilingBytes;
+        } else {
+          violations.push(`${entry.id} follows unresolved pending amendment ${pending.id}`);
+        }
+      }
+      if (entry.previousCeilingBytes !== chainCeiling) {
+        violations.push(`${entry.id} previous ceiling does not continue the immutable amendment chain`);
+      }
+      pending = entry;
+    } else if (entry?.kind === 'revocation') {
+      revocationCount += 1;
+      violations.push(...validateRevocation(entry, revocationCount, contract));
+      if (!pending || entry.amendmentId !== pending.id) {
+        violations.push(`${entry.id || `Record ${index + 1}`} must revoke the currently pending amendment`);
+      } else {
+        pending = null;
+      }
+    } else {
+      violations.push(`${label} ledger entry ${index + 1} has an unsupported kind`);
+    }
+  }
+  if (pending && activeCeiling === pending.proposedCeilingBytes) {
+    chainCeiling = pending.proposedCeilingBytes;
+    pending = null;
+  }
+  if (activeCeiling !== (pending ? pending.previousCeilingBytes : chainCeiling)) {
+    violations.push(`${label} active ceiling does not derive pending or consumed state from the ledger`);
+  }
+  return { pending, violations };
+}
+
+function changedFilesForAuthorization(record) {
+  const evidencePaths = [
+    record?.prototypeContract?.path,
+    ...(Array.isArray(record?.reports) ? record.reports.map(report => report?.path) : []),
+  ].filter(path => typeof path === 'string');
+  return new Set([
+    ledgerPath,
+    documentationPath,
+    ...evidencePaths,
+  ]);
+}
+
+function changedFilesForRevocation() {
+  return new Set([ledgerPath, documentationPath]);
+}
+
+function mapBy(items, key, label) {
+  const map = new Map();
+  const violations = [];
+  if (!Array.isArray(items)) {
+    return { map, violations: [`${label} must be an array`] };
+  }
+  for (const item of items) {
+    const value = item?.[key];
+    if (typeof value !== 'string' || map.has(value)) {
+      violations.push(`${label} has an invalid or duplicate ${key} ${value}`);
+    } else {
+      map.set(value, item);
+    }
+  }
+  return { map, violations };
+}
+
+function validatePrototypeContract(authority, prototype) {
+  const violations = [];
+  if (!authority || typeof authority !== 'object' ||
+      !prototype || typeof prototype !== 'object') {
+    return ['Prototype performance contract must be an object'];
+  }
+  if (!isDeepStrictEqual(Object.keys(authority).sort(), Object.keys(prototype).sort())) {
+    violations.push('Prototype performance contract top-level fields differ from authority');
+  }
+  for (const key of Object.keys(authority)) {
+    if (!['runtimeArtifacts', 'productionGraphs'].includes(key) &&
+        !isDeepStrictEqual(authority[key], prototype[key])) {
+      violations.push(`Prototype performance contract changes authority ${key}`);
+    }
+  }
+  const authorityArtifacts = mapBy(authority.runtimeArtifacts, 'path', 'Authority artifacts');
+  const prototypeArtifacts = mapBy(prototype.runtimeArtifacts, 'path', 'Prototype artifacts');
+  const authorityGraphs = mapBy(authority.productionGraphs, 'subpath', 'Authority graphs');
+  const prototypeGraphs = mapBy(prototype.productionGraphs, 'subpath', 'Prototype graphs');
+  violations.push(
+    ...authorityArtifacts.violations,
+    ...prototypeArtifacts.violations,
+    ...authorityGraphs.violations,
+    ...prototypeGraphs.violations
+  );
+  for (const [path, artifact] of authorityArtifacts.map) {
+    if (!isDeepStrictEqual(prototypeArtifacts.map.get(path), artifact)) {
+      violations.push(`Prototype changes or removes authority artifact ${path}`);
+    }
+  }
+  for (const [path, artifact] of prototypeArtifacts.map) {
+    if (!authorityArtifacts.map.has(path) &&
+        (!exactFields(artifact, ['baselineBrotliBytes', 'name', 'path']) ||
+          !validArtifactPath(path) || typeof artifact.name !== 'string' || !artifact.name ||
+          artifact.baselineBrotliBytes !== 0)) {
+      violations.push(`Prototype new artifact ${path} must have a safe zero-baseline contract`);
+    }
+  }
+  for (const [subpath, graph] of authorityGraphs.map) {
+    if (!isDeepStrictEqual(prototypeGraphs.map.get(subpath), graph)) {
+      violations.push(`Prototype changes or removes authority graph ${subpath}`);
+    }
+  }
+  for (const [subpath, graph] of prototypeGraphs.map) {
+    if (authorityGraphs.map.has(subpath)) {
+      continue;
+    }
+    if (!exactFields(graph, [
+      'baselineExternalImports',
+      'baselineModules',
+      'input',
+      'output',
+      'subpath',
+    ]) || !validSubpath(subpath) || typeof graph.input !== 'string' ||
+        !/^[A-Za-z0-9][A-Za-z0-9._/-]*\.js$/.test(graph.input) ||
+        !validArtifactPath(graph.output) || !Array.isArray(graph.baselineModules) ||
+        graph.baselineModules.length || !Array.isArray(graph.baselineExternalImports) ||
+        graph.baselineExternalImports.length || !prototypeArtifacts.map.has(graph.output)) {
+      violations.push(`Prototype new graph ${subpath} has an invalid additive contract`);
+    }
+  }
+  return violations;
+}
+
+function measuredReport(report, contract, label, expectedCeiling) {
+  const violations = [];
+  if (report?.schemaVersion !== 1 ||
+      report?.baselineSourceCommit !== contract?.baseline?.sourceCommit ||
+      report?.brotliQuality !== contract?.baseline?.brotliQuality ||
+      !isDeepStrictEqual(report?.thresholds, contract?.thresholds) ||
+      report?.cumulative?.baselineSize !== contract?.baseline?.totalBrotliBytes ||
+      report?.cumulative?.absoluteCeiling !== expectedCeiling ||
+      !Array.isArray(report?.artifacts) || !Array.isArray(report?.graphs)) {
+    return { violations: [`${label} is not a compatible bundle-size report`] };
+  }
+  const artifacts = new Map();
+  const expectedArtifacts = mapBy(contract.runtimeArtifacts, 'path', `${label} expected artifacts`);
+  const expectedGraphs = mapBy(contract.productionGraphs, 'subpath', `${label} expected graphs`);
+  violations.push(...expectedArtifacts.violations, ...expectedGraphs.violations);
+  let total = 0;
+  for (const artifact of report.artifacts) {
+    if (typeof artifact?.path !== 'string' || artifacts.has(artifact.path) ||
+        artifact.status !== 'measured' || !Number.isSafeInteger(artifact.size) || artifact.size < 0) {
+      violations.push(`${label} has a malformed or duplicate measured artifact ${artifact?.path}`);
+      continue;
+    }
+    artifacts.set(artifact.path, artifact.size);
+    if (!Number.isSafeInteger(total + artifact.size)) {
+      violations.push(`${label} measured artifact total exceeds the safe integer range`);
+    } else {
+      total += artifact.size;
+    }
+    if (expectedArtifacts.map.get(artifact.path)?.name !== artifact.name) {
+      violations.push(`${label} artifact ${artifact.path} does not match its contract name`);
+    }
+  }
+  const missingArtifacts = [...expectedArtifacts.map.keys()]
+    .filter(path => !artifacts.has(path)).sort();
+  const extraArtifacts = [...artifacts.keys()]
+    .filter(path => !expectedArtifacts.map.has(path)).sort();
+  if (missingArtifacts.length || extraArtifacts.length) {
+    violations.push(`${label} artifact set mismatch; missing: ${missingArtifacts.join(', ') || 'none'}; extra: ${extraArtifacts.join(', ') || 'none'}`);
+  }
+  if (report?.cumulative?.size !== total) {
+    violations.push(`${label} cumulative size does not equal all measured artifacts`);
+  }
+  const expectedViolations = total > expectedCeiling ? [
+    `Cumulative Brotli-${contract.baseline.brotliQuality} size ${total} exceeds the absolute ceiling ${expectedCeiling}`,
+  ] : [];
+  if (!isDeepStrictEqual(report?.violations, expectedViolations)) {
+    violations.push(`${label} violations do not match its measured cumulative result`);
+  }
+  const subpaths = new Set();
+  for (const graph of report.graphs) {
+    if (typeof graph?.subpath !== 'string' || subpaths.has(graph.subpath) ||
+        graph.status !== 'measured' || !Array.isArray(graph.forbiddenModules) ||
+        graph.forbiddenModules.length) {
+      violations.push(`${label} has a malformed, duplicate, or forbidden production graph ${graph?.subpath}`);
+      continue;
+    }
+    subpaths.add(graph.subpath);
+    const expected = expectedGraphs.map.get(graph.subpath);
+    if (expected && (graph.input !== expected.input || graph.output !== expected.output) ||
+        !Array.isArray(graph.modules) || !Array.isArray(graph.externalImports)) {
+      violations.push(`${label} graph ${graph.subpath} does not match its measured contract`);
+    }
+  }
+  const missingGraphs = [...expectedGraphs.map.keys()]
+    .filter(subpath => !subpaths.has(subpath)).sort();
+  const extraGraphs = [...subpaths]
+    .filter(subpath => !expectedGraphs.map.has(subpath)).sort();
+  if (missingGraphs.length || extraGraphs.length) {
+    violations.push(`${label} graph set mismatch; missing: ${missingGraphs.join(', ') || 'none'}; extra: ${extraGraphs.join(', ') || 'none'}`);
+  }
+  return { artifacts, subpaths, total, violations };
+}
+
+function measuredDelta(
+  baseReport,
+  currentReport,
+  contract,
+  label,
+  { baseCeiling, baseContract = contract, currentCeiling, currentContract = contract } = {}
+) {
+  const base = measuredReport(
+    baseReport,
+    baseContract,
+    `${label} base report`,
+    baseCeiling ?? contract.baseline.absoluteCeilingBytes
+  );
+  const current = measuredReport(
+    currentReport,
+    currentContract,
+    `${label} current report`,
+    currentCeiling ?? contract.baseline.absoluteCeilingBytes
+  );
+  const violations = [...base.violations, ...current.violations];
+  if (violations.length) {
+    return { artifactPaths: [], newSubpaths: [], total: null, violations };
+  }
+  const missingArtifacts = [...base.artifacts.keys()]
+    .filter(path => !current.artifacts.has(path)).sort();
+  const missingSubpaths = [...base.subpaths]
+    .filter(subpath => !current.subpaths.has(subpath)).sort();
+  if (missingArtifacts.length) {
+    violations.push(`${label} removes measured artifacts: ${missingArtifacts.join(', ')}`);
+  }
+  if (missingSubpaths.length) {
+    violations.push(`${label} removes measured production subpaths: ${missingSubpaths.join(', ')}`);
+  }
+  const artifactPaths = [...current.artifacts]
+    .filter(([path, size]) => size > (base.artifacts.get(path) ?? 0))
+    .map(([path]) => path).sort();
+  const newSubpaths = [...current.subpaths]
+    .filter(subpath => !base.subpaths.has(subpath)).sort();
+  return { artifactPaths, newSubpaths, total: current.total, violations };
+}
+
+function validateMeasuredScope(amendment, delta, label) {
+  const violations = [...delta.violations];
+  if (!isDeepStrictEqual(delta.artifactPaths, amendment.authorizedArtifactPaths)) {
+    violations.push(`${label} prototype artifact scope does not match ${amendment.id}`);
+  }
+  if (!isDeepStrictEqual(delta.newSubpaths, amendment.authorizedNewSubpaths)) {
+    violations.push(`${label} new subpath scope does not match ${amendment.id}`);
+  }
+  if (delta.total !== null && delta.total <= amendment.previousCeilingBytes) {
+    violations.push(`${label} measured total must exceed the previous ceiling ${amendment.previousCeilingBytes}`);
+  }
+  if (delta.total !== null && delta.total > amendment.proposedCeilingBytes) {
+    violations.push(`${label} measured total exceeds proposed ceiling ${amendment.proposedCeilingBytes}`);
+  }
+  return violations;
+}
+
+function validatePrototypeEvidence(amendment, evidenceReports, contract) {
+  if (!Array.isArray(amendment?.reports) || !amendment?.prototypeContract?.path) {
+    return [`${amendment?.id || 'Budget amendment'} prototype evidence is malformed`];
+  }
+  const reports = new Map(amendment.reports.map(report => [report?.role, report]));
+  const base = evidenceReports?.[reports.get('base')?.path];
+  const prototype = evidenceReports?.[reports.get('prototype')?.path];
+  const prototypeContract = evidenceReports?.[amendment.prototypeContract.path];
+  const violations = [];
+  if (base?.schemaVersion !== 1 || base?.revision !== amendment.prototypeBaseCommit ||
+      prototype?.schemaVersion !== 1 || prototype?.revision !== amendment.prototypeCommit) {
+    violations.push(`${amendment.id} evidence reports do not bind the declared prototype revisions`);
+    return violations;
+  }
+  violations.push(...validatePrototypeContract(contract, prototypeContract));
+  if (violations.length) {
+    return violations;
+  }
+  const delta = measuredDelta(
+    base.report,
+    prototype.report,
+    contract,
+    `${amendment.id} evidence`,
+    {
+      baseCeiling: amendment.previousCeilingBytes,
+      baseContract: contract,
+      currentCeiling: amendment.previousCeilingBytes,
+      currentContract: prototypeContract,
+    }
+  );
+  const authorityArtifacts = new Set(contract.runtimeArtifacts.map(({ path }) => path));
+  const newArtifacts = prototypeContract.runtimeArtifacts
+    .filter(({ path }) => !authorityArtifacts.has(path));
+  if (newArtifacts.length && !delta.newSubpaths.length) {
+    violations.push(`${amendment.id} cannot authorize a new runtime artifact without a new production subpath`);
+  }
+  violations.push(...validateMeasuredScope(amendment, delta, `${amendment.id} evidence`));
+  return violations;
+}
+
+function commentIdentity(contract, comment) {
+  const issueNumber = Number(contract.pullRequestGrowthApproval.trackingIssueUrl.split('/').at(-1));
+  return Number.isSafeInteger(comment?.id) && comment.id > 0 &&
+    comment?.html_url ===
+      `https://github.com/${contract.pullRequestGrowthApproval.repository}/issues/${issueNumber}#issuecomment-${comment.id}`;
+}
+
+function validateGovernanceEvidence({
+  amendment,
+  approvalComments,
+  contract,
+  evidenceComments,
+  headSha,
+  pullRequestNumber,
+}) {
+  const repository = contract?.pullRequestGrowthApproval?.repository;
+  if (approvalComments?.schemaVersion !== 1 || approvalComments.status !== 'ok' ||
+      approvalComments.repository !== repository ||
+      approvalComments.pullRequestNumber !== pullRequestNumber ||
+      !Array.isArray(approvalComments.comments) ||
+      evidenceComments?.schemaVersion !== 1 || evidenceComments.status !== 'ok' ||
+      evidenceComments.repository !== repository || evidenceComments.issueNumber !==
+        Number(contract?.pullRequestGrowthApproval?.trackingIssueUrl?.split('/').at(-1)) ||
+      !Array.isArray(evidenceComments.comments)) {
+    return ['Budget-amendment approval or evidence comment snapshot is missing or malformed'];
+  }
+  const evidence = new Map(evidenceComments.comments
+    .filter(comment => commentIdentity(contract, comment))
+    .map(comment => [comment.html_url, comment]));
+  const allowedLogins = new Set(
+    Array.isArray(contract.pullRequestGrowthApproval.allowedLogins) ?
+      contract.pullRequestGrowthApproval.allowedLogins : []
+  );
+  const violations = [];
+  const trustedMarked = approvalComments.comments.filter(comment => {
+    const login = comment?.user?.login?.toLowerCase();
+    return comment?.user?.type === 'User' &&
+      allowedAuthorAssociations.has(comment?.author_association) &&
+      allowedLogins.has(login) && budgetApprovalTargetsEntry(comment?.body, amendment);
+  });
+  const canonical = trustedMarked.filter(comment =>
+    parseBudgetAmendmentApproval(comment.body, amendment, headSha));
+  if (canonical.length !== 1 || trustedMarked.length !== canonical.length) {
+    violations.push(`${amendment.id} must have exactly one canonical exact-head maintainer approval`);
+  }
+  for (const url of Array.isArray(amendment.approvalUrls) ? amendment.approvalUrls : []) {
+    const comment = approvalComments.comments.find(value => value?.html_url === url &&
+      Number.isSafeInteger(value?.id) && value.id > 0 &&
+      url === `https://github.com/${repository}/pull/${pullRequestNumber}#issuecomment-${value.id}`);
+    const login = comment?.user?.login?.toLowerCase();
+    if (comment?.user?.type !== 'User' ||
+        !allowedAuthorAssociations.has(comment?.author_association) ||
+        !allowedLogins.has(login) ||
+        !parseBudgetAmendmentApproval(comment?.body, amendment, headSha)) {
+      violations.push(`${amendment.id} approval URL does not resolve to one canonical exact-head maintainer approval: ${url}`);
+    }
+  }
+  for (const url of Array.isArray(amendment.evidenceUrls) ? amendment.evidenceUrls : []) {
+    const comment = evidence.get(url);
+    if (comment?.user?.type !== 'User' ||
+        !allowedAuthorAssociations.has(comment?.author_association)) {
+      violations.push(`${amendment.id} evidence URL does not resolve to a trusted comment: ${url}`);
+    }
+  }
+  return violations;
+}
+
+export function formatBudgetAmendmentLedger(ledger) {
+  return `${JSON.stringify(ledger, null, 2)}\n`;
+}
+
+function entryDigest(entry) {
+  return createHash('sha256').update(`${JSON.stringify(entry, null, 2)}\n`).digest('hex');
+}
+
+export function formatBudgetAmendmentApproval(entry, headSha) {
+  const record = {
+    schemaVersion: 1,
+    action: entry.kind === 'revocation' ? 'revoke' : 'authorize',
+    headSha,
+    entryId: entry.id,
+    entrySha256: entryDigest(entry),
+    evidenceUrls: entry.evidenceUrls,
+  };
+  return `${approvalMarker}\n\`\`\`json\n${JSON.stringify(record, null, 2)}\n\`\`\``;
+}
+
+function parseBudgetAmendmentApproval(body, entry, headSha) {
+  if (typeof body !== 'string' || !body.includes(approvalMarker)) {
+    return false;
+  }
+  const normalized = body.replaceAll('\r\n', '\n').replace(/\n$/, '');
+  const match = normalized.match(
+    /^<!-- marionette-performance-budget-amendment:v1 -->\n```json\n([\s\S]+)\n```$/
+  );
+  if (!match) {
+    return false;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    return false;
+  }
+  return normalized === formatBudgetAmendmentApproval(entry, headSha) &&
+    parsed.headSha === headSha && parsed.entryId === entry.id;
+}
+
+function budgetApprovalTargetsEntry(body, entry) {
+  if (typeof body !== 'string' || !body.includes(approvalMarker)) {
+    return false;
+  }
+  const match = body.replaceAll('\r\n', '\n').match(
+    /^<!-- marionette-performance-budget-amendment:v1 -->\n```json\n([\s\S]+)\n```\n?$/
+  );
+  if (!match) {
+    return true;
+  }
+  try {
+    return JSON.parse(match[1]).entryId === entry.id;
+  } catch {
+    return true;
+  }
+}
+
+export function parseBudgetAmendmentLedger(text) {
+  let ledger;
+  try {
+    ledger = JSON.parse(text);
+  } catch {
+    throw new Error('Budget-amendment ledger is not valid JSON');
+  }
+  if (text !== formatBudgetAmendmentLedger(ledger)) {
+    throw new Error('Budget-amendment ledger must use canonical JSON formatting');
+  }
+  return ledger;
+}
+
+export function validateBudgetAmendmentLedger(ledger, contract) {
+  return validateLedger(ledger, contract, 'Active').violations;
+}
+
+export function bootstrapBudgetAmendmentLedger(baseHead) {
+  if (baseHead !== '154a8bb43f81a1836fcd70c014f4301e750bcb77') {
+    throw new Error(`Missing exact-base budget-amendment ledger at ${baseHead}`);
+  }
+  return { schemaVersion: 1, entries: [] };
+}
+
+export function validateBudgetAmendmentTransition({
+  authorityContract,
+  authorityLedger,
+  candidateContract,
+  candidateLedger,
+  changedFiles = [],
+  changedFileEntries,
+  currentReport,
+  baseReport,
+  approvalComments,
+  evidenceComments,
+  evidenceReports = {},
+  reportHashes = {},
+  headSha,
+  pullRequestNumber,
+}) {
+  const diagnostics = [];
+  const authority = validateLedger(authorityLedger, authorityContract, 'Exact-base');
+  const candidate = validateLedger(candidateLedger, candidateContract, 'Candidate');
+  diagnostics.push(...authority.violations, ...candidate.violations);
+
+  if (!isDeepStrictEqual(immutableBaseline(authorityContract), immutableBaseline(candidateContract)) ||
+      !isDeepStrictEqual(authorityContract?.thresholds, candidateContract?.thresholds)) {
+    diagnostics.push('Candidate changes the immutable Phase 0 baseline or thresholds');
+  }
+
+  const authorityRecords = Array.isArray(authorityLedger?.entries) ? authorityLedger.entries : [];
+  const candidateRecords = Array.isArray(candidateLedger?.entries) ? candidateLedger.entries : [];
+  if (candidateRecords.length < authorityRecords.length) {
+    diagnostics.push('Candidate deletes budget-amendment history from the exact base');
+  }
+  for (const [index, record] of authorityRecords.entries()) {
+    if (!isDeepStrictEqual(candidateRecords[index], record)) {
+      diagnostics.push(`Candidate changes or reorders exact-base budget amendment ${record?.id || index + 1}`);
+    }
+  }
+  if (candidateRecords.length > authorityRecords.length + 1) {
+    diagnostics.push('Candidate may append only one budget amendment at a time');
+  }
+  for (const record of candidateRecords.filter(entry => entry?.kind === 'authorization')) {
+    const evidenceRecords = [
+      record?.prototypeContract,
+      ...(Array.isArray(record?.reports) ? record.reports : []),
+    ].filter(value => typeof value?.path === 'string');
+    for (const evidenceRecord of evidenceRecords) {
+      if (reportHashes[evidenceRecord.path] !== evidenceRecord.sha256) {
+        diagnostics.push(`${record.id} evidence ${evidenceRecord.path} SHA-256 does not match its ledger record`);
+      }
+    }
+  }
+
+  const appended = candidateRecords.length === authorityRecords.length + 1 ?
+    candidateRecords.at(-1) : null;
+  const authorityCeiling = authorityContract?.baseline?.absoluteCeilingBytes;
+  const candidateCeiling = candidateContract?.baseline?.absoluteCeilingBytes;
+  const ceilingChanged = authorityCeiling !== candidateCeiling;
+  let amendment = null;
+  let mode = 'none';
+
+  if (appended?.kind === 'authorization') {
+    mode = 'authorize';
+    amendment = appended;
+    if (ceilingChanged) {
+      diagnostics.push('A pull request cannot add and consume its own budget amendment');
+    }
+    if (authority.pending) {
+      diagnostics.push(`Cannot append ${appended.id} while ${authority.pending.id} is pending`);
+    }
+    const allowed = changedFilesForAuthorization(appended);
+    const unauthorized = changedFiles.filter(path => !allowed.has(path)).sort();
+    const evidenceRecords = [
+      appended?.prototypeContract,
+      ...(Array.isArray(appended?.reports) ? appended.reports : []),
+    ].filter(value => typeof value?.path === 'string');
+    const missing = [ledgerPath, ...evidenceRecords.map(record => record.path)]
+      .filter(path => !changedFiles.includes(path));
+    if (unauthorized.length || missing.length) {
+      diagnostics.push(
+        `An authorization pull request may change only its ledger, immutable evidence, and performance documentation; unauthorized: ${unauthorized.join(', ') || 'none'}; missing: ${missing.join(', ') || 'none'}`
+      );
+    }
+    if (changedFileEntries) {
+      for (const path of changedFiles) {
+        const change = changedFileEntries[path];
+        if (change?.candidateMode !== '100644' || change.status === 'deleted') {
+          diagnostics.push(`Authorization file ${path} must be a regular committed file`);
+        }
+      }
+      for (const path of [ledgerPath, ...evidenceRecords.map(record => record.path)]) {
+        const change = changedFileEntries[path];
+        if (!change || change.candidateMode !== '100644' ||
+            (path !== ledgerPath && change.status !== 'added')) {
+          diagnostics.push(`Authorization file ${path} must be a regular committed ${path === ledgerPath ? 'ledger' : 'new evidence'} file`);
+        }
+      }
+    }
+    diagnostics.push(...validatePrototypeEvidence(appended, evidenceReports, authorityContract));
+    diagnostics.push(...validateGovernanceEvidence({
+      amendment: appended,
+      approvalComments,
+      contract: authorityContract,
+      evidenceComments,
+      headSha,
+      pullRequestNumber,
+    }));
+  } else if (appended?.kind === 'revocation') {
+    mode = 'revoke';
+    amendment = authority.pending;
+    if (ceilingChanged) {
+      diagnostics.push('A revocation pull request cannot change the active ceiling');
+    }
+    if (!authority.pending || appended.amendmentId !== authority.pending.id) {
+      diagnostics.push(`${appended.id} does not revoke the pending exact-base amendment`);
+    }
+    const allowed = changedFilesForRevocation();
+    const unauthorized = changedFiles.filter(path => !allowed.has(path)).sort();
+    if (!changedFiles.includes(ledgerPath) || unauthorized.length) {
+      diagnostics.push(
+        `A revocation pull request may change only its ledger and performance documentation; unauthorized: ${unauthorized.join(', ') || 'none'}`
+      );
+    }
+    if (changedFileEntries && changedFileEntries[ledgerPath]?.candidateMode !== '100644') {
+      diagnostics.push('Revocation ledger must be a regular committed file');
+    }
+    if (changedFileEntries) {
+      for (const path of changedFiles) {
+        const change = changedFileEntries[path];
+        if (change?.candidateMode !== '100644' || change.status === 'deleted') {
+          diagnostics.push(`Revocation file ${path} must be a regular committed file`);
+        }
+      }
+    }
+    diagnostics.push(...validateGovernanceEvidence({
+      amendment: appended,
+      approvalComments,
+      contract: authorityContract,
+      evidenceComments,
+      headSha,
+      pullRequestNumber,
+    }));
+  } else if (ceilingChanged) {
+    mode = 'consume';
+    amendment = authority.pending;
+    if (!amendment) {
+      diagnostics.push('Candidate changes the ceiling without a pending exact-base amendment');
+    } else if (candidateCeiling !== amendment.proposedCeilingBytes) {
+      diagnostics.push(`Candidate ceiling must consume ${amendment.id} proposed ceiling ${amendment.proposedCeilingBytes}`);
+    } else if (!baseReport || !currentReport) {
+      diagnostics.push('Consuming a budget amendment requires exact-base and current measured reports');
+    } else {
+      const delta = measuredDelta(
+        baseReport,
+        currentReport,
+        authorityContract,
+        `${amendment.id} consumption`,
+        {
+          baseCeiling: amendment.previousCeilingBytes,
+          baseContract: authorityContract,
+          currentCeiling: amendment.proposedCeilingBytes,
+          currentContract: candidateContract,
+        }
+      );
+      diagnostics.push(...validateMeasuredScope(amendment, delta, `${amendment.id} consumption`));
+    }
+  }
+
+  return {
+    activeCeilingBytes: candidateCeiling,
+    amendment,
+    diagnostics,
+    mode,
+    requiresExactHeadGrowthApproval: mode === 'consume',
+    schemaVersion: 1,
+    status: diagnostics.length ? 'rejected' : 'accepted',
+  };
+}
+
+function parseTree(output) {
+  const files = new Map();
+  for (const entry of output.split('\0')) {
+    if (!entry) {
+      continue;
+    }
+    const match = entry.match(/^(\d+) (\w+) ([a-f\d]+)\t(.+)$/s);
+    if (!match) {
+      throw new Error('Unable to parse committed Git tree');
+    }
+    files.set(match[4], { mode: match[1], object: match[3], type: match[2] });
+  }
+  return files;
+}
+
+async function committedTree(root) {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['-C', root, 'ls-tree', '-r', '-z', '--full-tree', 'HEAD'],
+    { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
+  );
+  return parseTree(stdout);
+}
+
+async function checkoutHead(root) {
+  const { stdout } = await execFileAsync('git', ['-C', root, 'rev-parse', 'HEAD'], {
+    encoding: 'utf8',
+  });
+  return stdout.trim();
+}
+
+async function committedCheckoutState(
+  baseRoot,
+  candidateRoot,
+  expectedHead,
+  expectedBaseHead
+) {
+  const [baseTree, candidateTree, baseHead, candidateHead] = await Promise.all([
+    committedTree(baseRoot),
+    committedTree(candidateRoot),
+    checkoutHead(baseRoot),
+    checkoutHead(candidateRoot),
+  ]);
+  if (candidateHead !== expectedHead) {
+    throw new Error(`Requested head SHA ${expectedHead} does not match checkout ${candidateHead}`);
+  }
+  if (expectedBaseHead && baseHead !== expectedBaseHead) {
+    throw new Error(`Requested base SHA ${expectedBaseHead} does not match authority checkout ${baseHead}`);
+  }
+  const paths = [...new Set([...baseTree.keys(), ...candidateTree.keys()])].sort();
+  const entries = {};
+  for (const path of paths) {
+    const base = baseTree.get(path);
+    const candidate = candidateTree.get(path);
+    if (base?.mode === candidate?.mode && base?.type === candidate?.type &&
+        base?.object === candidate?.object) {
+      continue;
+    }
+    entries[path] = {
+      baseMode: base?.mode || null,
+      candidateMode: candidate?.mode || null,
+      status: !base ? 'added' : !candidate ? 'deleted' : 'modified',
+    };
+  }
+  return { baseHead, baseTree, candidateHead, candidateTree, entries, paths: Object.keys(entries) };
+}
+
+export async function committedCheckoutChanges(
+  baseRoot,
+  candidateRoot,
+  expectedHead,
+  expectedBaseHead
+) {
+  const state = await committedCheckoutState(
+    baseRoot,
+    candidateRoot,
+    expectedHead,
+    expectedBaseHead
+  );
+  return { entries: state.entries, paths: state.paths };
+}
+
+async function committedBlob(root, tree, path) {
+  const entry = tree.get(path);
+  if (!entry || entry.mode !== '100644' || entry.type !== 'blob') {
+    const error = new Error(`Committed file ${path} is missing or is not a regular blob`);
+    error.code = 'COMMITTED_FILE_INVALID';
+    throw error;
+  }
+  const { stdout } = await execFileAsync('git', ['-C', root, 'cat-file', 'blob', entry.object], {
+    encoding: null,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+export async function readCommittedBudgetFile(root, path, expectedHead) {
+  const [tree, head] = await Promise.all([committedTree(root), checkoutHead(root)]);
+  if (head !== expectedHead) {
+    throw new Error(`Requested head SHA ${expectedHead} does not match checkout ${head}`);
+  }
+  return committedBlob(root, tree, path);
+}
+
+async function committedLedger(root, tree) {
+  const contents = await committedBlob(root, tree, ledgerPath);
+  return parseBudgetAmendmentLedger(contents.toString('utf8'));
+}
+
+async function evidenceFiles(candidateRoot, candidateTree, candidateLedger) {
+  const reports = candidateLedger.entries
+    .filter(entry => entry.kind === 'authorization')
+    .flatMap(entry => [
+      entry?.prototypeContract,
+      ...(Array.isArray(entry?.reports) ? entry.reports : []),
+    ]);
+  const hashes = {};
+  const values = {};
+  for (const report of reports) {
+    if (typeof report?.path !== 'string' ||
+        !report.path.startsWith('evidence/performance-budget-amendments/') ||
+        report.path.includes('//') || report.path.split('/').includes('..')) {
+      continue;
+    }
+    const contents = await committedBlob(candidateRoot, candidateTree, report.path);
+    hashes[report.path] = createHash('sha256').update(contents).digest('hex');
+    try {
+      values[report.path] = JSON.parse(contents);
+    } catch {
+      values[report.path] = null;
+    }
+  }
+  return { hashes, values };
+}
+
+export async function evaluateBudgetAmendmentFromCheckouts({
+  approvalComments,
+  authorityContract,
+  authorityContractPath,
+  baseReport,
+  candidateContract,
+  candidateRoot = '.',
+  currentReport,
+  evidenceComments,
+  expectedBaseHead,
+  headSha,
+  pullRequestNumber,
+}) {
+  const authorityRoot = resolve(dirname(authorityContractPath), '..');
+  const resolvedCandidateRoot = resolve(candidateRoot);
+  const state = await committedCheckoutState(
+    authorityRoot,
+    resolvedCandidateRoot,
+    headSha,
+    expectedBaseHead
+  );
+  let authorityLedger;
+  let bootstrap = false;
+  try {
+    authorityLedger = await committedLedger(authorityRoot, state.baseTree);
+  } catch (error) {
+    if (error.code !== 'COMMITTED_FILE_INVALID') {
+      throw error;
+    }
+    authorityLedger = bootstrapBudgetAmendmentLedger(state.baseHead);
+    bootstrap = true;
+  }
+  const candidateLedger = await committedLedger(resolvedCandidateRoot, state.candidateTree);
+  if (bootstrap && candidateLedger.entries.length) {
+    throw new Error('The pinned empty-ledger bootstrap cannot add an authorization');
+  }
+  const [committedAuthorityContract, committedCandidateContract] = await Promise.all([
+    committedBlob(authorityRoot, state.baseTree, 'config/performance.json')
+      .then(contents => JSON.parse(contents.toString('utf8'))),
+    committedBlob(resolvedCandidateRoot, state.candidateTree, 'config/performance.json')
+      .then(contents => JSON.parse(contents.toString('utf8'))),
+  ]);
+  if (!isDeepStrictEqual(authorityContract, committedAuthorityContract) ||
+      !isDeepStrictEqual(candidateContract, committedCandidateContract)) {
+    throw new Error('Performance contracts differ from their verified committed Git blobs');
+  }
+  const evidence = await evidenceFiles(
+    resolvedCandidateRoot,
+    state.candidateTree,
+    candidateLedger
+  );
+  return validateBudgetAmendmentTransition({
+    approvalComments,
+    authorityContract,
+    authorityLedger,
+    baseReport,
+    candidateContract,
+    candidateLedger,
+    changedFileEntries: state.entries,
+    changedFiles: state.paths,
+    currentReport,
+    evidenceComments,
+    evidenceReports: evidence.values,
+    headSha,
+    pullRequestNumber,
+    reportHashes: evidence.hashes,
+  });
+}
+
+export function validateBudgetAmendmentScope(amendment, artifactPaths, newSubpaths) {
+  const unauthorizedArtifacts = artifactPaths
+    .filter(path => !amendment.authorizedArtifactPaths.includes(path)).sort();
+  const unauthorizedSubpaths = newSubpaths
+    .filter(path => !amendment.authorizedNewSubpaths.includes(path)).sort();
+  const violations = [];
+  if (unauthorizedArtifacts.length) {
+    violations.push(`Budget amendment ${amendment.id} does not authorize artifacts: ${unauthorizedArtifacts.join(', ')}`);
+  }
+  if (unauthorizedSubpaths.length) {
+    violations.push(`Budget amendment ${amendment.id} does not authorize new subpaths: ${unauthorizedSubpaths.join(', ')}`);
+  }
+  return violations;
+}

--- a/config/release/performance-budget-amendments.mjs
+++ b/config/release/performance-budget-amendments.mjs
@@ -59,6 +59,12 @@ function validArtifactPath(path) {
     !path.includes('//') && !path.split('/').includes('..');
 }
 
+function validSourcePath(path) {
+  return typeof path === 'string' &&
+    /^[A-Za-z0-9][A-Za-z0-9._/-]*\.js$/.test(path) &&
+    !path.includes('//') && !path.split('/').includes('..');
+}
+
 function validSubpath(subpath) {
   return typeof subpath === 'string' &&
     /^\.\/[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(subpath) &&
@@ -188,7 +194,9 @@ function validateAuthorization(record, identifier, contract) {
   if (!exactFields(record.prototypeContract, prototypeContractFields) ||
       typeof record.prototypeContract?.path !== 'string' ||
       !record.prototypeContract.path.startsWith(expectedContractPrefix) ||
-      !record.prototypeContract.path.endsWith('.json') ||
+      !/^[A-Za-z0-9][A-Za-z0-9._/-]*\.json$/.test(
+        record.prototypeContract.path.slice(expectedContractPrefix.length)
+      ) ||
       record.prototypeContract.path.includes('//') ||
       record.prototypeContract.path.split('/').includes('..') ||
       !/^[a-f\d]{64}$/.test(record.prototypeContract?.sha256 || '')) {
@@ -395,8 +403,7 @@ function validatePrototypeContract(authority, prototype) {
       'input',
       'output',
       'subpath',
-    ]) || !validSubpath(subpath) || typeof graph.input !== 'string' ||
-        !/^[A-Za-z0-9][A-Za-z0-9._/-]*\.js$/.test(graph.input) ||
+    ]) || !validSubpath(subpath) || !validSourcePath(graph.input) ||
         !validArtifactPath(graph.output) || !Array.isArray(graph.baselineModules) ||
         graph.baselineModules.length || !Array.isArray(graph.baselineExternalImports) ||
         graph.baselineExternalImports.length || !prototypeArtifacts.map.has(graph.output)) {

--- a/config/release/performance-budget-amendments.mjs
+++ b/config/release/performance-budget-amendments.mjs
@@ -627,11 +627,13 @@ function validateGovernanceEvidence({
   if (!authorLogin) {
     violations.push('Pull request author login is missing or malformed');
   }
+  const soleMaintainerAttestation = allowedLogins.size === 1 &&
+    allowedLogins.has(authorLogin);
   const trustedMarked = approvalComments.comments.filter(comment => {
     const login = normalizedLogin(comment?.user?.login);
     return comment?.user?.type === 'User' &&
       allowedAuthorAssociations.has(comment?.author_association) &&
-      allowedLogins.has(login) && login !== authorLogin &&
+      allowedLogins.has(login) && (login !== authorLogin || soleMaintainerAttestation) &&
       budgetApprovalTargetsEntry(comment?.body, amendment);
   });
   const canonical = trustedMarked.filter(comment =>
@@ -647,7 +649,7 @@ function validateGovernanceEvidence({
     if (comment?.user?.type !== 'User' ||
         !allowedAuthorAssociations.has(comment?.author_association) ||
         !allowedLogins.has(login) ||
-        login === authorLogin ||
+        (login === authorLogin && !soleMaintainerAttestation) ||
         !parseBudgetAmendmentApproval(comment?.body, amendment, headSha)) {
       violations.push(`${amendment.id} approval URL does not resolve to one canonical exact-head maintainer approval: ${url}`);
     }

--- a/config/release/performance-budget-amendments.mjs
+++ b/config/release/performance-budget-amendments.mjs
@@ -591,12 +591,17 @@ function commentIdentity(contract, comment) {
       `https://github.com/${contract.pullRequestGrowthApproval.repository}/issues/${issueNumber}#issuecomment-${comment.id}`;
 }
 
+function normalizedLogin(value) {
+  return typeof value === 'string' ? value.toLowerCase() : null;
+}
+
 function validateGovernanceEvidence({
   amendment,
   approvalComments,
   contract,
   evidenceComments,
   headSha,
+  pullRequestAuthorLogin,
   pullRequestNumber,
 }) {
   const repository = contract?.pullRequestGrowthApproval?.repository;
@@ -618,11 +623,16 @@ function validateGovernanceEvidence({
       contract.pullRequestGrowthApproval.allowedLogins : []
   );
   const violations = [];
+  const authorLogin = normalizedLogin(pullRequestAuthorLogin);
+  if (!authorLogin) {
+    violations.push('Pull request author login is missing or malformed');
+  }
   const trustedMarked = approvalComments.comments.filter(comment => {
-    const login = comment?.user?.login?.toLowerCase();
+    const login = normalizedLogin(comment?.user?.login);
     return comment?.user?.type === 'User' &&
       allowedAuthorAssociations.has(comment?.author_association) &&
-      allowedLogins.has(login) && budgetApprovalTargetsEntry(comment?.body, amendment);
+      allowedLogins.has(login) && login !== authorLogin &&
+      budgetApprovalTargetsEntry(comment?.body, amendment);
   });
   const canonical = trustedMarked.filter(comment =>
     parseBudgetAmendmentApproval(comment.body, amendment, headSha));
@@ -633,10 +643,11 @@ function validateGovernanceEvidence({
     const comment = approvalComments.comments.find(value => value?.html_url === url &&
       Number.isSafeInteger(value?.id) && value.id > 0 &&
       url === `https://github.com/${repository}/pull/${pullRequestNumber}#issuecomment-${value.id}`);
-    const login = comment?.user?.login?.toLowerCase();
+    const login = normalizedLogin(comment?.user?.login);
     if (comment?.user?.type !== 'User' ||
         !allowedAuthorAssociations.has(comment?.author_association) ||
         !allowedLogins.has(login) ||
+        login === authorLogin ||
         !parseBudgetAmendmentApproval(comment?.body, amendment, headSha)) {
       violations.push(`${amendment.id} approval URL does not resolve to one canonical exact-head maintainer approval: ${url}`);
     }
@@ -747,6 +758,7 @@ export function validateBudgetAmendmentTransition({
   evidenceReports = {},
   reportHashes = {},
   headSha,
+  pullRequestAuthorLogin,
   pullRequestNumber,
 }) {
   const diagnostics = [];
@@ -836,6 +848,7 @@ export function validateBudgetAmendmentTransition({
       contract: authorityContract,
       evidenceComments,
       headSha,
+      pullRequestAuthorLogin,
       pullRequestNumber,
     }));
   } else if (appended?.kind === 'revocation') {
@@ -871,6 +884,7 @@ export function validateBudgetAmendmentTransition({
       contract: authorityContract,
       evidenceComments,
       headSha,
+      pullRequestAuthorLogin,
       pullRequestNumber,
     }));
   } else if (ceilingChanged) {
@@ -1056,8 +1070,12 @@ export async function evaluateBudgetAmendmentFromCheckouts({
   evidenceComments,
   expectedBaseHead,
   headSha,
+  pullRequestAuthorLogin,
   pullRequestNumber,
 }) {
+  if (typeof expectedBaseHead !== 'string' || !/^[a-f\d]{40}$/.test(expectedBaseHead)) {
+    throw new Error('Budget-amendment evaluation requires an independently verified base SHA');
+  }
   const authorityRoot = resolve(dirname(authorityContractPath), '..');
   const resolvedCandidateRoot = resolve(candidateRoot);
   const state = await committedCheckoutState(
@@ -1109,6 +1127,7 @@ export async function evaluateBudgetAmendmentFromCheckouts({
     evidenceComments,
     evidenceReports: evidence.values,
     headSha,
+    pullRequestAuthorLogin,
     pullRequestNumber,
     reportHashes: evidence.hashes,
   });

--- a/config/release/performance-budget-amendments.mjs
+++ b/config/release/performance-budget-amendments.mjs
@@ -675,7 +675,7 @@ function parseBudgetAmendmentApproval(body, entry, headSha) {
   if (typeof body !== 'string' || !body.includes(approvalMarker)) {
     return false;
   }
-  const normalized = body.replaceAll('\r\n', '\n').replace(/\n$/, '');
+  const normalized = body.replaceAll('\r\n', '\n').replace(/\s+$/, '');
   const match = normalized.match(
     /^<!-- marionette-performance-budget-amendment:v1 -->\n```json\n([\s\S]+)\n```$/
   );
@@ -696,8 +696,8 @@ function budgetApprovalTargetsEntry(body, entry) {
   if (typeof body !== 'string' || !body.includes(approvalMarker)) {
     return false;
   }
-  const match = body.replaceAll('\r\n', '\n').match(
-    /^<!-- marionette-performance-budget-amendment:v1 -->\n```json\n([\s\S]+)\n```\n?$/
+  const match = body.replaceAll('\r\n', '\n').replace(/\s+$/, '').match(
+    /^<!-- marionette-performance-budget-amendment:v1 -->\n```json\n([\s\S]+)\n```$/
   );
   if (!match) {
     return true;

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -35,11 +35,9 @@ backstop are independent hard gates. These fixtures are not implemented yet and 
 tracked by issue #127, so the current command enforces only the aggregate package
 backstop and per-artifact comparison described below.
 
-The Phase 0 baseline never changes. Before the initial package ceiling or a future
-consumer-scenario ceiling can change, issue #127 must implement a versioned two-stage
-amendment protocol: a governance change records exact prototype and scenario evidence,
-then a later runtime implementation may consume that authorization. A runtime change
-cannot raise its own ceiling.
+The Phase 0 baseline never changes. Aggregate package ceiling changes use the
+versioned, two-stage amendment protocol described below. Consumer-scenario targets
+remain unsupported until issue #127 establishes their canonical fixtures.
 
 The same command asks Rollup for the actual internal modules and external imports of
 `.`, `./backbone`, and `./jquery-dom-api`. It records graph changes and fails if test,
@@ -61,6 +59,77 @@ two objects are emptied. These measurements are structural ownership proxies. Th
 detect eager containers, listener ownership, managed DOM cleanup, and known internal
 cycles deterministically; they are not heap-size, reachability, leak-detector, or
 garbage-collector proof.
+
+## Budget amendments
+
+[`config/release/performance-budget-amendments.json`](https://github.com/marionettejs/marionette/blob/master/config/release/performance-budget-amendments.json)
+is an append-only governance ledger outside the production package. The initial
+ledger is empty. Its entries are either authorizations with sequential `BA0001`
+identifiers or revocations with sequential `BR0001` identifiers. There is no mutable
+status field. The active ceiling and entry order derive whether the latest
+authorization is pending, consumed, or revoked.
+
+An authorization records only the `aggregate-shipped-package` target, its previous
+and proposed ceilings, exact prototype base and head commits, an implementation issue,
+the complete positive-delta artifact and new-subpath scope, and exactly one base and
+one prototype report. Each evidence file is an immutable wrapper containing
+`schemaVersion: 1`, its exact measured `revision`, and the ordinary JSON bundle-size
+`report`; the ledger binds that file with its canonical path and SHA-256. The single
+approval URL must resolve to a canonical exact-head pull-request comment from a
+base-allowed maintainer. Evidence URLs remain durable issue #127 comments from trusted
+repository participants. The record also preserves its rationale and rollback
+condition.
+
+The approval comment contains only the
+`marionette-performance-budget-amendment:v1` marker and canonical JSON. It binds the
+action (`authorize` or `revoke`), full pull-request head SHA, entry identifier,
+SHA-256 of the canonical complete entry, and its evidence URLs. Missing, stale,
+malformed, unrelated, or multiple allowed-maintainer records fail closed. Creating,
+editing, or deleting this marked pull-request comment queues the same exact-head
+`Bundle size` refresh used by ordinary growth approvals. Editing or deleting a
+referenced issue #127 evidence comment routes through the approval's bound
+`evidenceUrls` and also refreshes the affected open pull request.
+
+Authorization is the first stage. It may append one record while leaving the active
+ceiling unchanged. The exact-base validator derives the committed change set directly
+from the separate base and head Git trees. Only
+`config/release/performance-budget-amendments.json`, the new record's regular evidence files
+under `evidence/performance-budget-amendments/<id>/`, and
+`docs/performance-baselines.md` may change. Evidence symlinks, missing or edited report
+files, hash or revision mismatches, scope mismatches, unrelated source or workflow
+changes, and adding and consuming a record together fail closed. The prototype's
+measured aggregate must exceed the previous ceiling without exceeding the proposal.
+A new runtime artifact also requires a measured new production subpath, matching the
+later new-production adoption contract. Every later pull request rechecks each
+historical evidence blob against its immutable ledger hash.
+
+Consumption is a later implementation based on the merged authorization. It leaves
+the ledger byte-for-byte unchanged and may change the active ceiling only from that
+pending record's previous value to its proposed value. Exact-base and current reports
+must show the same complete positive-delta artifact and new-subpath scope, with a
+current aggregate above the previous ceiling and no greater than the proposal. The
+ordinary exact-head growth approval remains independently required for every positive
+artifact delta, including changes at or below the usual one-percent threshold.
+
+If a pending implementation is abandoned, a governance-only revocation appends a
+record naming that exact authorization. A revocation cannot change the ceiling and may
+change only the ledger and this document. Consumed authorizations and revocations stay
+in history; neither the Phase 0 record nor earlier entries may be edited, deleted, or
+reordered.
+
+The required workflow already invokes the exact-base growth evaluator with both
+contracts and reports. That evaluator automatically loads both ledgers and compares
+the two committed Git trees, so amendment enforcement does not depend on candidate
+workflow arguments. The one-time empty-ledger activation is pinned to base
+`154a8bb43f81a1836fcd70c014f4301e750bcb77`: that base cannot validate the new
+external ledger, but this activation contains no authorization and changes no ceiling.
+Every descendant uses the merged exact-base parser and ledger. This is authority
+within the repository's required-workflow trust model, not a claim of cryptographic
+protection from repository-administrator rule changes.
+
+The ledger, parser, reports, tests, and documentation are absent from package exports
+and the measured production graphs remain byte-for-byte free of them. They add no
+production artifact, module, allocation, subscription, or runtime work.
 
 ## Pull request comparison
 

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -80,6 +80,12 @@ base-allowed maintainer. Evidence URLs remain durable issue #127 comments from t
 repository participants. The record also preserves its rationale and rollback
 condition.
 
+The approval must come from a different base-allowed maintainer whenever the exact-base
+allowlist contains an eligible alternative. If the pull-request author is the sole
+allowlisted maintainer, that maintainer may provide the canonical exact-head
+attestation so the two-stage protocol remains usable. Adding another allowlisted
+maintainer automatically makes distinct approval mandatory.
+
 The approval comment contains only the
 `marionette-performance-budget-amendment:v1` marker and canonical JSON. It binds the
 action (`authorize` or `revoke`), full pull-request head SHA, entry identifier,

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -795,12 +795,41 @@ describe('two-stage performance budget amendments', () => {
     assert.equal(malformedResult.status, 'rejected');
     assert.match(malformedResult.diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
 
+    const soleMaintainerApproved = transition({
+      ...options,
+      pullRequestAuthorLogin: 'paulfalgout',
+    });
+    assert.equal(soleMaintainerApproved.status, 'accepted',
+      soleMaintainerApproved.diagnostics.join('\n'));
+
+    const twoMaintainers = contract();
+    twoMaintainers.pullRequestGrowthApproval.allowedLogins = ['other-maintainer', 'paulfalgout'];
     const selfApproved = transition({
       ...options,
+      authorityContract: twoMaintainers,
+      candidateContract: twoMaintainers,
+      evidence: {
+        ...evidenceReports(),
+        [prototypeContractPath]: twoMaintainers,
+      },
       pullRequestAuthorLogin: 'paulfalgout',
     });
     assert.equal(selfApproved.status, 'rejected');
     assert.match(selfApproved.diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
+
+    const alternateApproved = transition({
+      ...options,
+      authorityContract: twoMaintainers,
+      candidateContract: twoMaintainers,
+      comments: trustedComments({ approvalLogin: 'other-maintainer' }),
+      evidence: {
+        ...evidenceReports(),
+        [prototypeContractPath]: twoMaintainers,
+      },
+      pullRequestAuthorLogin: 'paulfalgout',
+    });
+    assert.equal(alternateApproved.status, 'accepted',
+      alternateApproved.diagnostics.join('\n'));
     assert.match(transition({
       ...options,
       comments: trustedComments({ evidenceAssociation: 'NONE' }),
@@ -966,7 +995,7 @@ describe('two-stage performance budget amendments', () => {
     assert.equal(result.amendment.id, 'BA0001');
     assert.equal(result.requiresExactHeadGrowthApproval, false);
 
-    const selfApproved = transition({
+    const soleMaintainerApproved = transition({
       authorityLedger: ledger([record]),
       candidateLedger: ledger([record, revoked]),
       changedFiles: [
@@ -975,7 +1004,7 @@ describe('two-stage performance budget amendments', () => {
       ],
       pullRequestAuthorLogin: 'paulfalgout',
     });
-    assert.equal(selfApproved.status, 'rejected');
-    assert.match(selfApproved.diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
+    assert.equal(soleMaintainerApproved.status, 'accepted',
+      soleMaintainerApproved.diagnostics.join('\n'));
   });
 });

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -1,0 +1,759 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import {
+  bootstrapBudgetAmendmentLedger,
+  committedCheckoutChanges,
+  formatBudgetAmendmentLedger,
+  formatBudgetAmendmentApproval,
+  parseBudgetAmendmentLedger,
+  readCommittedBudgetFile,
+  validateBudgetAmendmentTransition,
+} from '../../config/release/performance-budget-amendments.mjs';
+
+const initialCeiling = 51975;
+const proposedCeiling = 53000;
+const baseReportPath = 'evidence/performance-budget-amendments/BA0001/base.json';
+const prototypeContractPath =
+  'evidence/performance-budget-amendments/BA0001/prototype-contract.json';
+const reportPath = 'evidence/performance-budget-amendments/BA0001/prototype.json';
+const baseReportHash = '0'.repeat(64);
+const prototypeContractHash = '2'.repeat(64);
+const reportHash = '1'.repeat(64);
+const headSha = '9999999990abcdef1234567890abcdef12345678';
+const root = fileURLToPath(new URL('../..', import.meta.url));
+
+function contract(ceiling = initialCeiling) {
+  return {
+    schemaVersion: 1,
+    baseline: {
+      sourceCommit: '31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4',
+      brotliQuality: 11,
+      totalBrotliBytes: 49500,
+      absoluteCeilingBytes: ceiling,
+    },
+    thresholds: {
+      cumulativeGrowthPercent: 5,
+    },
+    pullRequestGrowthApproval: {
+      repository: 'marionettejs/marionette',
+      trackingIssueUrl: 'https://github.com/marionettejs/marionette/issues/127',
+      allowedLogins: ['paulfalgout'],
+    },
+    runtimeArtifacts: [{
+      name: 'Main',
+      path: 'dist/marionette.js',
+      baselineBrotliBytes: 49500,
+    }],
+    productionGraphs: [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/marionette.js',
+      baselineModules: ['index.js'],
+      baselineExternalImports: [],
+    }],
+    forbiddenProductionModulePrefixes: ['test/'],
+    forbiddenProductionModules: ['config/performance.json'],
+  };
+}
+
+function amendment(overrides = {}) {
+  return {
+    kind: 'authorization',
+    id: 'BA0001',
+    target: 'aggregate-shipped-package',
+    previousCeilingBytes: initialCeiling,
+    proposedCeilingBytes: proposedCeiling,
+    prototypeBaseCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+    prototypeCommit: '1234567890abcdef1234567890abcdef12345678',
+    implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/205',
+    authorizedArtifactPaths: ['dist/marionette.js'],
+    authorizedNewSubpaths: [],
+    reports: [
+      { path: baseReportPath, role: 'base', sha256: baseReportHash },
+      { path: reportPath, role: 'prototype', sha256: reportHash },
+    ],
+    prototypeContract: {
+      path: prototypeContractPath,
+      sha256: prototypeContractHash,
+    },
+    approvalUrls: [
+      'https://github.com/marionettejs/marionette/pull/1#issuecomment-100',
+    ],
+    evidenceUrls: [
+      'https://github.com/marionettejs/marionette/issues/127#issuecomment-101',
+    ],
+    rationale: 'The measured prototype needs a bounded aggregate package increase.',
+    rollbackCondition: 'Remove the unconsumed authorization if the implementation is abandoned.',
+    ...overrides,
+  };
+}
+
+function ledger(entries = []) {
+  return { schemaVersion: 1, entries };
+}
+
+function revocation() {
+  return {
+    kind: 'revocation',
+    id: 'BR0001',
+    amendmentId: 'BA0001',
+    approvalUrls: [
+      'https://github.com/marionettejs/marionette/pull/1#issuecomment-300',
+    ],
+    evidenceUrls: [
+      'https://github.com/marionettejs/marionette/issues/127#issuecomment-301',
+    ],
+    rationale: 'The implementation was abandoned before consuming the authorization.',
+  };
+}
+
+function measuredReport(size, { ceiling = initialCeiling, subpaths = ['.'] } = {}) {
+  return {
+    schemaVersion: 1,
+    baselineSourceCommit: '31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4',
+    brotliQuality: 11,
+    thresholds: { cumulativeGrowthPercent: 5 },
+    artifacts: [{ name: 'Main', path: 'dist/marionette.js', status: 'measured', size }],
+    cumulative: { size, baselineSize: 49500, absoluteCeiling: ceiling },
+    graphs: subpaths.map(subpath => ({
+      subpath,
+      input: subpath === '.' ? 'index.js' : 'feature.js',
+      output: 'dist/marionette.js',
+      status: 'measured',
+      modules: ['index.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    })),
+    violations: size > ceiling ? [
+      `Cumulative Brotli-11 size ${size} exceeds the absolute ceiling ${ceiling}`,
+    ] : [],
+  };
+}
+
+function evidenceReports() {
+  return {
+    [baseReportPath]: {
+      schemaVersion: 1,
+      revision: 'abcdef1234567890abcdef1234567890abcdef12',
+      report: measuredReport(51000),
+    },
+    [reportPath]: {
+      schemaVersion: 1,
+      revision: '1234567890abcdef1234567890abcdef12345678',
+      report: measuredReport(52000),
+    },
+    [prototypeContractPath]: contract(),
+  };
+}
+
+function evidenceHashes() {
+  return {
+    [baseReportPath]: baseReportHash,
+    [prototypeContractPath]: prototypeContractHash,
+    [reportPath]: reportHash,
+  };
+}
+
+function trustedComments({ approvalLogin = 'paulfalgout', evidenceAssociation = 'MEMBER' } = {}) {
+  const authorization = amendment();
+  const revoked = revocation();
+  return {
+    approval: {
+      schemaVersion: 1,
+      status: 'ok',
+      repository: 'marionettejs/marionette',
+      pullRequestNumber: 1,
+      comments: [
+        {
+          id: 100,
+          'author_association': 'OWNER',
+          'html_url': 'https://github.com/marionettejs/marionette/pull/1#issuecomment-100',
+          body: formatBudgetAmendmentApproval(authorization, headSha),
+          user: { login: approvalLogin, type: 'User' },
+        },
+        {
+          id: 300,
+          'author_association': 'OWNER',
+          'html_url': 'https://github.com/marionettejs/marionette/pull/1#issuecomment-300',
+          body: formatBudgetAmendmentApproval(revoked, headSha),
+          user: { login: approvalLogin, type: 'User' },
+        },
+      ],
+    },
+    evidence: {
+      schemaVersion: 1,
+      status: 'ok',
+      repository: 'marionettejs/marionette',
+      issueNumber: 127,
+      comments: [
+        {
+          id: 101,
+          'author_association': evidenceAssociation,
+          'html_url': 'https://github.com/marionettejs/marionette/issues/127#issuecomment-101',
+          user: { login: 'evidence-author', type: 'User' },
+        },
+        {
+          id: 301,
+          'author_association': evidenceAssociation,
+          'html_url': 'https://github.com/marionettejs/marionette/issues/127#issuecomment-301',
+          user: { login: 'evidence-author', type: 'User' },
+        },
+      ],
+    },
+  };
+}
+
+function transition({
+  authorityContract = contract(),
+  authorityLedger = ledger(),
+  candidateContract = contract(),
+  candidateLedger = ledger(),
+  changedFiles = [],
+  changedFileEntries,
+  currentReport,
+  baseReport,
+  evidence = evidenceReports(),
+  comments = trustedComments(),
+  reportHashes = evidenceHashes(),
+  currentHead = headSha,
+} = {}) {
+  return validateBudgetAmendmentTransition({
+    authorityContract,
+    authorityLedger,
+    candidateContract,
+    candidateLedger,
+    changedFileEntries,
+    changedFiles,
+    currentReport,
+    baseReport,
+    approvalComments: comments.approval,
+    evidenceComments: comments.evidence,
+    evidenceReports: evidence,
+    headSha: currentHead,
+    pullRequestNumber: 1,
+    reportHashes,
+  });
+}
+
+describe('two-stage performance budget amendments', () => {
+  test('parses only the canonical versioned ledger', () => {
+    const value = ledger([amendment()]);
+    const text = formatBudgetAmendmentLedger(value);
+
+    assert.deepEqual(parseBudgetAmendmentLedger(text), value);
+    assert.throws(() => parseBudgetAmendmentLedger(text.trim()), /canonical JSON/);
+    assert.throws(
+      () => parseBudgetAmendmentLedger(text.replace('"schemaVersion": 1,',
+        '"schemaVersion": 1,\n  "schemaVersion": 1,')),
+      /canonical JSON/
+    );
+  });
+
+  test('binds committed change discovery to the exact candidate HEAD', async() => {
+    const head = spawnSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+    }).stdout.trim();
+    assert.deepEqual(await committedCheckoutChanges(root, root, head), {
+      entries: {},
+      paths: [],
+    });
+    await assert.rejects(
+      committedCheckoutChanges(root, root, '0'.repeat(40)),
+      /does not match checkout/
+    );
+    await assert.rejects(
+      committedCheckoutChanges(root, root, head, '0'.repeat(40)),
+      /does not match authority checkout/
+    );
+  });
+
+  test('pins the one-time missing-ledger bootstrap to the reviewed base', () => {
+    assert.deepEqual(
+      bootstrapBudgetAmendmentLedger('154a8bb43f81a1836fcd70c014f4301e750bcb77'),
+      ledger()
+    );
+    assert.throws(
+      () => bootstrapBudgetAmendmentLedger('0'.repeat(40)),
+      /Missing exact-base budget-amendment ledger/
+    );
+  });
+
+  test('reads authority inputs from the verified committed blob, not dirty worktree data', async() => {
+    const fixture = await mkdtemp(join(tmpdir(), 'marionette-budget-git-'));
+    try {
+      for (const args of [
+        ['init'],
+        ['config', 'user.email', 'test@example.com'],
+        ['config', 'user.name', 'Test'],
+      ]) {
+        assert.equal(spawnSync('git', args, { cwd: fixture }).status, 0);
+      }
+      await writeFile(join(fixture, 'ledger.json'), 'committed\n');
+      assert.equal(spawnSync('git', ['add', 'ledger.json'], { cwd: fixture }).status, 0);
+      assert.equal(spawnSync('git', ['commit', '-m', 'test: fixture'], {
+        cwd: fixture,
+      }).status, 0);
+      const head = spawnSync('git', ['rev-parse', 'HEAD'], {
+        cwd: fixture,
+        encoding: 'utf8',
+      }).stdout.trim();
+      await writeFile(join(fixture, 'ledger.json'), 'dirty\n');
+
+      assert.equal(
+        (await readCommittedBudgetFile(fixture, 'ledger.json', head)).toString('utf8'),
+        'committed\n'
+      );
+    } finally {
+      await rm(fixture, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts an authorization append without changing the active ceiling', () => {
+    const record = amendment();
+    const result = transition({
+      candidateLedger: ledger([record]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        'docs/performance-baselines.md',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    });
+
+    assert.equal(result.status, 'accepted', result.diagnostics.join('\n'));
+    assert.equal(result.mode, 'authorize');
+    assert.equal(result.amendment.id, 'BA0001');
+    assert.equal(result.activeCeilingBytes, initialCeiling);
+    assert.equal(result.requiresExactHeadGrowthApproval, false);
+  });
+
+  test('accepts later consumption only from a merged pending authority record', () => {
+    const record = amendment();
+    const result = transition({
+      authorityLedger: ledger([record]),
+      candidateContract: contract(proposedCeiling),
+      candidateLedger: ledger([record]),
+      baseReport: measuredReport(51000),
+      currentReport: measuredReport(52000, { ceiling: proposedCeiling }),
+      changedFiles: ['config/performance.json', 'modules/feature.js'],
+    });
+
+    assert.equal(result.status, 'accepted');
+    assert.equal(result.mode, 'consume');
+    assert.equal(result.amendment.id, 'BA0001');
+    assert.equal(result.activeCeilingBytes, proposedCeiling);
+    assert.equal(result.requiresExactHeadGrowthApproval, true);
+  });
+
+  test('rejects adding and consuming an authorization in one pull request', () => {
+    const record = amendment();
+    const result = transition({
+      candidateContract: contract(proposedCeiling),
+      candidateLedger: ledger([record]),
+      changedFiles: ['config/release/performance-budget-amendments.json', 'config/performance.json'],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.match(result.diagnostics.join('\n'), /cannot add and consume/i);
+  });
+
+  test('rejects record edits, deletion, reordering, and identifier reuse', () => {
+    const first = amendment();
+    const second = amendment({
+      id: 'BA0002',
+      previousCeilingBytes: proposedCeiling,
+      proposedCeilingBytes: 54000,
+      prototypeCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+      prototypeBaseCommit: '1234567890abcdef1234567890abcdef12345678',
+      implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/206',
+      reports: [
+        {
+          path: 'evidence/performance-budget-amendments/BA0002/base.json',
+          role: 'base',
+          sha256: '2'.repeat(64),
+        },
+        {
+          path: 'evidence/performance-budget-amendments/BA0002/prototype.json',
+          role: 'prototype',
+          sha256: '3'.repeat(64),
+        },
+      ],
+      prototypeContract: {
+        path: 'evidence/performance-budget-amendments/BA0002/prototype-contract.json',
+        sha256: '4'.repeat(64),
+      },
+      approvalUrls: [
+        'https://github.com/marionettejs/marionette/pull/1#issuecomment-200',
+      ],
+      evidenceUrls: [
+        'https://github.com/marionettejs/marionette/issues/127#issuecomment-201',
+      ],
+    });
+    const authorityLedger = ledger([first, second]);
+
+    for (const candidateLedger of [
+      ledger([amendment({ rationale: 'Rewritten.' }), second]),
+      ledger([first]),
+      ledger([second, first]),
+      ledger([first, { ...second, id: 'BA0001' }]),
+    ]) {
+      const result = transition({ authorityLedger, candidateLedger });
+      assert.equal(result.status, 'rejected');
+    }
+  });
+
+  test('rejects multiple pending records and a broken ceiling chain', () => {
+    const second = amendment({
+      id: 'BA0002',
+      previousCeilingBytes: proposedCeiling,
+      proposedCeilingBytes: 54000,
+      prototypeCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+      prototypeBaseCommit: '1234567890abcdef1234567890abcdef12345678',
+      implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/206',
+      reports: [
+        {
+          path: 'evidence/performance-budget-amendments/BA0002/base.json',
+          role: 'base',
+          sha256: '2'.repeat(64),
+        },
+        {
+          path: 'evidence/performance-budget-amendments/BA0002/prototype.json',
+          role: 'prototype',
+          sha256: '3'.repeat(64),
+        },
+      ],
+      prototypeContract: {
+        path: 'evidence/performance-budget-amendments/BA0002/prototype-contract.json',
+        sha256: '4'.repeat(64),
+      },
+      approvalUrls: [
+        'https://github.com/marionettejs/marionette/pull/1#issuecomment-200',
+      ],
+      evidenceUrls: [
+        'https://github.com/marionettejs/marionette/issues/127#issuecomment-201',
+      ],
+    });
+
+    assert.equal(transition({
+      authorityLedger: ledger([amendment(), second]),
+      candidateLedger: ledger([amendment(), second]),
+    }).status, 'rejected');
+
+    assert.match(transition({
+      authorityLedger: ledger([amendment({ previousCeilingBytes: 50000 })]),
+      candidateLedger: ledger([amendment({ previousCeilingBytes: 50000 })]),
+    }).diagnostics.join('\n'), /previous ceiling/i);
+  });
+
+  test('rejects unauthorized ceiling changes and immutable baseline rewrites', () => {
+    assert.match(transition({
+      candidateContract: contract(53000),
+    }).diagnostics.join('\n'), /pending exact-base amendment/i);
+
+    const rewritten = contract();
+    rewritten.baseline.totalBrotliBytes = 49000;
+    assert.match(transition({
+      candidateContract: rewritten,
+    }).diagnostics.join('\n'), /immutable Phase 0 baseline/i);
+  });
+
+  test('rejects report hash mismatches and authorization pull request scope escapes', () => {
+    const record = amendment();
+    const options = {
+      candidateLedger: ledger([record]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: 'f'.repeat(64),
+      },
+    };
+
+    assert.match(transition(options).diagnostics.join('\n'), /SHA-256/i);
+    assert.match(transition({
+      ...options,
+      changedFiles: [...options.changedFiles, 'modules/view.js'],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    }).diagnostics.join('\n'), /authorization pull request may change only/i);
+
+    assert.match(transition({
+      ...options,
+      changedFileEntries: {
+        'config/release/performance-budget-amendments.json': {
+          candidateMode: '100644', status: 'modified',
+        },
+        [baseReportPath]: { candidateMode: '120000', status: 'added' },
+        [prototypeContractPath]: { candidateMode: '100644', status: 'added' },
+        [reportPath]: { candidateMode: '100644', status: 'added' },
+      },
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    }).diagnostics.join('\n'), /regular committed/);
+  });
+
+  test('revalidates immutable evidence hashes after authorization is merged', () => {
+    const record = amendment();
+    const ordinary = transition({
+      authorityLedger: ledger([record]),
+      candidateLedger: ledger([record]),
+      changedFiles: [reportPath],
+      reportHashes: {
+        ...evidenceHashes(),
+        [reportPath]: 'f'.repeat(64),
+      },
+    });
+    assert.match(ordinary.diagnostics.join('\n'), /SHA-256/i);
+
+    const consumption = transition({
+      authorityLedger: ledger([record]),
+      candidateContract: contract(proposedCeiling),
+      candidateLedger: ledger([record]),
+      baseReport: measuredReport(51000),
+      currentReport: measuredReport(52000, { ceiling: proposedCeiling }),
+      reportHashes: {
+        ...evidenceHashes(),
+        [prototypeContractPath]: 'f'.repeat(64),
+      },
+    });
+    assert.match(consumption.diagnostics.join('\n'), /SHA-256/i);
+  });
+
+  test('derives the complete authorization scope and ceiling from prototype evidence', () => {
+    const wrongScope = amendment({ authorizedArtifactPaths: ['dist/other.js'] });
+    assert.match(transition({
+      candidateLedger: ledger([wrongScope]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    }).diagnostics.join('\n'), /prototype artifact scope/i);
+
+    const belowOldCeiling = evidenceReports();
+    belowOldCeiling[reportPath].report = measuredReport(51900);
+    assert.match(transition({
+      candidateLedger: ledger([amendment()]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      evidence: belowOldCeiling,
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    }).diagnostics.join('\n'), /must exceed the previous ceiling/i);
+
+    const artifactWithoutSubpath = evidenceReports();
+    artifactWithoutSubpath[prototypeContractPath].runtimeArtifacts.push({
+      name: 'Feature',
+      path: 'dist/feature.js',
+      baselineBrotliBytes: 0,
+    });
+    artifactWithoutSubpath[reportPath].report.artifacts.push({
+      name: 'Feature',
+      path: 'dist/feature.js',
+      status: 'measured',
+      size: 4,
+    });
+    artifactWithoutSubpath[reportPath].report.cumulative.size = 52004;
+    artifactWithoutSubpath[reportPath].report.violations = [
+      `Cumulative Brotli-11 size 52004 exceeds the absolute ceiling ${initialCeiling}`,
+    ];
+    assert.match(transition({
+      candidateLedger: ledger([amendment({
+        authorizedArtifactPaths: ['dist/feature.js', 'dist/marionette.js'],
+      })]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      evidence: artifactWithoutSubpath,
+    }).diagnostics.join('\n'), /new runtime artifact without a new production subpath/i);
+  });
+
+  test('requires approval and evidence URLs to resolve to trusted issue comments', () => {
+    const options = {
+      candidateLedger: ledger([amendment()]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    };
+    assert.match(transition({
+      ...options,
+      comments: trustedComments({ approvalLogin: 'attacker' }),
+    }).diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
+    assert.match(transition({
+      ...options,
+      comments: trustedComments({ evidenceAssociation: 'NONE' }),
+    }).diagnostics.join('\n'), /evidence URL.*trusted comment/i);
+
+    const arbitrary = trustedComments();
+    arbitrary.approval.comments[0].body = 'unrelated maintainer comment';
+    assert.match(transition({
+      ...options,
+      comments: arbitrary,
+    }).diagnostics.join('\n'), /canonical exact-head maintainer approval/i);
+
+    const ambiguous = trustedComments();
+    ambiguous.approval.comments.push({
+      ...ambiguous.approval.comments[0],
+      id: 102,
+      'html_url': 'https://github.com/marionettejs/marionette/pull/1#issuecomment-102',
+    });
+    assert.match(transition({
+      ...options,
+      comments: ambiguous,
+    }).diagnostics.join('\n'), /exactly one canonical/i);
+  });
+
+  test('rejects unsafe ceilings and structurally incomplete prototype reports', () => {
+    assert.match(transition({
+      candidateLedger: ledger([amendment({ proposedCeilingBytes: Number.MAX_VALUE })]),
+    }).diagnostics.join('\n'), /non-negative integer previous ceiling/i);
+
+    const missingGraph = evidenceReports();
+    missingGraph[reportPath].report.graphs = [];
+    assert.match(transition({
+      candidateLedger: ledger([amendment()]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      evidence: missingGraph,
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    }).diagnostics.join('\n'), /graph set mismatch/i);
+  });
+
+  test('requires a consuming implementation to use the authorized measured scope', () => {
+    const record = amendment();
+    const accepted = transition({
+      authorityLedger: ledger([record]),
+      candidateContract: contract(proposedCeiling),
+      candidateLedger: ledger([record]),
+      baseReport: measuredReport(51000),
+      currentReport: measuredReport(52000, { ceiling: proposedCeiling }),
+    });
+    assert.equal(accepted.status, 'accepted');
+
+    const noGrowth = transition({
+      authorityLedger: ledger([record]),
+      candidateContract: contract(proposedCeiling),
+      candidateLedger: ledger([record]),
+      baseReport: measuredReport(51000),
+      currentReport: measuredReport(51000, { ceiling: proposedCeiling }),
+    });
+    assert.match(noGrowth.diagnostics.join('\n'), /must exceed the previous ceiling/i);
+
+    const wrongSubpath = transition({
+      authorityLedger: ledger([record]),
+      candidateContract: contract(proposedCeiling),
+      candidateLedger: ledger([record]),
+      baseReport: measuredReport(51000),
+      currentReport: measuredReport(52000, {
+        ceiling: proposedCeiling,
+        subpaths: ['.', './feature'],
+      }),
+    });
+    assert.match(wrongSubpath.diagnostics.join('\n'), /graph set mismatch/i);
+  });
+
+  test('rejects malformed fields and unsupported consumer-scenario targets', () => {
+    const malformed = amendment({
+      target: 'consumer-scenario',
+      authorizedArtifactPaths: ['../escape.js'],
+      authorizedNewSubpaths: ['./bad/../path'],
+      unexpected: true,
+    });
+    const result = transition({
+      candidateLedger: ledger([malformed]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.match(result.diagnostics.join('\n'), /aggregate-shipped-package/);
+    assert.match(result.diagnostics.join('\n'), /fields/);
+  });
+
+  test('allows an append-only governance revocation to clear an abandoned pending record', () => {
+    const record = amendment();
+    const revoked = revocation();
+    const result = transition({
+      authorityLedger: ledger([record]),
+      candidateLedger: ledger([record, revoked]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        'docs/performance-baselines.md',
+      ],
+    });
+
+    assert.equal(result.status, 'accepted', result.diagnostics.join('\n'));
+    assert.equal(result.mode, 'revoke');
+    assert.equal(result.amendment.id, 'BA0001');
+    assert.equal(result.requiresExactHeadGrowthApproval, false);
+  });
+});

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -95,6 +95,39 @@ function amendment(overrides = {}) {
   };
 }
 
+function secondAmendment() {
+  return amendment({
+    id: 'BA0002',
+    previousCeilingBytes: proposedCeiling,
+    proposedCeilingBytes: 54000,
+    prototypeCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+    prototypeBaseCommit: '1234567890abcdef1234567890abcdef12345678',
+    implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/206',
+    reports: [
+      {
+        path: 'evidence/performance-budget-amendments/BA0002/base.json',
+        role: 'base',
+        sha256: '2'.repeat(64),
+      },
+      {
+        path: 'evidence/performance-budget-amendments/BA0002/prototype.json',
+        role: 'prototype',
+        sha256: '3'.repeat(64),
+      },
+    ],
+    prototypeContract: {
+      path: 'evidence/performance-budget-amendments/BA0002/prototype-contract.json',
+      sha256: '4'.repeat(64),
+    },
+    approvalUrls: [
+      'https://github.com/marionettejs/marionette/pull/1#issuecomment-200',
+    ],
+    evidenceUrls: [
+      'https://github.com/marionettejs/marionette/issues/127#issuecomment-201',
+    ],
+  });
+}
+
 function ledger(entries = []) {
   return { schemaVersion: 1, entries };
 }
@@ -274,6 +307,7 @@ function transition({
   comments = trustedComments(),
   reportHashes = evidenceHashes(),
   currentHead = headSha,
+  pullRequestAuthorLogin = 'contributor',
 } = {}) {
   return validateBudgetAmendmentTransition({
     authorityContract,
@@ -288,6 +322,7 @@ function transition({
     evidenceComments: comments.evidence,
     evidenceReports: evidence,
     headSha: currentHead,
+    pullRequestAuthorLogin,
     pullRequestNumber: 1,
     reportHashes,
   });
@@ -460,6 +495,22 @@ describe('two-stage performance budget amendments', () => {
         ...evidenceFiles,
       });
       const comments = governanceComments(record, authorizationHead);
+      await assert.rejects(
+        evaluateBudgetAmendmentFromCheckouts({
+          approvalComments: comments.approval,
+          authorityContract: contract(),
+          authorityContractPath: join(baseRoot, 'config/performance.json'),
+          baseReport: measuredReport(51000),
+          candidateContract: contract(),
+          candidateRoot: authorizationRoot,
+          currentReport: measuredReport(51000),
+          evidenceComments: comments.evidence,
+          headSha: authorizationHead,
+          pullRequestAuthorLogin: 'contributor',
+          pullRequestNumber: 1,
+        }),
+        /independently verified base SHA/
+      );
       const authorization = await evaluateBudgetAmendmentFromCheckouts({
         approvalComments: comments.approval,
         authorityContract: contract(),
@@ -471,6 +522,7 @@ describe('two-stage performance budget amendments', () => {
         evidenceComments: comments.evidence,
         expectedBaseHead: baseHead,
         headSha: authorizationHead,
+        pullRequestAuthorLogin: 'contributor',
         pullRequestNumber: 1,
       });
       assert.equal(authorization.status, 'accepted', authorization.diagnostics.join('\n'));
@@ -500,6 +552,7 @@ describe('two-stage performance budget amendments', () => {
         evidenceComments: comments.evidence,
         expectedBaseHead: authorizationHead,
         headSha: consumptionHead,
+        pullRequestAuthorLogin: 'contributor',
         pullRequestNumber: 1,
       });
       assert.equal(consumption.status, 'accepted', consumption.diagnostics.join('\n'));
@@ -528,36 +581,7 @@ describe('two-stage performance budget amendments', () => {
 
   test('rejects record edits, deletion, reordering, and identifier reuse', () => {
     const first = amendment();
-    const second = amendment({
-      id: 'BA0002',
-      previousCeilingBytes: proposedCeiling,
-      proposedCeilingBytes: 54000,
-      prototypeCommit: 'abcdef1234567890abcdef1234567890abcdef12',
-      prototypeBaseCommit: '1234567890abcdef1234567890abcdef12345678',
-      implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/206',
-      reports: [
-        {
-          path: 'evidence/performance-budget-amendments/BA0002/base.json',
-          role: 'base',
-          sha256: '2'.repeat(64),
-        },
-        {
-          path: 'evidence/performance-budget-amendments/BA0002/prototype.json',
-          role: 'prototype',
-          sha256: '3'.repeat(64),
-        },
-      ],
-      prototypeContract: {
-        path: 'evidence/performance-budget-amendments/BA0002/prototype-contract.json',
-        sha256: '4'.repeat(64),
-      },
-      approvalUrls: [
-        'https://github.com/marionettejs/marionette/pull/1#issuecomment-200',
-      ],
-      evidenceUrls: [
-        'https://github.com/marionettejs/marionette/issues/127#issuecomment-201',
-      ],
-    });
+    const second = secondAmendment();
     const authorityLedger = ledger([first, second]);
 
     for (const candidateLedger of [
@@ -572,36 +596,7 @@ describe('two-stage performance budget amendments', () => {
   });
 
   test('rejects multiple pending records and a broken ceiling chain', () => {
-    const second = amendment({
-      id: 'BA0002',
-      previousCeilingBytes: proposedCeiling,
-      proposedCeilingBytes: 54000,
-      prototypeCommit: 'abcdef1234567890abcdef1234567890abcdef12',
-      prototypeBaseCommit: '1234567890abcdef1234567890abcdef12345678',
-      implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/206',
-      reports: [
-        {
-          path: 'evidence/performance-budget-amendments/BA0002/base.json',
-          role: 'base',
-          sha256: '2'.repeat(64),
-        },
-        {
-          path: 'evidence/performance-budget-amendments/BA0002/prototype.json',
-          role: 'prototype',
-          sha256: '3'.repeat(64),
-        },
-      ],
-      prototypeContract: {
-        path: 'evidence/performance-budget-amendments/BA0002/prototype-contract.json',
-        sha256: '4'.repeat(64),
-      },
-      approvalUrls: [
-        'https://github.com/marionettejs/marionette/pull/1#issuecomment-200',
-      ],
-      evidenceUrls: [
-        'https://github.com/marionettejs/marionette/issues/127#issuecomment-201',
-      ],
-    });
+    const second = secondAmendment();
 
     assert.equal(transition({
       authorityLedger: ledger([amendment(), second]),
@@ -793,6 +788,19 @@ describe('two-stage performance budget amendments', () => {
       ...options,
       comments: trustedComments({ approvalLogin: 'attacker' }),
     }).diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
+
+    const malformedLogin = trustedComments();
+    malformedLogin.approval.comments[0].user.login = { value: 'paulfalgout' };
+    const malformedResult = transition({ ...options, comments: malformedLogin });
+    assert.equal(malformedResult.status, 'rejected');
+    assert.match(malformedResult.diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
+
+    const selfApproved = transition({
+      ...options,
+      pullRequestAuthorLogin: 'paulfalgout',
+    });
+    assert.equal(selfApproved.status, 'rejected');
+    assert.match(selfApproved.diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
     assert.match(transition({
       ...options,
       comments: trustedComments({ evidenceAssociation: 'NONE' }),
@@ -957,5 +965,17 @@ describe('two-stage performance budget amendments', () => {
     assert.equal(result.mode, 'revoke');
     assert.equal(result.amendment.id, 'BA0001');
     assert.equal(result.requiresExactHeadGrowthApproval, false);
+
+    const selfApproved = transition({
+      authorityLedger: ledger([record]),
+      candidateLedger: ledger([record, revoked]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        'docs/performance-baselines.md',
+      ],
+      pullRequestAuthorLogin: 'paulfalgout',
+    });
+    assert.equal(selfApproved.status, 'rejected');
+    assert.match(selfApproved.diagnostics.join('\n'), /approval URL.*exact-head maintainer/i);
   });
 });

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -779,6 +779,16 @@ describe('two-stage performance budget amendments', () => {
         [reportPath]: reportHash,
       },
     };
+    const padded = trustedComments();
+    padded.approval.comments[0].body += '\n\n \t';
+    assert.equal(transition({
+      ...options,
+      changedFiles: [
+        ...options.changedFiles,
+        'docs/performance-baselines.md',
+      ],
+      comments: padded,
+    }).status, 'accepted');
     assert.match(transition({
       ...options,
       comments: trustedComments({ approvalLogin: 'attacker' }),

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -1,13 +1,15 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import {
   bootstrapBudgetAmendmentLedger,
   committedCheckoutChanges,
+  evaluateBudgetAmendmentFromCheckouts,
   formatBudgetAmendmentLedger,
   formatBudgetAmendmentApproval,
   parseBudgetAmendmentLedger,
@@ -149,6 +151,57 @@ function evidenceReports() {
     },
     [prototypeContractPath]: contract(),
   };
+}
+
+function jsonText(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function writeRepositoryFiles(repository, files) {
+  for (const [path, contents] of Object.entries(files)) {
+    const target = join(repository, path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, contents);
+  }
+}
+
+function git(repository, args) {
+  const result = spawnSync('git', args, { cwd: repository, encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+async function commitRepository(repository, files) {
+  await mkdir(repository, { recursive: true });
+  git(repository, ['init']);
+  git(repository, ['config', 'user.email', 'test@example.com']);
+  git(repository, ['config', 'user.name', 'Test']);
+  await writeRepositoryFiles(repository, files);
+  git(repository, ['add', '.']);
+  git(repository, ['commit', '-m', 'test: performance budget fixture']);
+  return git(repository, ['rev-parse', 'HEAD']);
+}
+
+function governanceComments(record, approvalHead) {
+  const comments = trustedComments();
+  comments.approval.comments = [{
+    ...comments.approval.comments[0],
+    body: formatBudgetAmendmentApproval(record, approvalHead),
+  }];
+  return comments;
+}
+
+async function removeFixture(path) {
+  await rm(path, {
+    force: true,
+    maxRetries: 5,
+    recursive: true,
+    retryDelay: 50,
+  });
 }
 
 function evidenceHashes() {
@@ -310,7 +363,7 @@ describe('two-stage performance budget amendments', () => {
         'committed\n'
       );
     } finally {
-      await rm(fixture, { force: true, recursive: true });
+      await removeFixture(fixture);
     }
   });
 
@@ -355,6 +408,105 @@ describe('two-stage performance budget amendments', () => {
     assert.equal(result.amendment.id, 'BA0001');
     assert.equal(result.activeCeilingBytes, proposedCeiling);
     assert.equal(result.requiresExactHeadGrowthApproval, true);
+  });
+
+  test('evaluates committed authorization then exact consumption across Git repositories', async() => {
+    const fixture = await mkdtemp(join(tmpdir(), 'marionette-budget-integration-'));
+    const baseRoot = join(fixture, 'base');
+    const authorizationRoot = join(fixture, 'authorization');
+    const consumptionRoot = join(fixture, 'consumption');
+    const baseFiles = {
+      'config/performance.json': jsonText(contract()),
+      'config/release/performance-budget-amendments.json':
+        formatBudgetAmendmentLedger(ledger()),
+      'docs/performance-baselines.md': 'Performance baseline fixture.\n',
+    };
+
+    try {
+      const baseHead = await commitRepository(baseRoot, baseFiles);
+      const prototypeCommit = '1'.repeat(40);
+      const baseEvidence = jsonText({
+        schemaVersion: 1,
+        revision: baseHead,
+        report: measuredReport(51000),
+      });
+      const prototypeEvidence = jsonText({
+        schemaVersion: 1,
+        revision: prototypeCommit,
+        report: measuredReport(52000),
+      });
+      const prototypeContract = jsonText(contract());
+      const record = amendment({
+        prototypeBaseCommit: baseHead,
+        prototypeCommit,
+        reports: [
+          { path: baseReportPath, role: 'base', sha256: sha256(baseEvidence) },
+          { path: reportPath, role: 'prototype', sha256: sha256(prototypeEvidence) },
+        ],
+        prototypeContract: {
+          path: prototypeContractPath,
+          sha256: sha256(prototypeContract),
+        },
+      });
+      const evidenceFiles = {
+        [baseReportPath]: baseEvidence,
+        [prototypeContractPath]: prototypeContract,
+        [reportPath]: prototypeEvidence,
+      };
+      const authorizationHead = await commitRepository(authorizationRoot, {
+        ...baseFiles,
+        'config/release/performance-budget-amendments.json':
+          formatBudgetAmendmentLedger(ledger([record])),
+        ...evidenceFiles,
+      });
+      const comments = governanceComments(record, authorizationHead);
+      const authorization = await evaluateBudgetAmendmentFromCheckouts({
+        approvalComments: comments.approval,
+        authorityContract: contract(),
+        authorityContractPath: join(baseRoot, 'config/performance.json'),
+        baseReport: measuredReport(51000),
+        candidateContract: contract(),
+        candidateRoot: authorizationRoot,
+        currentReport: measuredReport(51000),
+        evidenceComments: comments.evidence,
+        expectedBaseHead: baseHead,
+        headSha: authorizationHead,
+        pullRequestNumber: 1,
+      });
+      assert.equal(authorization.status, 'accepted', authorization.diagnostics.join('\n'));
+      assert.equal(authorization.mode, 'authorize');
+
+      const consumptionHead = await commitRepository(consumptionRoot, {
+        ...baseFiles,
+        'config/performance.json': jsonText(contract(proposedCeiling)),
+        'config/release/performance-budget-amendments.json':
+          formatBudgetAmendmentLedger(ledger([record])),
+        'modules/feature.js': 'export const feature = true;\n',
+        ...evidenceFiles,
+      });
+      await writeFile(
+        join(consumptionRoot, 'config/release/performance-budget-amendments.json'),
+        'dirty worktree data\n'
+      );
+      await writeFile(join(consumptionRoot, reportPath), 'dirty worktree data\n');
+      const consumption = await evaluateBudgetAmendmentFromCheckouts({
+        approvalComments: comments.approval,
+        authorityContract: contract(),
+        authorityContractPath: join(authorizationRoot, 'config/performance.json'),
+        baseReport: measuredReport(51000),
+        candidateContract: contract(proposedCeiling),
+        candidateRoot: consumptionRoot,
+        currentReport: measuredReport(52000, { ceiling: proposedCeiling }),
+        evidenceComments: comments.evidence,
+        expectedBaseHead: authorizationHead,
+        headSha: consumptionHead,
+        pullRequestNumber: 1,
+      });
+      assert.equal(consumption.status, 'accepted', consumption.diagnostics.join('\n'));
+      assert.equal(consumption.mode, 'consume');
+    } finally {
+      await removeFixture(fixture);
+    }
   });
 
   test('rejects adding and consuming an authorization in one pull request', () => {
@@ -677,6 +829,46 @@ describe('two-stage performance budget amendments', () => {
         [reportPath]: reportHash,
       },
     }).diagnostics.join('\n'), /graph set mismatch/i);
+  });
+
+  test('rejects unsafe prototype contract and source paths', () => {
+    const unsafeContractPath = amendment({
+      prototypeContract: {
+        path: 'evidence/performance-budget-amendments/BA0001/bad\\name.json',
+        sha256: prototypeContractHash,
+      },
+    });
+    assert.match(transition({
+      candidateLedger: ledger([unsafeContractPath]),
+    }).diagnostics.join('\n'), /prototypeContract must use a safe immutable JSON path/i);
+
+    const unsafeSource = evidenceReports();
+    unsafeSource[prototypeContractPath].productionGraphs.push({
+      subpath: './unsafe',
+      input: 'modules/../unsafe.js',
+      output: 'dist/marionette.js',
+      baselineModules: [],
+      baselineExternalImports: [],
+    });
+    unsafeSource[reportPath].report.graphs.push({
+      subpath: './unsafe',
+      input: 'modules/../unsafe.js',
+      output: 'dist/marionette.js',
+      status: 'measured',
+      modules: ['unsafe.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+    assert.match(transition({
+      candidateLedger: ledger([amendment({ authorizedNewSubpaths: ['./unsafe'] })]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      evidence: unsafeSource,
+    }).diagnostics.join('\n'), /new graph .* invalid additive contract/i);
   });
 
   test('requires a consuming implementation to use the authorized measured scope', () => {

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -42,7 +42,7 @@ function contractFor(paths = ['dist/index.mjs']) {
       path,
       baselineBrotliBytes: 10,
     })),
-    productionGraphs: [{ subpath: '.' }],
+    productionGraphs: [{ subpath: '.', output: paths[0] }],
     forbiddenProductionModulePrefixes: ['test/'],
     forbiddenProductionModules: ['config/performance.json'],
   };
@@ -230,9 +230,7 @@ describe('performance contract validation', () => {
       ['index.mjs'],
       { schemaVersion: 1, entries: [authorization] }
     );
-    assert.equal(accepted.some(violation => violation.startsWith('Absolute ceiling')), false);
-    assert.equal(accepted.some(violation => violation.includes('active ceiling')), false);
-    assert.equal(accepted.some(violation => violation.includes('BA0001')), false);
+    assert.deepEqual(accepted, []);
 
     const rejected = validateContract(
       contract,

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -181,6 +181,68 @@ describe('performance contract validation', () => {
     ));
   });
 
+  test('resolves an amended active ceiling from the append-only ledger', () => {
+    const contract = contractFor();
+    contract.baseline.absoluteCeilingBytes = 12;
+    const packageJson = {
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+    const authorization = {
+      kind: 'authorization',
+      id: 'BA0001',
+      target: 'aggregate-shipped-package',
+      previousCeilingBytes: 10,
+      proposedCeilingBytes: 12,
+      prototypeBaseCommit: 'abcdef1234567890abcdef1234567890abcdef12',
+      prototypeCommit: '1234567890abcdef1234567890abcdef12345678',
+      implementationIssueUrl: 'https://github.com/marionettejs/marionette/issues/205',
+      authorizedArtifactPaths: ['dist/index.mjs'],
+      authorizedNewSubpaths: [],
+      reports: [
+        {
+          path: 'evidence/performance-budget-amendments/BA0001/base.json',
+          role: 'base',
+          sha256: '0'.repeat(64),
+        },
+        {
+          path: 'evidence/performance-budget-amendments/BA0001/prototype.json',
+          role: 'prototype',
+          sha256: '1'.repeat(64),
+        },
+      ],
+      prototypeContract: {
+        path: 'evidence/performance-budget-amendments/BA0001/prototype-contract.json',
+        sha256: '2'.repeat(64),
+      },
+      approvalUrls: [
+        'https://github.com/marionettejs/marionette/pull/205#issuecomment-100',
+      ],
+      evidenceUrls: [
+        'https://github.com/marionettejs/marionette/issues/127#issuecomment-101',
+      ],
+      rationale: 'Measured prototype evidence justifies a bounded ceiling increase.',
+      rollbackCondition: 'Revoke the pending authorization if implementation stops.',
+    };
+
+    const accepted = validateContract(
+      contract,
+      packageJson,
+      ['index.mjs'],
+      { schemaVersion: 1, entries: [authorization] }
+    );
+    assert.equal(accepted.some(violation => violation.startsWith('Absolute ceiling')), false);
+    assert.equal(accepted.some(violation => violation.includes('active ceiling')), false);
+    assert.equal(accepted.some(violation => violation.includes('BA0001')), false);
+
+    const rejected = validateContract(
+      contract,
+      packageJson,
+      ['index.mjs'],
+      { schemaVersion: 1, entries: [] }
+    );
+    assert.equal(rejected.some(violation => violation.includes('active ceiling')), true);
+  });
+
   test('measures malformed artifact and subpath changes without an uncaught error', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-contract-'));
     const contract = contractFor();
@@ -524,6 +586,15 @@ describe('performance contract validation', () => {
     assert.ok(commands[approvalIndex].includes('--candidate-contract config/performance.json'));
     assert.ok(measurementIndex < approvalIndex);
     assert.ok(resourceValidationIndex < approvalIndex);
+  });
+
+  test('refreshes checks when budget-amendment approvals or evidence change', async() => {
+    const workflow = await readFile(
+      join(root, '.github/workflows/performance-approval-refresh.yml'),
+      'utf8'
+    );
+    assert.match(workflow, /marionette-performance-budget-amendment:v1/);
+    assert.match(workflow, /growth-approval\|budget-amendment/);
   });
 
   test('rejects forbidden modules from the measured production graph', async() => {

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -1064,6 +1064,13 @@ describe('exact-head performance growth approval contract', () => {
       evidence: join(fixtureRoot, 'evidence.json'),
     };
     const cli = join(root, 'config/performance-growth-approval.mjs');
+    const offlineEnv = { ...process.env };
+    delete offlineEnv.GITHUB_ACTIONS;
+    delete offlineEnv.GITHUB_EVENT_PATH;
+    const runCli = cliArgs => spawnSync(process.execPath, cliArgs, {
+      encoding: 'utf8',
+      env: offlineEnv,
+    });
     const checkoutHead = spawnSync('git', ['rev-parse', 'HEAD'], {
       cwd: root,
       encoding: 'utf8',
@@ -1090,7 +1097,7 @@ describe('exact-head performance growth approval contract', () => {
         writeFile(paths.evidence, JSON.stringify(evidenceSnapshot())),
       ]);
 
-      const approved = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      const approved = runCli(args);
       assert.equal(approved.status, 0);
       assert.equal(JSON.parse(approved.stdout).status, 'approved');
 
@@ -1107,15 +1114,15 @@ describe('exact-head performance growth approval contract', () => {
         writeFile(paths.current, JSON.stringify(productionReport({ includeFeature: true }))),
         writeFile(paths.comments, JSON.stringify(snapshot([comment(cliNewApproval)]))),
       ]);
-      const beforeActivation = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      const beforeActivation = runCli(args);
       assert.equal(beforeActivation.status, 1);
       assert.equal(JSON.parse(beforeActivation.stdout).status, 'blocked');
       assert.equal(JSON.parse(beforeActivation.stdout).newProductionEnforced, false);
 
-      const newSubpath = spawnSync(process.execPath, [
+      const newSubpath = runCli([
         ...args,
         '--candidate-contract', paths.candidate,
-      ], { encoding: 'utf8' });
+      ]);
       assert.equal(newSubpath.status, 0);
       assert.deepEqual(JSON.parse(newSubpath.stdout).newSubpaths, ['./feature']);
 
@@ -1128,7 +1135,7 @@ describe('exact-head performance growth approval contract', () => {
 
       const mismatchedArgs = [...args];
       mismatchedArgs[mismatchedArgs.indexOf('--head-sha') + 1] = headSha;
-      const mismatchedHead = spawnSync(process.execPath, mismatchedArgs, { encoding: 'utf8' });
+      const mismatchedHead = runCli(mismatchedArgs);
       assert.equal(mismatchedHead.status, 1);
       assert.match(
         JSON.parse(mismatchedHead.stdout).diagnostics[0].message,
@@ -1136,11 +1143,11 @@ describe('exact-head performance growth approval contract', () => {
       );
 
       await writeFile(paths.comments, JSON.stringify(snapshot([])));
-      const missing = spawnSync(process.execPath, args, { encoding: 'utf8' });
+      const missing = runCli(args);
       assert.equal(missing.status, 1);
       assert.equal(JSON.parse(missing.stdout).diagnostics[0].code, 'GROWTH_APPROVAL_MISSING');
 
-      const invalidInput = spawnSync(process.execPath, [cli], { encoding: 'utf8' });
+      const invalidInput = runCli([cli]);
       assert.equal(invalidInput.status, 1);
       assert.equal(
         JSON.parse(invalidInput.stdout).diagnostics[0].code,
@@ -1151,9 +1158,9 @@ describe('exact-head performance growth approval contract', () => {
         /Missing value for --head-sha/
       );
 
-      const invalidPullRequest = spawnSync(process.execPath, [
+      const invalidPullRequest = runCli([
         ...args.slice(0, -1), '1e2',
-      ], { encoding: 'utf8' });
+      ]);
       assert.equal(invalidPullRequest.status, 1);
       assert.match(
         JSON.parse(invalidPullRequest.stdout).diagnostics[0].message,

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -442,6 +442,51 @@ describe('exact-head performance growth approval contract', () => {
     );
   });
 
+  test('requires an independent exact-head approval when consuming a base-owned budget', () => {
+    const candidateContract = growthContract();
+    candidateContract.baseline.absoluteCeilingBytes = 110;
+    const currentReport = productionReport();
+    currentReport.artifacts[0].size = 106;
+    currentReport.cumulative.size = 106;
+    currentReport.cumulative.absoluteCeiling = 110;
+    const budgetAmendment = {
+      activeCeilingBytes: 110,
+      amendment: {
+        id: 'BA0001',
+        authorizedArtifactPaths: ['dist/main.js'],
+        authorizedNewSubpaths: [],
+      },
+      diagnostics: [],
+      mode: 'consume',
+      requiresExactHeadGrowthApproval: true,
+      schemaVersion: 1,
+      status: 'accepted',
+    };
+    const options = {
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      budgetAmendment,
+      candidateContract,
+      currentReport,
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    };
+
+    const missing = validateGrowthApproval({ ...options, comments: snapshot([]) });
+    assert.equal(missing.status, 'required');
+    assert.equal(missing.diagnostics[0].code, 'GROWTH_APPROVAL_MISSING');
+
+    const approved = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(approvalRecord(['dist/main.js']))]),
+    });
+    assert.equal(approved.status, 'approved');
+    assert.deepEqual(approved.required.map(({ path }) => path), ['dist/main.js']);
+  });
+
   test('fails closed for removed base entries and invalid new production evidence', () => {
     const removedArtifact = candidateGrowthContract();
     removedArtifact.runtimeArtifacts.shift();

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -455,6 +455,7 @@ describe('exact-head performance growth approval contract', () => {
         id: 'BA0001',
         authorizedArtifactPaths: ['dist/main.js'],
         authorizedNewSubpaths: [],
+        proposedCeilingBytes: 110,
       },
       diagnostics: [],
       mode: 'consume',
@@ -485,6 +486,27 @@ describe('exact-head performance growth approval contract', () => {
     });
     assert.equal(approved.status, 'approved');
     assert.deepEqual(approved.required.map(({ path }) => path), ['dist/main.js']);
+
+    const staleCeilingReport = structuredClone(currentReport);
+    staleCeilingReport.cumulative.absoluteCeiling = 105;
+    const staleCeiling = validateGrowthApproval({
+      ...options,
+      comments: snapshot([]),
+      currentReport: staleCeilingReport,
+    });
+    assert.match(
+      staleCeiling.diagnostics.map(({ message }) => message).join('\n'),
+      /Pull request report does not use the active performance authority/
+    );
+
+    const wrongProposedCeiling = structuredClone(budgetAmendment);
+    wrongProposedCeiling.amendment.proposedCeilingBytes = 109;
+    assert.match(
+      validateCandidateGrowthContract(growthContract(), candidateContract, {
+        budgetAmendment: wrongProposedCeiling,
+      }).join('\n'),
+      /changes exact-base baseline beyond the authorized ceiling/
+    );
   });
 
   test('fails closed for removed base entries and invalid new production evidence', () => {


### PR DESCRIPTION
Closes #205
Related #127

## What

- Add a versioned, append-only performance-budget amendment ledger with exact-base authorization, revocation, and later consumption validation.
- Bind amendments to committed prototype reports, immutable evidence hashes, artifact/subpath scope, and an exact-head maintainer approval marker.
- Extend bundle-size and growth-approval tooling, tests, documentation, CODEOWNERS, and the approval-refresh workflow to enforce the protocol.

## Why

The immutable Phase 0 package budget must not become a wall against legitimate architecture work, but an implementation candidate must never raise and consume its own ceiling. This creates a two-PR governance boundary while preserving the original baseline and independently requiring the existing exact-head growth approval.

## Agent-development failure addressed

An agent can propose measured package growth, but cannot raise and consume the ceiling in one pull request, rewrite history, consume a different value or scope, or rely on mutable worktree evidence.

## Public behavior contract

- Canonical behavior after this PR: the Phase 0 aggregate ceiling remains active unless a separately merged, evidence-backed authorization exists in the base; a later implementation may consume exactly that authorization.
- Superseded behavior removed, if any: none. The existing fixed budget remains the default and the bootstrap ledger is empty.
- Compatibility exception and removal condition, if any: none.

## Scope

- Changes only performance governance/configuration, CI support tooling, documentation, CODEOWNERS, and performance contract tests.
- Does not change runtime source, package exports, dependencies, lockfiles, `dist/`, `version.js`, `config/performance.json`, or the ruleset-pinned `.github/workflows/ci.yml`.
- Does not change GitHub organization/repository settings and does not publish a website, package, tag, or release.

## Runtime cost

- [ ] Static or documentation only
- [x] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: unchanged at 49.82 kB raw / 51.98 kB total artifact budget report.
- Startup/hot path: no production module or runtime path changed.
- Allocations/retention: none in production; the new modules execute only in CI/test tooling.

## Deployment Impact

No application or website deployment is required. No package, tag, release, or documentation site is published by this PR.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npm ci
npm run test:performance
npm run lint:ci
npm run docs:check
npm run size
node --check config/release/performance-budget-amendments.mjs
node --check config/performance-growth-approval.mjs
node --check config/bundle-size.mjs
git diff --check origin/master...HEAD
```

Results:

- `npm ci`: 357 packages installed; 0 vulnerabilities.
- Performance tests: 89/89 passed twice after the final test-harness change.
- Lint passed.
- Docs check: 29 pages, 30 HTML files, 288 links.
- Size check passed at 49.82 kB raw / 51.98 kB total; module graphs 40/1/1.
- Syntax and diff checks passed.
- `config/performance.json`, `.github/workflows/ci.yml`, package manifests, `dist/`, and `version.js` remain byte-identical to the base.

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: none.
- Production/dev/test module-graph impact: production and dev graphs unchanged; CI/test tooling adds the amendment parser and adversarial tests.

## Rollback or deprecation

Before the empty mechanism is used, revert this PR. After an authorization exists, append a revocation record for an abandoned pending amendment; never delete or rewrite authorization history or the Phase 0 baseline.

## Review notes

- Bootstrap is pinned to exact base `154a8bb43f81a1836fcd70c014f4301e750bcb77`.
- The existing organization-ruleset-pinned `ci.yml` is unchanged; its exact-base invocation already activates this enforcement.
- A consuming implementation still requires the existing exact-head performance-growth approval even when its per-artifact growth is at or below 1%.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a two-stage budget amendment protocol so the Phase 0 package ceiling can only be raised by a separately merged, evidence-backed authorization, and the implementing PR can only consume exactly that authorization. The fixed budget was previously the only ceiling; now a versioned append-only ledger governs authorizations, revocations, and consumption, while the existing exact-head growth approval still applies to any consuming implementation.

**New Features**
- Adds a versioned append-only ledger at `config/release/performance-budget-amendments.json` with bootstrap, authorization, revocation, and consumption validation.
- Binds amendments to committed prototype reports, immutable evidence hashes, artifact/subpath scope, and an exact-base maintainer approval marker.
- Extends the bundle-size and growth-approval tooling, approval-refresh workflow, docs, CODEOWNERS, and performance tests to enforce the protocol.
- Supports sole-maintainer attestations, and approval comment parsing now tolerates trailing whitespace after the marker.

**Migration**
- Roll back by reverting this PR before any authorization is recorded; after that, append a revocation record instead of deleting or rewriting ledger history.

<sup>Written for commit d5f3ec77ccb7b00b4cb2943e97e19ba4adcf7fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a governed process for authorizing, consuming, and revoking performance budget amendments.
  * Performance checks now recognize approved active ceilings and validate amendment scope and evidence.
  * Approval workflows support both performance growth approvals and budget amendment approvals.

* **Documentation**
  * Documented amendment rules, required evidence, staged consumption, revocation, and workflow behavior.

* **Tests**
  * Added comprehensive coverage for valid amendments, approvals, revocations, invalid changes, and workflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
