### PR TITLE
test(lifecycle): specify setElement transitions

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -140,6 +140,7 @@ attachment events and automatic child `isAttached()` updates.
 | --- | --- | --- |
 | Construct | Starts not rendered and not destroyed. It is attached only when its element is already in the document. | No children have been built. |
 | `render()` | Enters rendered and preserves its attached state. Repeated render stays rendered. | Builds and renders the current children. Repeated render destroys the previous children before building replacements. |
+| `setElement(el)` while alive | Preserves rendered state and recomputes attached state from whether the replacement element is in the document. Repeating the call with the same element recomputes the same state. | Existing managed child state and ownership are unchanged; child elements are not moved to the replacement element. |
 | A rendered collection resets | Remains rendered and preserves its attached state. | Destroys the previous children and builds replacements for the reset collection. |
 | `addChildView(view)` | Renders first when needed, then remains rendered. | Renders and manages the added View. |
 | `detachChildView(view)` | State is unchanged. | Removes and returns the live View in a detached state. The caller becomes responsible for it. |

--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -40,7 +40,7 @@ Returns a boolean value reflecting if the view has been destroyed.
 ### State vectors
 
 The three lifecycle methods are independent observations, not one linear state enum.
-Construction can therefore produce any of the four alive render/attachment vectors:
+`View` construction can therefore produce any of the four alive render/attachment vectors:
 
 | Initial `el` | `isRendered()` | `isAttached()` | `isDestroyed()` |
 | --- | --- | --- | --- |
@@ -49,12 +49,16 @@ Construction can therefore produce any of the four alive render/attachment vecto
 | Populated and detached | `true` | `false` | `false` |
 | Populated and in the document | `true` | `true` | `false` |
 
+`CollectionView` starts unrendered regardless of its initial contents and has its own
+[lifecycle transition table](./marionette.collectionview.md#view-lifecycle-and-events).
+
 With lifecycle monitoring enabled, Marionette-managed operations preserve the
 following observable transitions:
 
 | Operation | Result | Repeated call |
 | --- | --- | --- |
 | `view.render()` with a renderable template while alive | Rendered becomes `true`; attachment is unchanged | Renders again and runs the render lifecycle again |
+| `View#setElement(el)` while alive | Rendered reflects whether the replacement element has contents; attached reflects whether it is in the document | Recomputes the same state from the current element |
 | `region.show(view)` | Ensures the view is rendered; attached becomes `true` only when the Region is in the document | Showing the current view is a no-op |
 | `region.detachView()` | Rendered stays `true`; attached becomes `false`; destroyed stays `false` | Returns `undefined` with no transition |
 | Re-show a detached view | Rendered stays `true`; attachment reflects the Region | Does not render the view again |
@@ -88,10 +92,12 @@ For more information on instanting a view with pre-rendered DOM see: [Prerendere
 
 `Backbone.View` allows the user to change the view's `el` after instantiaton using
 [`setElement`](http://backbonejs.org/#View-setElement). This method can be used in Marionette
-as well, but should be done with caution. `setElement` will redelegate view events, but it will
-essentially ignore children of the view, whether through `regions` or through `children` and the
-view's `behaviors` will also be unaware of the change. It is likely better to reconstuct a new
-view with the new `el` than to try to change the `el` of an existing view.
+as well, but should be done with caution. While the View is alive, `setElement` recomputes
+`isRendered()` from the replacement element's contents and `isAttached()` from whether that
+element is in the document. Repeating the call with the same element recomputes the same state.
+View and Behavior DOM events are redelegated to the replacement element, but existing managed
+children and Region contents are not moved. It is usually better to reconstruct a new View with
+the new `el` than to change the `el` of an existing View with managed children.
 
 ## Rendering a View
 
@@ -99,7 +105,8 @@ In Marionette [rendering a view](./view.rendering.md) is changing a view's `el`'
 
 What rendering indicates varies slightly between the two Marionette views.
 
-**Note** Once a view is considered "rendered" it cannot be unrendered until it is [destroyed](#destroying-a-view).
+**Note** Outside an alive View's explicit `setElement()` replacement, once a View is considered
+rendered it cannot become unrendered until it is [destroyed](#destroying-a-view).
 
 ### `View` Rendering
 

--- a/test/unit/collection-view/collection-view-lifecycle.spec.js
+++ b/test/unit/collection-view/collection-view-lifecycle.spec.js
@@ -69,6 +69,97 @@ describe('CollectionView lifecycle contract', function() {
     });
   }
 
+  it('preserves rendered state and recomputes attachment when replacing its element while alive', function() {
+    this.setFixtures(`
+      <div id="replacement-empty"></div>
+      <div id="replacement-populated"><span>Existing content</span></div>
+    `);
+    const populatedDetached = document.createElement('div');
+    populatedDetached.innerHTML = '<span>Existing content</span>';
+    const replacements = [
+      {
+        el: document.createElement('div'),
+        expected: { rendered: true, attached: false, destroyed: false },
+      },
+      {
+        el: populatedDetached,
+        expected: { rendered: true, attached: false, destroyed: false },
+      },
+      {
+        el: document.querySelector('#replacement-empty'),
+        expected: { rendered: true, attached: true, destroyed: false },
+      },
+      {
+        el: document.querySelector('#replacement-populated'),
+        expected: { rendered: true, attached: true, destroyed: false },
+      },
+    ];
+    const collectionView = new CollectionView();
+
+    for (const replacement of [replacements[0], replacements[2]]) {
+      const expected = { ...replacement.expected, rendered: false };
+
+      expect(collectionView.setElement(replacement.el)).to.equal(collectionView);
+      expect(state(collectionView)).to.deep.equal(expected);
+
+      expect(collectionView.setElement(replacement.el)).to.equal(collectionView);
+      expect(state(collectionView)).to.deep.equal(expected);
+    }
+
+    collectionView.render();
+
+    for (const replacement of replacements) {
+      expect(collectionView.setElement(replacement.el)).to.equal(collectionView);
+      expect(state(collectionView)).to.deep.equal(replacement.expected);
+
+      expect(collectionView.setElement(replacement.el)).to.equal(collectionView);
+      expect(state(collectionView)).to.deep.equal(replacement.expected);
+    }
+
+    collectionView.destroy();
+  });
+
+  it('preserves child ownership without moving child DOM when replacing its element', function() {
+    this.setFixtures('<div id="collection-owner"></div>');
+    const oldRoot = document.querySelector('#collection-owner');
+    const replacementRoot = document.createElement('div');
+    replacementRoot.innerHTML = '<span>Replacement content</span>';
+    const model = new Backbone.Model({ id: 1 });
+    const collectionView = new CollectionView({
+      el: oldRoot,
+      collection: new Backbone.Collection([model]),
+      childView: ChildView,
+    });
+    collectionView.render();
+    const child = collectionView.children.findByModel(model);
+
+    expect(oldRoot.contains(child.el)).to.be.true;
+    expect(state(child)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+
+    collectionView.setElement(replacementRoot);
+
+    expect(state(collectionView)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(collectionView.children).to.have.lengthOf(1);
+    expect(collectionView.children.findByModel(model)).to.equal(child);
+    expect(state(child)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(oldRoot.contains(child.el)).to.be.true;
+    expect(replacementRoot.contains(child.el)).to.be.false;
+
+    collectionView.destroy();
+  });
+
   it('follows the normal Region-managed transition sequence', function() {
     this.setFixtures('<div id="collection-region"></div>');
     const collection = new Backbone.Collection([{ id: 1 }, { id: 2 }]);

--- a/test/unit/view-lifecycle.spec.js
+++ b/test/unit/view-lifecycle.spec.js
@@ -55,6 +55,87 @@ describe('View lifecycle contract', function() {
     });
   }
 
+  it('recomputes state when replacing its element while alive', function() {
+    this.setFixtures(`
+      <div id="replacement-empty"></div>
+      <div id="replacement-populated"><span>Existing content</span></div>
+    `);
+    const populatedDetached = document.createElement('div');
+    populatedDetached.innerHTML = '<span>Existing content</span>';
+    const replacements = [
+      {
+        el: document.createElement('div'),
+        expected: { rendered: false, attached: false, destroyed: false },
+      },
+      {
+        el: populatedDetached,
+        expected: { rendered: true, attached: false, destroyed: false },
+      },
+      {
+        el: document.querySelector('#replacement-empty'),
+        expected: { rendered: false, attached: true, destroyed: false },
+      },
+      {
+        el: document.querySelector('#replacement-populated'),
+        expected: { rendered: true, attached: true, destroyed: false },
+      },
+    ];
+    const view = new View({ template: false });
+
+    for (const replacement of replacements) {
+      expect(view.setElement(replacement.el)).to.equal(view);
+      expect(state(view)).to.deep.equal(replacement.expected);
+
+      expect(view.setElement(replacement.el)).to.equal(view);
+      expect(state(view)).to.deep.equal(replacement.expected);
+    }
+
+    view.destroy();
+  });
+
+  it('preserves Region ownership without moving child DOM when replacing its element', function() {
+    this.setFixtures('<div id="region-owner"></div>');
+    const oldRoot = document.querySelector('#region-owner');
+    const replacementRoot = document.createElement('div');
+    replacementRoot.innerHTML = '<span>Replacement content</span>';
+    const view = new View({
+      el: oldRoot,
+      template: () => '<div class="child-region"></div>',
+      regions: { child: '.child-region' },
+    });
+    const child = new View({ template: () => '<span>Child</span>' });
+    view.render();
+    view.showChildView('child', child);
+    const region = view.getRegion('child');
+
+    expect(oldRoot.contains(child.el)).to.be.true;
+    expect(state(child)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+
+    view.setElement(replacementRoot);
+
+    expect(state(view)).to.deep.equal({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    });
+    expect(view.getRegion('child')).to.equal(region);
+    expect(view.getChildView('child')).to.equal(child);
+    expect(region.currentView).to.equal(child);
+    expect(state(child)).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(oldRoot.contains(child.el)).to.be.true;
+    expect(replacementRoot.contains(child.el)).to.be.false;
+
+    view.destroy();
+  });
+
   it('follows the normal Region-managed transition sequence', function() {
     this.setFixtures('<div id="lifecycle-region"></div>');
     const region = new Region({ el: '#lifecycle-region' });


### PR DESCRIPTION
Related #131

## What

- Add table-driven lifecycle coverage for alive View and CollectionView element replacement across empty/populated and attached/detached roots.
- Characterize repeated replacement calls and preservation of nested Region and CollectionView child ownership without moving child DOM.
- Document the distinct View and CollectionView rendered-state contracts and correct the previous View lifecycle overstatement.

## Why

Agents should not need to infer setElement lifecycle behavior from implementation details. The existing lifecycle tables omitted the replace-element transition, and the View guide incorrectly implied that an alive rendered View could never become unrendered.

## Scope

This changes only View and CollectionView lifecycle tests and documentation. Post-destroy replacement behavior, Application/State design, runtime modules, generated artifacts, package metadata, and performance contracts are intentionally unchanged.

## Deployment Impact

No application or website deployment is required. This does not publish npm, create a tag, or release v5.

## Testing

- Full Vitest coverage: 70 files, 1,218 tests, 100% statements/branches/functions/lines.
- Agent benchmark contract: 19 tests passed.
- `npm run lint:ci`
- `npm run docs:check` (33 pages, 34 HTML files, 320 internal links)
- `npm run check:dist`
- `npm run test:performance` (89 tests)
- `npm run test:release-promotion`
- Browser profile, release profile, release-promotion dry-run, and bundle-size checks.
- Runtime size remained unchanged at 51,878 / 51,975 bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lifecycle coverage for `setElement()` element replacement on `View` and `CollectionView`, and corrects the docs to match the actual behavior.

Previously the View lifecycle docs claimed a rendered View could never become unrendered while alive; `setElement()` can change that based on the replacement element's contents. The new tests specify that rendered and attached state are recomputed from the replacement element, repeated calls with the same element recompute the same state, and managed children and Region contents are preserved without moving child DOM. Runtime behavior is unchanged.

**Testing**
- Full Vitest suite: 70 files, 1,218 tests, 100% coverage.
- Performance, lint, docs, and bundle-size checks all pass; runtime size unchanged.

<sup>Written for commit 231c0d60194e81b95f1a355e87fb6e6fd98df3ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how replacing a live view’s element recalculates rendered and attached state.
  - Documented event redelegation and clarified that managed children and Region contents remain in their original DOM location.
  - Added guidance favoring reconstruction of a new view when appropriate.

- **Tests**
  - Added coverage for element replacement across detached, attached, empty, and populated states.
  - Verified repeated replacements are consistent and preserve child ownership and DOM placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->