### PR TITLE
test(lifecycle): specify nested attachment propagation

### DIFF
--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -221,6 +221,12 @@ The attached state is maintained when attaching a view with a `Region` or as a c
 or during [view instantiation](#instantiating-a-view).
 If a view is attached by other means like `$.append` [`isAttached`] may not reflect the actual state of attachment.
 
+A child shown in a rendered but detached parent View's Region is rendered and remains
+detached. When the parent is later shown in an attached Region, attachment propagates
+to its existing children. A child shown during the parent's `onAttach` is attached
+immediately. Showing the same attached parent again is a no-op for both parent and child
+attachment lifecycles.
+
 ## Detaching a View
 
 A view is detached when its `el` is removed from the DOM.
@@ -229,6 +235,11 @@ The best time to clean up any listeners added to the `el` is in the [`before:det
 While the `el` of the view may remain attached, its contents will be removed on render.
 If you have added listeners to the contents of the view rather than `before:detach` the
 [`dom:remove` event](./events.class.md#domremove-event) would be best.
+
+Detaching a parent View propagates detachment to its managed Region children while
+preserving their rendered state and ownership. Re-showing that parent attaches the same
+children again. Emptying the parent-owning Region then detaches and destroys the parent
+and its still-managed children once.
 
 ## Destroying a View
 

--- a/test/unit/view-lifecycle.spec.js
+++ b/test/unit/view-lifecycle.spec.js
@@ -136,6 +136,96 @@ describe('View lifecycle contract', function() {
     view.destroy();
   });
 
+  it('propagates nested attachment through detached, reentrant, and repeated transitions', function() {
+    this.setFixtures('<div id="nested-lifecycle-region"></div>');
+    const existingChild = new View({ template: () => '<span>Existing child</span>' });
+    const reentrantChild = new View({ template: () => '<span>Reentrant child</span>' });
+    let firstReentrantStateDuringAttach;
+    const ParentView = View.extend({
+      template: () => `
+        <div class="existing-region"></div>
+        <div class="reentrant-region"></div>
+      `,
+      regions: {
+        existing: '.existing-region',
+        reentrant: '.reentrant-region',
+      },
+      onAttach() {
+        this.showChildView('reentrant', reentrantChild);
+        if (!firstReentrantStateDuringAttach) {
+          firstReentrantStateDuringAttach = state(reentrantChild);
+        }
+      },
+    });
+    const parent = new ParentView();
+    const region = new Region({ el: '#nested-lifecycle-region' });
+    const trackLifecycle = view => {
+      const events = {
+        attach: this.sinon.spy(),
+        detach: this.sinon.spy(),
+        destroy: this.sinon.spy(),
+      };
+      view.on(events);
+      return events;
+    };
+    const lifecycleEvents = [
+      trackLifecycle(parent),
+      trackLifecycle(existingChild),
+      trackLifecycle(reentrantChild),
+    ];
+
+    parent.render();
+    parent.showChildView('existing', existingChild);
+
+    expect(state(parent)).to.deep.equal({ rendered: true, attached: false, destroyed: false });
+    expect(state(existingChild)).to.deep.equal({ rendered: true, attached: false, destroyed: false });
+    expect(state(reentrantChild)).to.deep.equal({ rendered: false, attached: false, destroyed: false });
+
+    region.show(parent);
+
+    expect(firstReentrantStateDuringAttach).to.deep.equal({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    });
+    expect(parent.getChildView('existing')).to.equal(existingChild);
+    expect(parent.getChildView('reentrant')).to.equal(reentrantChild);
+    expect([parent, existingChild, reentrantChild].map(state)).to.deep.equal(Array(3).fill({
+      rendered: true,
+      attached: true,
+      destroyed: false,
+    }));
+    lifecycleEvents.forEach(events => expect(events.attach).to.have.been.calledOnce);
+
+    region.show(parent);
+    lifecycleEvents.forEach(events => expect(events.attach).to.have.been.calledOnce);
+
+    expect(region.detachView()).to.equal(parent);
+    expect([parent, existingChild, reentrantChild].map(state)).to.deep.equal(Array(3).fill({
+      rendered: true,
+      attached: false,
+      destroyed: false,
+    }));
+    lifecycleEvents.forEach(events => expect(events.detach).to.have.been.calledOnce);
+
+    region.show(parent);
+    lifecycleEvents.forEach(events => expect(events.attach).to.have.been.calledTwice);
+
+    region.empty();
+    region.empty();
+    expect([parent, existingChild, reentrantChild].map(state)).to.deep.equal(Array(3).fill({
+      rendered: false,
+      attached: false,
+      destroyed: true,
+    }));
+    lifecycleEvents.forEach(events => {
+      expect(events.detach).to.have.been.calledTwice;
+      expect(events.destroy).to.have.been.calledOnce;
+    });
+
+    region.destroy();
+  });
+
   it('follows the normal Region-managed transition sequence', function() {
     this.setFixtures('<div id="lifecycle-region"></div>');
     const region = new Region({ el: '#lifecycle-region' });


### PR DESCRIPTION
Related #131

## What

- Add one canonical public-API lifecycle sequence for a detached rendered parent View and its existing Region child.
- Characterize attachment propagation, a second child shown synchronously during parent `onAttach`, repeated same-parent show, detach/re-show, and repeated final teardown.
- Document the corresponding nested Region-managed attachment and detachment contract.

## Why

The behavior existed in implementation and scattered legacy callback tests, but agents still had to infer the complete nested state transition sequence. This makes the detached-parent, selected reentrant, repeated-call, and teardown behavior executable in the canonical lifecycle contract.

## Scope

This changes only the View lifecycle test and documentation. It intentionally excludes pre-render `showChildView`, post-destroy operations, Application/State lifecycle design, runtime modules, generated artifacts, package metadata, and performance contracts.

## Deployment Impact

No application or website deployment is required. This does not publish npm, create a tag, or release v5.

## Testing

- Full Vitest coverage: 70 files, 1,219 tests, 100% statements/branches/functions/lines.
- Agent benchmark contract: 19 tests passed.
- `npm run lint:ci`
- `npm run docs:check` (33 pages, 34 HTML files, 320 internal links)
- `npm run check:dist`
- `npm run test:fixtures`
- `npm run test:performance` (89 tests)
- Release-promotion, browser-profile, release-profile, and bundle-size checks.
- Runtime size remained unchanged at 51,878 / 51,975 bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Specifies the nested attachment propagation lifecycle for rendered-but-detached parent Views and their existing Region children, covering reentrant `showChildView` during parent `onAttach`, repeated same-parent shows, detach/re-show, and repeated teardown. This makes the previously inferred behavior executable and documented, satisfying the contract requirements in #131.

No behavior, runtime, or deployment changes; the diff adds only a canonical lifecycle test and two doc paragraphs.

<sup>Written for commit 88964c114811d85ea6509ceb2eba4be3db8f2fd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

