### PR TITLE
fix(ci): find required workflow runs for approval refresh

### DIFF
--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -136,17 +136,27 @@ jobs:
             run_id=''
             lookup_failed=0
             for attempt in {1..24}; do
+              # Required workflow runs are omitted by the repository workflow-scoped endpoint.
               if ! gh api \
                 -H 'Accept: application/vnd.github+json' \
                 -H 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/${REPOSITORY}/actions/workflows/ci.yml/runs?event=pull_request&head_sha=${head_sha}&per_page=100" \
+                "repos/${REPOSITORY}/actions/runs?event=pull_request&head_sha=${head_sha}&per_page=100" \
                 > "${workflow_runs}"; then
                 lookup_failed=1
                 break
               fi
               run_id="$(jq -r --arg expected_run_name "${expected_run_name}" \
+                --arg repository "${REPOSITORY}" \
+                --arg head_sha "${head_sha}" \
                 '.workflow_runs |
-                 map(select(.display_title == $expected_run_name)) |
+                 map(select(
+                   .display_title == $expected_run_name and
+                   .event == "pull_request" and
+                   .head_sha == $head_sha and
+                   .path == ".github/workflows/ci.yml" and
+                   .repository.full_name == $repository and
+                   ((.workflow_url // "") | startswith("https://api.github.com/repos/" + $repository + "/actions/required_workflows/"))
+                 )) |
                  sort_by(.created_at) | last | .id // empty' \
                 "${workflow_runs}")"
               if [ -n "${run_id}" ]; then

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -153,7 +153,9 @@ jobs:
                    .display_title == $expected_run_name and
                    .event == "pull_request" and
                    .head_sha == $head_sha and
-                   ((.path // "") | split("@")[0]) == ".github/workflows/ci.yml" and
+                   (((.path // "") | split("@")[0]) as $workflow_path |
+                     ($workflow_path == ".github/workflows/ci.yml" or
+                      $workflow_path == ($repository + "/.github/workflows/ci.yml"))) and
                    .repository.full_name == $repository and
                    ((.workflow_url // "") | startswith("https://api.github.com/repos/" + $repository + "/actions/required_workflows/"))
                  )) |

--- a/.github/workflows/performance-approval-refresh.yml
+++ b/.github/workflows/performance-approval-refresh.yml
@@ -137,7 +137,7 @@ jobs:
             lookup_failed=0
             for attempt in {1..24}; do
               # Required workflow runs are omitted by the repository workflow-scoped endpoint.
-              if ! gh api \
+              if ! gh api --paginate --slurp \
                 -H 'Accept: application/vnd.github+json' \
                 -H 'X-GitHub-Api-Version: 2022-11-28' \
                 "repos/${REPOSITORY}/actions/runs?event=pull_request&head_sha=${head_sha}&per_page=100" \
@@ -148,12 +148,12 @@ jobs:
               run_id="$(jq -r --arg expected_run_name "${expected_run_name}" \
                 --arg repository "${REPOSITORY}" \
                 --arg head_sha "${head_sha}" \
-                '.workflow_runs |
+                '[.[].workflow_runs[]] |
                  map(select(
                    .display_title == $expected_run_name and
                    .event == "pull_request" and
                    .head_sha == $head_sha and
-                   .path == ".github/workflows/ci.yml" and
+                   ((.path // "") | split("@")[0]) == ".github/workflows/ci.yml" and
                    .repository.full_name == $repository and
                    ((.workflow_url // "") | startswith("https://api.github.com/repos/" + $repository + "/actions/required_workflows/"))
                  )) |

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -595,7 +595,9 @@ describe('performance contract validation', () => {
     assert.match(workflow, /growth-approval\|budget-amendment/);
     assert.match(workflow, /actions\/runs\?event=pull_request&head_sha=\$\{head_sha\}/);
     assert.doesNotMatch(workflow, /actions\/workflows\/ci\.yml\/runs/);
-    assert.match(workflow, /\.path == "\.github\/workflows\/ci\.yml"/);
+    assert.match(workflow, /gh api --paginate --slurp/);
+    assert.match(workflow, /\[\.\[\]\.workflow_runs\[\]\]/);
+    assert.match(workflow, /\(\.path \/\/ ""\) \| split\("@"\)\[0\]/);
     assert.match(workflow, /actions\/required_workflows\//);
   });
 

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -598,6 +598,8 @@ describe('performance contract validation', () => {
     assert.match(workflow, /gh api --paginate --slurp/);
     assert.match(workflow, /\[\.\[\]\.workflow_runs\[\]\]/);
     assert.match(workflow, /\(\.path \/\/ ""\) \| split\("@"\)\[0\]/);
+    assert.match(workflow, /\$workflow_path == "\.github\/workflows\/ci\.yml"/);
+    assert.match(workflow, /\$repository \+ "\/\.github\/workflows\/ci\.yml"/);
     assert.match(workflow, /actions\/required_workflows\//);
   });
 

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -593,6 +593,10 @@ describe('performance contract validation', () => {
     );
     assert.match(workflow, /marionette-performance-budget-amendment:v1/);
     assert.match(workflow, /growth-approval\|budget-amendment/);
+    assert.match(workflow, /actions\/runs\?event=pull_request&head_sha=\$\{head_sha\}/);
+    assert.doesNotMatch(workflow, /actions\/workflows\/ci\.yml\/runs/);
+    assert.match(workflow, /\.path == "\.github\/workflows\/ci\.yml"/);
+    assert.match(workflow, /actions\/required_workflows\//);
   });
 
   test('rejects forbidden modules from the measured production graph', async() => {


### PR DESCRIPTION
Related #205

## What

- Find organization-required CI runs through the repository-wide Actions runs endpoint instead of the repository workflow-scoped endpoint.
- Fail closed unless the selected run matches the exact PR/base/head title, pull-request event, top-level head SHA, CI path, repository, and immutable required-workflow API URL class.
- Add a performance-contract regression test that pins the required-workflow lookup and rejects returning to the path-scoped endpoint.

## Why

The first live exact-head approval refresh on PR #208 could not find its required CI run. GitHub omits organization-required workflow runs from `actions/workflows/ci.yml/runs`, even though the same run is present in `actions/runs`. As a result, a valid growth approval could not rerun the Bundle size job.

The broader endpoint also exposes candidate-owned workflow runs, so selection must distinguish the organization-required workflow from a lookalike rather than relying on path or title alone.

## Scope

- Changes only `.github/workflows/performance-approval-refresh.yml` and its focused performance-contract test.
- Does not change the ruleset-pinned `.github/workflows/ci.yml`, runtime source, package artifacts, dependencies, performance budgets, or GitHub settings.
- Does not publish a website, package, tag, or release.

## Deployment Impact

No application deployment or package redeploy is required. The merged repository workflow will affect future approval-comment refresh events immediately; PR #208 will then be rebased and exercised as the live verification.

## Testing

- Live API replay selected required run `33201521218` for PR #208 exact head `cfc55f77`.
- An adversarial newer candidate-workflow lookalike fixture still selected the required run.
- Candidate-only and wrong-path fixtures selected no run.
- `node --test test/performance/contract.test.mjs` - 27 tests passed.
- `npm run test:performance` - 89 tests passed.
- `npm run lint:ci`
- Ruby YAML AST parse
- `git diff --check`

No runtime or distribution files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow run detection for pull requests by validating the event, commit, repository, workflow path, and required-workflow API source.
  * Prevented unintended reruns of the base CI workflow while ensuring appropriate reruns when the CI workflow changes.

* **Tests**
  * Added coverage for pull-request filtering, workflow path changes, and required-workflow API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the approval refresh workflow so it can find organization-required CI runs, which GitHub omits from the `actions/workflows/ci.yml/runs` endpoint. The refresh now queries the repository-wide `actions/runs` endpoint with strict selection criteria so a candidate-owned lookalike run can't be chosen. Resolves the failed live lookup reported in #205.

**Bug Fixes**

- Selection requires the exact display title, pull-request event, head SHA, repository, and required-workflow API URL, with the CI path normalized to accept bare or repository-prefixed forms.
- Adds a contract regression test that pins the repository-wide endpoint and normalized path handling, rejecting a return to the path-scoped lookup.
- No application deployment or package changes; the merged workflow affects future approval-comment refresh events immediately.

<sup>Written for commit 2179d7aef0828a8639735a1c587da9f12c70a951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

