### PR TITLE
feat(backbone): add conditional shim declarations

### DIFF
--- a/dist/backbone.d.cts
+++ b/dist/backbone.d.cts
@@ -1,0 +1,21 @@
+import Backbone = require('backbone');
+
+declare module 'backbone' {
+  interface Model<T extends ObjectHash = any, S = ModelSetOptions, E = any> {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+
+  interface Collection<TModel extends Model = Model> {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+
+  interface View<TModel extends Model | undefined = Model, TElement extends Element = HTMLElement> {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+
+  interface Router {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+}
+
+export = Backbone;

--- a/dist/backbone.d.mts
+++ b/dist/backbone.d.mts
@@ -1,0 +1,21 @@
+import Backbone from 'backbone';
+
+declare module 'backbone' {
+  interface Model<T extends ObjectHash = any, S = ModelSetOptions, E = any> {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+
+  interface Collection<TModel extends Model = Model> {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+
+  interface View<TModel extends Model | undefined = Model, TElement extends Element = HTMLElement> {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+
+  interface Router {
+    triggerMethod(event: string, ...args: unknown[]): unknown;
+  }
+}
+
+export default Backbone;

--- a/package.json
+++ b/package.json
@@ -24,8 +24,14 @@
       "default": "./dist/marionette.js"
     },
     "./backbone": {
-      "import": "./dist/backbone.js",
-      "require": "./dist/backbone.cjs",
+      "import": {
+        "types": "./dist/backbone.d.mts",
+        "default": "./dist/backbone.js"
+      },
+      "require": {
+        "types": "./dist/backbone.d.cts",
+        "default": "./dist/backbone.cjs"
+      },
       "default": "./dist/backbone.js"
     },
     "./jquery-dom-api": {

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -14,6 +14,7 @@ const fixtures = [
   'esm-node',
   'no-default-export',
   'shim',
+  'shim-types',
   'jquery-dom-api',
   'vite',
   'peer-underscore-min',

--- a/test/fixtures/shim-types/package.json
+++ b/test/fixtures/shim-types/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json"
+  },
+  "dependencies": {
+    "@types/backbone": "1.4.23",
+    "@types/jquery": "4.0.1",
+    "@types/underscore": "1.13.0",
+    "backbone": "1.4.0",
+    "typescript": "7.0.2",
+    "underscore": "1.13.8"
+  }
+}

--- a/test/fixtures/shim-types/tsconfig.cjs.json
+++ b/test/fixtures/shim-types/tsconfig.cjs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "files": [
+    "validate.cts"
+  ]
+}

--- a/test/fixtures/shim-types/tsconfig.esm.json
+++ b/test/fixtures/shim-types/tsconfig.esm.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "files": [
+    "validate.mts"
+  ]
+}

--- a/test/fixtures/shim-types/tsconfig.json
+++ b/test/fixtures/shim-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true
+  }
+}

--- a/test/fixtures/shim-types/validate.cts
+++ b/test/fixtures/shim-types/validate.cts
@@ -1,0 +1,30 @@
+import Backbone = require('marionette/backbone');
+import CanonicalBackbone = require('backbone');
+
+const sameBackboneType: typeof CanonicalBackbone = Backbone;
+const model = new sameBackboneType.Model({ id: 1, name: 'first' });
+const collection = new sameBackboneType.Collection([model]);
+const listener = new sameBackboneType.Model();
+
+listener.listenTo(model, 'change:name', (changedModel, value) => {
+  const typedModel: CanonicalBackbone.Model = changedModel;
+  const typedValue: unknown = value;
+
+  void typedModel;
+  void typedValue;
+});
+
+collection.add({ id: 2, name: 'second' });
+listener.stopListening(model);
+
+const triggerResult: unknown = model.triggerMethod('fixture:event', 1);
+collection.triggerMethod('fixture:event');
+new sameBackboneType.View().triggerMethod('fixture:event');
+new sameBackboneType.Router().triggerMethod('fixture:event');
+
+// @ts-expect-error The shim does not patch the Backbone namespace.
+sameBackboneType.triggerMethod('fixture:event');
+// @ts-expect-error The shim does not patch Backbone.History.
+new sameBackboneType.History().triggerMethod('fixture:event');
+
+void triggerResult;

--- a/test/fixtures/shim-types/validate.mts
+++ b/test/fixtures/shim-types/validate.mts
@@ -1,0 +1,30 @@
+import Backbone from 'marionette/backbone';
+import CanonicalBackbone from 'backbone';
+
+const sameBackboneType: typeof CanonicalBackbone = Backbone;
+const model = new sameBackboneType.Model({ id: 1, name: 'first' });
+const collection = new sameBackboneType.Collection([model]);
+const listener = new sameBackboneType.Model();
+
+listener.listenTo(model, 'change:name', (changedModel, value) => {
+  const typedModel: CanonicalBackbone.Model = changedModel;
+  const typedValue: unknown = value;
+
+  void typedModel;
+  void typedValue;
+});
+
+collection.add({ id: 2, name: 'second' });
+listener.stopListening(model);
+
+const triggerResult: unknown = model.triggerMethod('fixture:event', 1);
+collection.triggerMethod('fixture:event');
+new sameBackboneType.View().triggerMethod('fixture:event');
+new sameBackboneType.Router().triggerMethod('fixture:event');
+
+// @ts-expect-error The shim does not patch the Backbone namespace.
+sameBackboneType.triggerMethod('fixture:event');
+// @ts-expect-error The shim does not patch Backbone.History.
+new sameBackboneType.History().triggerMethod('fixture:event');
+
+void triggerResult;


### PR DESCRIPTION
Related #137
Related #71

## What

- Add conditional ESM and CommonJS declarations for the `marionette/backbone` entrypoint.
- Preserve the existing runtime export targets while binding each module condition to its matching declaration format.
- Add isolated strict NodeNext installed-package fixtures for both module modes, including supported and intentionally unsupported augmentation boundaries.

## Why

The runtime shim contract is now covered, but the public subpath had no TypeScript declaration contract. Consumers should receive the canonical Backbone type plus the four runtime-added `triggerMethod` surfaces without exposing unsupported namespace or `History` members.

## Scope

This changes only the `./backbone` package export metadata, its two declaration files, and installed-package fixture coverage. The root entrypoint and other subpaths are intentionally unchanged. No JavaScript runtime or generated JavaScript artifact changed.

## Deployment Impact

No application or website deployment is required. This does not publish npm, create a tag, or release v5.

## Testing

- `npm run validate`
- `npm run test:fixtures`
- `npm run lint:ci`
- `npm run check:dist`
- `npm run size`
- `git diff --check`
- Separate `tsc -p tsconfig.esm.json` and `tsc -p tsconfig.cjs.json` fixture programs verify conditional declaration selection without cross-program augmentation leakage.
- Full validation passed with 1,214 tests at 100% coverage, 19 agent benchmark tests, 89 performance tests, docs/source/dist/release checks, and unchanged runtime size at 51,878 / 51,975 bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds conditional ESM and CommonJS type declarations for the `marionette/backbone` entrypoint, so TypeScript consumers get `triggerMethod` typed on Backbone models, collections, views, and routers. Previously this subpath had no type contract; the runtime shim and all other entrypoints are unchanged, and no deployment or release is required.

**Testing**
- Adds strict NodeNext installed-package fixtures for both module modes that verify the declarations resolve correctly and that unsupported namespace and `History` members still error.

<sup>Written for commit 4356854045a9512a410b34d9be9ac37357ccad82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

