### PR TITLE
test(backbone): verify shim interop contracts

### DIFF
--- a/docs/optional-backbone.md
+++ b/docs/optional-backbone.md
@@ -221,6 +221,26 @@ Importing this module is the v5 equivalent of "Marionette uses Backbone." It is 
 
 The shim is the recommended path for applications migrating from v4 and for any application that mixes Backbone classes with Marionette classes — particularly when a Backbone class is on the **listener side** (for example a `Backbone.View` subclass calling `listenTo`). The shim swaps Backbone's `Events` for Marionette's `Events` on all four Backbone prototypes so listener-side bookkeeping stays consistent across the two libraries.
 
+The `backbone` module may be loaded before or after `marionette/backbone`. The
+shim patches the same `Backbone` module object and preserves the identity of its
+`Model`, `Collection`, `View`, and `Router` constructors and prototypes. The ESM
+default export and CommonJS `require` value are that exact `Backbone` object. The
+canonical usage is still to load the shim before constructing objects or registering
+subscriptions:
+
+```javascript
+import 'marionette/backbone';
+import Backbone from 'backbone';
+```
+
+Handlers registered before the shim loads remain in Backbone's private `_events`
+store and are not migrated to Marionette's event bookkeeping. Recreate those
+subscriptions after loading the shim. The shim also deliberately does not patch the
+`Backbone` namespace or `Backbone.History`; use the four supported instance types
+above. If an installation resolves more than one physical copy of Backbone, only the
+copy resolved for the shim is patched, so consumers must share the package's supported
+Backbone peer instance.
+
 A plain `Backbone.Model` or `Backbone.Collection` already satisfies the emitter protocol on this page without the shim, because Marionette only calls `.on(...)`, `.off(...)`, and reads `.cid` / `.attributes` / `.get(...)` / `.models` / `.indexOf(...)` on the emitter. The shim is not required just to use Backbone entities with Marionette views.
 
 The protocol on this page is broader than the shim. The shim is one implementation of the protocol; this page describes the protocol itself.

--- a/test/fixtures/shim/assert-interop.cjs
+++ b/test/fixtures/shim/assert-interop.cjs
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict');
+
+module.exports = function assertInterop({
+  Backbone,
+  Marionette,
+  ShimmedBackbone,
+  constructors,
+}) {
+  assert.strictEqual(ShimmedBackbone, Backbone);
+  assert.strictEqual(Backbone.Model, constructors.Model);
+  assert.strictEqual(Backbone.Collection, constructors.Collection);
+  assert.strictEqual(Backbone.View, constructors.View);
+  assert.strictEqual(Backbone.Router, constructors.Router);
+
+  for (const Constructor of Object.values(constructors)) {
+    assert.strictEqual(
+      Constructor.prototype.triggerMethod,
+      Marionette.Events.triggerMethod,
+    );
+  }
+
+  const model = new Backbone.Model({ id: 1, name: 'before' });
+  const collection = new Backbone.Collection([model]);
+  const listener = new Backbone.Model();
+  const calls = [];
+
+  assert.ok(model instanceof constructors.Model);
+  assert.strictEqual(collection.get(model.id), model);
+
+  listener.listenTo(model, 'change:name', (changedModel, value) => {
+    calls.push(['change', changedModel, value]);
+  });
+  listener.listenTo(collection, 'add', (addedModel, changedCollection) => {
+    calls.push(['add', addedModel, changedCollection]);
+  });
+
+  model.set('name', 'after');
+  const addedModel = collection.add({ id: 2, name: 'second' });
+
+  assert.deepStrictEqual(calls, [
+    ['change', model, 'after'],
+    ['add', addedModel, collection],
+  ]);
+
+  listener.stopListening();
+  model.set('name', 'ignored');
+  collection.add({ id: 3 });
+
+  assert.strictEqual(calls.length, 2);
+};

--- a/test/fixtures/shim/validate-cjs-backbone-first.cjs
+++ b/test/fixtures/shim/validate-cjs-backbone-first.cjs
@@ -1,0 +1,21 @@
+const assertInterop = require('./assert-interop.cjs');
+const assert = require('node:assert/strict');
+
+const Backbone = require('backbone');
+const constructors = {
+  Collection: Backbone.Collection,
+  Model: Backbone.Model,
+  Router: Backbone.Router,
+  View: Backbone.View,
+};
+assert.strictEqual(Backbone.Model.prototype.triggerMethod, undefined);
+
+const Marionette = require('marionette');
+const ShimmedBackbone = require('marionette/backbone');
+
+assertInterop({
+  Backbone,
+  Marionette,
+  ShimmedBackbone,
+  constructors,
+});

--- a/test/fixtures/shim/validate-cjs-shim-first.cjs
+++ b/test/fixtures/shim/validate-cjs-shim-first.cjs
@@ -1,0 +1,18 @@
+const assertInterop = require('./assert-interop.cjs');
+
+const ShimmedBackbone = require('marionette/backbone');
+const Backbone = require('backbone');
+const Marionette = require('marionette');
+const constructors = {
+  Collection: Backbone.Collection,
+  Model: Backbone.Model,
+  Router: Backbone.Router,
+  View: Backbone.View,
+};
+
+assertInterop({
+  Backbone,
+  Marionette,
+  ShimmedBackbone,
+  constructors,
+});

--- a/test/fixtures/shim/validate-esm-backbone-first.mjs
+++ b/test/fixtures/shim/validate-esm-backbone-first.mjs
@@ -1,0 +1,21 @@
+import assertInterop from './assert-interop.cjs';
+import assert from 'node:assert/strict';
+
+const { default: Backbone } = await import('backbone');
+const constructors = {
+  Collection: Backbone.Collection,
+  Model: Backbone.Model,
+  Router: Backbone.Router,
+  View: Backbone.View,
+};
+assert.strictEqual(Backbone.Model.prototype.triggerMethod, undefined);
+
+const Marionette = await import('marionette');
+const { default: ShimmedBackbone } = await import('marionette/backbone');
+
+assertInterop({
+  Backbone,
+  Marionette,
+  ShimmedBackbone,
+  constructors,
+});

--- a/test/fixtures/shim/validate-esm-shim-first.mjs
+++ b/test/fixtures/shim/validate-esm-shim-first.mjs
@@ -1,0 +1,18 @@
+import assertInterop from './assert-interop.cjs';
+
+const { default: ShimmedBackbone } = await import('marionette/backbone');
+const { default: Backbone } = await import('backbone');
+const Marionette = await import('marionette');
+const constructors = {
+  Collection: Backbone.Collection,
+  Model: Backbone.Model,
+  Router: Backbone.Router,
+  View: Backbone.View,
+};
+
+assertInterop({
+  Backbone,
+  Marionette,
+  ShimmedBackbone,
+  constructors,
+});

--- a/test/fixtures/shim/validate.mjs
+++ b/test/fixtures/shim/validate.mjs
@@ -1,18 +1,14 @@
-import assert from 'assert';
-import Backbone from 'backbone';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
 
-assert.strictEqual(Backbone.Model.prototype.triggerMethod, undefined);
-
-const ShimmedBackbone = (await import('marionette/backbone')).default;
-
-assert.strictEqual(ShimmedBackbone, Backbone);
-assert.strictEqual(typeof Backbone.Model.prototype.triggerMethod, 'function');
-
-let called = false;
-const model = new Backbone.Model();
-model.on('fixture:event', () => {
-  called = true;
-});
-model.triggerMethod('fixture:event');
-
-assert.strictEqual(called, true);
+for (const file of [
+  'validate-esm-backbone-first.mjs',
+  'validate-esm-shim-first.mjs',
+  'validate-cjs-backbone-first.cjs',
+  'validate-cjs-shim-first.cjs',
+]) {
+  execFileSync(process.execPath, [resolve(import.meta.dirname, file)], {
+    stdio: 'inherit',
+    timeout: 30_000,
+  });
+}

--- a/test/unit/backbone-shim.spec.js
+++ b/test/unit/backbone-shim.spec.js
@@ -6,8 +6,10 @@ const require = createRequire(import.meta.url);
 describe('Backbone shim', function() {
   let Backbone;
   let ShimmedBackbone;
+  let constructors;
   let historyMethods;
   let namespaceMethods;
+  let prototypes;
   let previousDocument;
   let previousWindow;
 
@@ -22,6 +24,18 @@ describe('Backbone shim', function() {
     Backbone = require('backbone');
     Backbone.$ = require('jquery');
 
+    constructors = {
+      Collection: Backbone.Collection,
+      Model: Backbone.Model,
+      Router: Backbone.Router,
+      View: Backbone.View
+    };
+    prototypes = {
+      Collection: Backbone.Collection.prototype,
+      Model: Backbone.Model.prototype,
+      Router: Backbone.Router.prototype,
+      View: Backbone.View.prototype
+    };
     namespaceMethods = {
       on: Backbone.on,
       off: Backbone.off,
@@ -57,6 +71,15 @@ describe('Backbone shim', function() {
     expect(Backbone.History.prototype.triggerMethod).to.equal(historyMethods.triggerMethod);
   });
 
+  it('preserves the Backbone module, constructors, and prototypes by identity', function() {
+    expect(ShimmedBackbone).to.equal(Backbone);
+
+    Object.keys(constructors).forEach(name => {
+      expect(Backbone[name]).to.equal(constructors[name]);
+      expect(Backbone[name].prototype).to.equal(prototypes[name]);
+    });
+  });
+
   it('mixes Marionette Events into supported Backbone instances', function() {
     [
       new Backbone.Model(),
@@ -73,5 +96,35 @@ describe('Backbone shim', function() {
       instance.triggerMethod('shim:test');
       expect(callCount).to.equal(1);
     });
+  });
+
+  it('preserves Model and Collection data and event behavior', function() {
+    const model = new Backbone.Model({ id: 1, name: 'before' });
+    const collection = new Backbone.Collection([model]);
+    const listener = new Backbone.Model();
+    const calls = [];
+
+    listener.listenTo(model, 'change:name', (changedModel, value) => {
+      calls.push(['change', changedModel, value]);
+    });
+    listener.listenTo(collection, 'add', (addedModel, changedCollection) => {
+      calls.push(['add', addedModel, changedCollection]);
+    });
+
+    model.set('name', 'after');
+    const addedModel = collection.add({ id: 2, name: 'second' });
+
+    expect(collection.get(1)).to.equal(model);
+    expect(collection.get(2)).to.equal(addedModel);
+    expect(calls).to.deep.equal([
+      ['change', model, 'after'],
+      ['add', addedModel, collection]
+    ]);
+
+    listener.stopListening();
+    model.set('name', 'ignored');
+    collection.add({ id: 3 });
+
+    expect(calls).to.have.lengthOf(2);
   });
 });


### PR DESCRIPTION
Related #71

## What

- Exercise the installed marionette/backbone package entrypoint in isolated ESM and CommonJS processes with both Backbone-first and shim-first loading.
- Verify exact Backbone export, constructor, and prototype identity plus Model, Collection, event, listenTo, and stopListening behavior.
- Document supported import order and the unsupported namespace, History, pre-shim subscription, and duplicate-Backbone boundaries.

## Why

marionette/backbone is a published v5 entrypoint. Agents and developers need executable evidence for its package conditions, mutation boundary, identity guarantees, and interop behavior rather than relying on implicit loader assumptions.

## Scope

- Affects tests, installed-package fixtures, and optional Backbone documentation only.
- Does not change runtime source, dist artifacts, package exports, workflows, or performance contracts.
- Keeps #71 open because its declaration/package-condition dependencies #137 and #144 remain separate.

## Deployment Impact

No application or website deployment is required. This PR does not publish documentation, npm, a tag, or a v5 release.

## Testing

- npm run coverage — 70 files, 1,214 tests, 100% statements, branches, functions, and lines; 19 agent benchmark contract tests.
- npm run lint:ci
- npm run docs:check — 33 pages, 34 HTML files, and 320 internal links.
- npm run test:source
- npm run test:dist
- npm run test:fixtures — includes four isolated Backbone shim import-order processes.
- npm run test:performance — 89 tests.
- npm run check:release-profile
- npm run check:browser-profile
- npm run check:release-promotion
- npm run check:dist
- npm run size — unchanged at 51,878 B / 51,975 B; no runtime or graph delta.
- git diff --check
- Explicit diff check confirms no changes under dist, modules, package.json, or config/performance.json.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds isolated ESM and CommonJS tests for the `marionette/backbone` shim that verify both import orders work, plus unit coverage for its identity and interop guarantees. No runtime, dist, or package changes; this is purely test and doc coverage.

**Testing and documentation**
- Runs four fixture processes covering Backbone-first and shim-first loading in both module systems.
- Asserts the shim returns the same Backbone object and preserves constructor, prototype, Model, Collection, event, `listenTo`, and `stopListening` behavior.
- Documents unsupported boundaries: pre-shim subscriptions, the `Backbone` namespace, `History`, and duplicate Backbone copies.
- Keeps #71 open because package-condition dependencies #137 and #144 remain.

<sup>Written for commit a0f8444f09f71fd0a7e01121653e803241b23871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

