### PR TITLE
feat(types): complete optional subpath declarations

### DIFF
--- a/dist/jquery-dom-api.d.cts
+++ b/dist/jquery-dom-api.d.cts
@@ -1,0 +1,17 @@
+import 'jquery';
+
+declare const JQueryDomApi: {
+  findEl<TElement extends Element = HTMLElement>(
+    el: Element | Document,
+    selector: string,
+  ): JQuery<TElement>;
+  detachEl(el: Element): void;
+  setContents(el: Element, html: string): void;
+  appendContents(
+    el: Element | DocumentFragment,
+    contents: Element | DocumentFragment | string,
+  ): void;
+  detachContents(el: Element): void;
+};
+
+export = JQueryDomApi;

--- a/dist/jquery-dom-api.d.mts
+++ b/dist/jquery-dom-api.d.mts
@@ -1,0 +1,17 @@
+import 'jquery';
+
+declare const JQueryDomApi: {
+  findEl<TElement extends Element = HTMLElement>(
+    el: Element | Document,
+    selector: string,
+  ): JQuery<TElement>;
+  detachEl(el: Element): void;
+  setContents(el: Element, html: string): void;
+  appendContents(
+    el: Element | DocumentFragment,
+    contents: Element | DocumentFragment | string,
+  ): void;
+  detachContents(el: Element): void;
+};
+
+export default JQueryDomApi;

--- a/dist/jquery-dom-api.d.ts
+++ b/dist/jquery-dom-api.d.ts
@@ -1,9 +1,0 @@
-declare const JQueryDomApi: {
-  findEl(el: Element | Document, selector: string): any;
-  detachEl(el: Element): void;
-  setContents(el: Element, html: string): void;
-  appendContents(el: Element | DocumentFragment, contents: Element | DocumentFragment | string): void;
-  detachContents(el: Element): void;
-};
-
-export default JQueryDomApi;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,9 @@ required; the rest are optional.
 |---|---|---|
 | `underscore` `^1.13.0` | Required | Always. Marionette publishes named ESM imports from `underscore`, and versions before 1.13 are CJS-only with no package `exports` map, so modern Node and bundler ESM resolution cannot satisfy the imports. |
 | `backbone` `^1.4.0` | Optional | Only if your app uses Backbone models/collections, or imports the bundled `marionette/backbone` shim. See [Backbone is optional](#backbone-is-optional). |
+| `@types/backbone` `^1.4.23` | Optional | TypeScript declarations for `marionette/backbone`. JavaScript consumers do not need it. |
 | `jquery` `^3.5.0` | Optional | Only if your app uses the `marionette/jquery-dom-api` adapter. See [jQuery DOM adapter is optional](#jquery-dom-adapter-is-optional). |
+| `@types/jquery` `^3.5.34` | Optional | TypeScript declarations for `marionette/jquery-dom-api`. JavaScript consumers do not need it. |
 
 Install the required peer alongside Marionette:
 
@@ -55,6 +57,17 @@ npm install backbone
 
 # Only if you use the jQuery DomApi adapter
 npm install jquery
+```
+
+Npm does not install missing optional peers. TypeScript consumers of an optional
+subpath must install its matching type package explicitly:
+
+```bash
+# Only if TypeScript imports marionette/backbone
+npm install --save-dev @types/backbone@^1.4.23
+
+# Only if TypeScript imports marionette/jquery-dom-api
+npm install --save-dev @types/jquery@^3.5.34
 ```
 
 ## Quick start

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,11 +36,19 @@
         "node": ">=24"
       },
       "peerDependencies": {
+        "@types/backbone": "^1.4.23",
+        "@types/jquery": "^3.5.34",
         "backbone": "^1.4.0",
         "jquery": "^3.5.0",
         "underscore": "^1.13.0"
       },
       "peerDependenciesMeta": {
+        "@types/backbone": {
+          "optional": true
+        },
+        "@types/jquery": {
+          "optional": true
+        },
         "backbone": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -35,9 +35,14 @@
       "default": "./dist/backbone.js"
     },
     "./jquery-dom-api": {
-      "types": "./dist/jquery-dom-api.d.ts",
-      "import": "./dist/jquery-dom-api.js",
-      "require": "./dist/jquery-dom-api.cjs",
+      "import": {
+        "types": "./dist/jquery-dom-api.d.mts",
+        "default": "./dist/jquery-dom-api.js"
+      },
+      "require": {
+        "types": "./dist/jquery-dom-api.d.cts",
+        "default": "./dist/jquery-dom-api.cjs"
+      },
       "default": "./dist/jquery-dom-api.js"
     },
     "./package.json": "./package.json"
@@ -109,6 +114,8 @@
   },
   "github": "https://github.com/marionettejs/marionette",
   "peerDependencies": {
+    "@types/backbone": "^1.4.23",
+    "@types/jquery": "^3.5.34",
     "backbone": "^1.4.0",
     "jquery": "^3.5.0",
     "underscore": "^1.13.0"
@@ -118,6 +125,12 @@
       "optional": true
     },
     "jquery": {
+      "optional": true
+    },
+    "@types/backbone": {
+      "optional": true
+    },
+    "@types/jquery": {
       "optional": true
     }
   },

--- a/test/fixtures/jquery-dom-api-types/package.json
+++ b/test/fixtures/jquery-dom-api-types/package.json
@@ -5,11 +5,8 @@
     "validate": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json"
   },
   "dependencies": {
-    "@types/backbone": "1.4.23",
     "@types/jquery": "3.5.34",
-    "@types/underscore": "1.13.0",
-    "backbone": "1.4.0",
-    "typescript": "7.0.2",
-    "underscore": "1.13.8"
+    "jquery": "3.5.1",
+    "typescript": "7.0.2"
   }
 }

--- a/test/fixtures/jquery-dom-api-types/tsconfig.cjs.json
+++ b/test/fixtures/jquery-dom-api-types/tsconfig.cjs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "files": [
+    "validate.cts"
+  ]
+}

--- a/test/fixtures/jquery-dom-api-types/tsconfig.esm.json
+++ b/test/fixtures/jquery-dom-api-types/tsconfig.esm.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "files": [
+    "validate.mts"
+  ]
+}

--- a/test/fixtures/jquery-dom-api-types/tsconfig.json
+++ b/test/fixtures/jquery-dom-api-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "DOM",
+      "ES2024"
+    ],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true
+  }
+}

--- a/test/fixtures/jquery-dom-api-types/validate.cts
+++ b/test/fixtures/jquery-dom-api-types/validate.cts
@@ -1,0 +1,21 @@
+import JQueryDomApi = require('marionette/jquery-dom-api');
+
+const host = document.createElement('div');
+const fragment = document.createDocumentFragment();
+const result: JQuery<HTMLElement> = JQueryDomApi.findEl(host, '.child');
+
+JQueryDomApi.detachEl(host);
+JQueryDomApi.setContents(host, '<span>child</span>');
+JQueryDomApi.appendContents(host, fragment);
+JQueryDomApi.appendContents(host, '<span>child</span>');
+JQueryDomApi.detachContents(host);
+
+// @ts-expect-error findEl returns a jQuery collection, not a DOM element.
+const element: Element = JQueryDomApi.findEl(host, '.child');
+// @ts-expect-error A selector must be a string.
+JQueryDomApi.findEl(host, 1);
+// @ts-expect-error The adapter does not expose arbitrary jQuery methods.
+JQueryDomApi.addClass('active');
+
+void result;
+void element;

--- a/test/fixtures/jquery-dom-api-types/validate.mts
+++ b/test/fixtures/jquery-dom-api-types/validate.mts
@@ -1,0 +1,21 @@
+import JQueryDomApi from 'marionette/jquery-dom-api';
+
+const host = document.createElement('div');
+const fragment = document.createDocumentFragment();
+const result: JQuery<HTMLElement> = JQueryDomApi.findEl(host, '.child');
+
+JQueryDomApi.detachEl(host);
+JQueryDomApi.setContents(host, '<span>child</span>');
+JQueryDomApi.appendContents(host, fragment);
+JQueryDomApi.appendContents(host, '<span>child</span>');
+JQueryDomApi.detachContents(host);
+
+// @ts-expect-error findEl returns a jQuery collection, not a DOM element.
+const element: Element = JQueryDomApi.findEl(host, '.child');
+// @ts-expect-error A selector must be a string.
+JQueryDomApi.findEl(host, 1);
+// @ts-expect-error The adapter does not expose arbitrary jQuery methods.
+JQueryDomApi.addClass('active');
+
+void result;
+void element;

--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -16,6 +16,7 @@ const fixtures = [
   'shim',
   'shim-types',
   'jquery-dom-api',
+  'jquery-dom-api-types',
   'vite',
   'peer-underscore-min',
 ];


### PR DESCRIPTION
Related #137

## What

- Add format-correct ESM and CommonJS declarations for `marionette/jquery-dom-api`, including a precise generic `JQuery<TElement>` return for `findEl`.
- Bind each runtime export condition to its matching declaration and add separately compiled strict NodeNext installed-package fixtures.
- Declare `@types/backbone` and `@types/jquery` as optional peers, align fixture versions with the supported runtime majors, and document the explicit TypeScript install contract.

## Why

The jQuery adapter had one unverified declaration whose `findEl` result was `any`. The new Backbone and jQuery subpath declarations also rely on external peer types that their runtime packages do not bundle; making those type peers explicit prevents fixtures from masking an undeclared consumer requirement while keeping JavaScript users unaffected.

## Scope

This changes optional-subpath declarations, export metadata, optional peer metadata, installation documentation, and installed-package type fixtures. Root Marionette declarations, Application/State contracts, runtime source, generated JavaScript, Rollup configuration, and performance contracts are intentionally unchanged.

## Deployment Impact

No application or website deployment is required. Optional type peers are not installed unless a consumer opts into the typed subpath. This does not publish npm, create a tag, or release v5.

## Testing

- Full Vitest coverage: 70 files, 1,218 tests, 100% statements/branches/functions/lines.
- Agent benchmark contract: 19 tests passed.
- `npm run test:fixtures`, including separate ESM and CommonJS TypeScript programs for both optional subpaths.
- `npm run lint:ci`
- `npm run docs:check` (33 pages, 34 HTML files, 320 internal links)
- `npm run check:dist`
- `npm run test:performance` (89 tests)
- Release-promotion, browser-profile, release-profile, and bundle-size checks.
- `npm audit --omit=dev` reported 0 vulnerabilities.
- Runtime artifacts stayed unchanged; cumulative size remains 51,878 / 51,975 bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds complete TypeScript declarations for the `marionette/jquery-dom-api` subpath, replacing the previous untyped `findEl` (which returned `any`) with a precise generic `JQuery<TElement>` return and format-correct ESM/CommonJS declaration files. Declares `@types/backbone` and `@types/jquery` as optional peers so TypeScript consumers know they must install those packages; JavaScript consumers are unaffected.

**Migration**

- TypeScript consumers importing `marionette/backbone` or `marionette/jquery-dom-api` must install the matching `@types/*` package as a dev dependency, since npm does not install optional peers.
- Adds strict NodeNext installed-package fixtures for both ESM and CommonJS to verify the new declarations resolve correctly.

<sup>Written for commit 839de3f6b3f8a677e567b3c63082646a820a0718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

