### PR TITLE
test(behavior): specify nested removal ownership

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -236,8 +236,10 @@ const Modal = Behavior.extend({
 
 [Live example](https://jsfiddle.net/marionettejs/7ffnqff3/)
 
-Nested Behaviors act as if they were direct Behaviors of the parent `Behavior`'s
-view instance.
+Nesting groups Behavior declarations; it does not transfer cleanup ownership to
+the declaring Behavior. Nested Behaviors act as direct Behaviors of the same host
+view, so destroying the declarer leaves them active until they are removed
+directly or the host is destroyed.
 
 ## The Behavior's `view`
 The `view` is a reference to the `View` instance that the `Behavior` is attached to.

--- a/test/unit/behavior-lifecycle.spec.js
+++ b/test/unit/behavior-lifecycle.spec.js
@@ -186,6 +186,58 @@ describe('Behavior lifecycle contract', function() {
     expect(behavior.stopListening).to.have.been.calledOnce;
   });
 
+  it('keeps a nested Behavior host-owned after directly removing its declarer', function() {
+    const parentHostEvent = this.sinon.spy();
+    const nestedHostEvent = this.sinon.spy();
+    const parentBeforeDestroy = this.sinon.spy();
+    const nestedBeforeDestroy = this.sinon.spy();
+    const parentDestroy = this.sinon.spy();
+    const nestedDestroy = this.sinon.spy();
+    let parentBehavior;
+    let nestedBehavior;
+
+    const NestedBehavior = Behavior.extend({
+      initialize() {
+        nestedBehavior = this;
+      },
+      onHostEvent: nestedHostEvent,
+      onBeforeDestroy: nestedBeforeDestroy,
+      onDestroy: nestedDestroy,
+    });
+    const ParentBehavior = Behavior.extend({
+      behaviors: [NestedBehavior],
+      initialize() {
+        parentBehavior = this;
+      },
+      onHostEvent: parentHostEvent,
+      onBeforeDestroy: parentBeforeDestroy,
+      onDestroy: parentDestroy,
+    });
+    const TestView = View.extend({ behaviors: [ParentBehavior] });
+    const view = new TestView();
+
+    expect(parentBehavior.view).to.equal(view);
+    expect(nestedBehavior.view).to.equal(view);
+    view.triggerMethod('host:event');
+    expect(parentHostEvent).to.have.been.calledOnce.and.calledOn(parentBehavior);
+    expect(nestedHostEvent).to.have.been.calledOnce.and.calledOn(nestedBehavior);
+
+    parentBehavior.destroy();
+
+    view.triggerMethod('host:event');
+
+    expect(parentHostEvent).to.have.been.calledOnce;
+    expect(nestedHostEvent).to.have.been.calledTwice;
+
+    view.destroy();
+    view.destroy();
+
+    expect(parentBeforeDestroy).to.not.have.been.called;
+    expect(parentDestroy).to.not.have.been.called;
+    expect(nestedBeforeDestroy).to.have.been.calledOnce.and.calledOn(nestedBehavior);
+    expect(nestedDestroy).to.have.been.calledOnce.and.calledOn(nestedBehavior);
+  });
+
   it('cleans up top-level and nested Behaviors once in host destroy order', function() {
     this.setFixtures('<div id="destroy-region"></div>');
     const lifecycle = [];


### PR DESCRIPTION
Related #133

## What

- Add a lifecycle contract proving that directly destroying a declaring Behavior removes only that instance.
- Verify its nested Behavior remains active on the shared host and is later destroyed exactly once by host teardown.
- Document Behavior nesting as declaration grouping rather than parent-owned cleanup.

## Why

Nested Behavior instances are flattened into the host-owned Behavior collection, but the public docs and tests did not state what happens when the declaring Behavior is removed directly. Agents should not infer cleanup ownership from declaration nesting.

## Scope

This changes only Behavior lifecycle tests and documentation. It intentionally leaves pre-rendered-host UI representation, repeated direct cleanup/reuse, dynamic Behavior replacement, root declarations, runtime modules, generated artifacts, package metadata, and performance contracts unchanged.

## Deployment Impact

No application or website deployment is required. This does not publish npm, create a tag, or release v5.

## Testing

- Full Vitest coverage: 70 files, 1,220 tests, 100% statements/branches/functions/lines.
- Agent benchmark contract: 19 tests passed.
- `npm run lint:ci`
- `npm run docs:check` (33 pages, 34 HTML files, 320 internal links)
- `npm run check:dist`
- `npm run test:fixtures`
- `npm run test:performance` (89 tests)
- Release-promotion, browser-profile, release-profile, and bundle-size checks.
- Runtime size remained unchanged at 51,878 / 51,975 bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses #133 by clarifying that nested Behaviors belong to the host view, not to the declaring Behavior. Previously cleanup ownership was unspecified; now destroying the declaring Behavior directly leaves nested Behaviors active until removed directly or the host is destroyed.

**Changes**
- Updates docs to state that nesting groups declarations rather than transferring cleanup ownership.
- Adds a lifecycle test proving the nested Behavior survives direct declarer removal and is destroyed exactly once at host teardown.
- Limits changes to tests and documentation; no production behavior or bundle size changes.

<sup>Written for commit 1b9791adeaa734f547deda2eae7d875bd74aa2ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

