### PR TITLE
test(region): cover owned region teardown

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -507,8 +507,10 @@ This can be useful in unit testing your views.
 
 ## `destroy` A Region
 
-A region can be destroyed which will `reset` the region, remove it from any parent view,
-and stop any internal region listeners. A destroyed region should not be reused.
+A region can be destroyed which will `reset` the region, destroy its current View,
+remove it from any parent View's Region lookups, and stop any internal Region listeners.
+Repeated Region destruction or later destruction of the parent View does not repeat
+the child or Region teardown. A destroyed Region should not be reused.
 
 ```javascript
 import { View } from 'backbone.marionette';

--- a/test/unit/region-lifecycle.spec.js
+++ b/test/unit/region-lifecycle.spec.js
@@ -211,4 +211,60 @@ describe('Region lifecycle contract', function() {
     expect(region.hasView()).to.be.false;
     expect(region.currentView).to.be.undefined;
   });
+
+  it('unlinks a directly destroyed owned Region without repeating teardown', function() {
+    const owner = new View({
+      regions: {
+        content: '.content',
+      },
+      template() {
+        return '<div class="content"></div>';
+      },
+    });
+    const child = new TestView();
+    const regionLifecycle = {
+      beforeDestroy: this.sinon.spy(),
+      beforeEmpty: this.sinon.spy(),
+      empty: this.sinon.spy(),
+      destroy: this.sinon.spy(),
+    };
+    const childLifecycle = {
+      beforeDestroy: this.sinon.spy(),
+      destroy: this.sinon.spy(),
+    };
+
+    owner.render();
+    const ownedRegion = owner.getRegion('content');
+    ownedRegion.on('before:destroy', regionLifecycle.beforeDestroy);
+    ownedRegion.on('before:empty', regionLifecycle.beforeEmpty);
+    ownedRegion.on('empty', regionLifecycle.empty);
+    ownedRegion.on('destroy', regionLifecycle.destroy);
+    child.on('before:destroy', childLifecycle.beforeDestroy);
+    child.on('destroy', childLifecycle.destroy);
+    ownedRegion.show(child);
+
+    expect(owner.getRegion('content')).to.equal(ownedRegion);
+    expect(owner.hasRegion('content')).to.be.true;
+    expect(ownedRegion.currentView).to.equal(child);
+
+    expect(ownedRegion.destroy()).to.equal(ownedRegion);
+    expect(ownedRegion.destroy()).to.equal(ownedRegion);
+
+    expect(ownedRegion.isDestroyed()).to.be.true;
+    expect(ownedRegion.hasView()).to.be.false;
+    expect(ownedRegion.currentView).to.be.undefined;
+    expect(child.isDestroyed()).to.be.true;
+    expect(owner.getRegion('content')).to.be.undefined;
+    expect(owner.hasRegion('content')).to.be.false;
+    expect(owner.getRegions()).not.to.have.own.property('content');
+
+    expect(owner.destroy()).to.equal(owner);
+    expect(owner.destroy()).to.equal(owner);
+
+    for (const lifecycle of [regionLifecycle, childLifecycle]) {
+      for (const callback of Object.values(lifecycle)) {
+        expect(callback).to.have.been.calledOnce;
+      }
+    }
+  });
 });


### PR DESCRIPTION
Related #132

## What

- Add a public-API contract test for directly destroying a View-owned Region.
- Document removal from the owning View lookup and exactly-once child/Region teardown.

## Why

Marionette already removes a directly destroyed named Region from its owner, but that topology transition was split across implementation details and separate tests. Agents need the observable ownership and teardown contract pinned before the broader pure-query work in #132.

## Agent-development failure addressed

A caller could not determine from one public contract whether direct Region destruction leaves stale owner topology or whether later owner destruction repeats cleanup.

## Public behavior contract

- Canonical behavior after this PR: directly destroying an owned Region destroys its current View once, clears Region state, removes the named Region from public owner lookups, and makes repeated Region or owner destruction a no-op for that teardown.
- Superseded behavior removed: none; this characterizes existing behavior.
- Compatibility exception and removal condition: none.

## Scope

- Affects Region lifecycle tests and Region documentation only.
- Does not change runtime code, Application topology, unrendered lookup behavior, or destroyed-Region reuse semantics.

## Runtime cost

- Static or documentation only.
- Bundle: zero runtime artifact delta.
- Startup/hot path: unchanged.
- Allocations/retention: unchanged.

## Deployment Impact

No application redeploy or package publication is needed. This PR changes repository tests and documentation only.

## Testing

- Narrow Region lifecycle test: 8 tests passed.
- npm run coverage: 70 files, 1,221 tests, 100% statements/branches/functions/lines; agent benchmark contract 19/19.
- npm run docs:check: 33 pages, 34 HTML files, 320 internal links.
- npm run lint:ci.
- npm run check:dist.
- git diff --check.
- Confirmed no changes under runtime, build, dist, package, or configuration paths.

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: none; the test characterizes existing public lifecycle behavior.
- Production/dev/test module-graph impact: none.

## Rollback or deprecation

Revert the test/documentation commit if the broader #132 design intentionally changes this ownership contract; no runtime rollback is required.

## Review notes

This is deliberately a partial #132 slice. Pure unrendered Region queries and Application topology remain out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the public contract for directly destroying a View-owned Region, supporting the pure-query work in #132. Directly destroying an owned Region destroys its current View once, clears Region state, unlinks the named Region from the owner's lookups, and makes repeated Region or owner destruction a no-op for that teardown.

**Scope**
- Changes tests and `docs/marionette.region.md` only; no runtime code changes.
- Does not touch Application topology, unrendered lookup behavior, or destroyed-Region reuse semantics.

<sup>Written for commit 36ba9b2b6d88f81c78c4060276c0cc42a2088087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that destroying a Region also destroys its current View and removes it from its parent View’s Region lookups.
  * Documented that destruction is safe to repeat and that destroyed Regions should not be reused.

* **Tests**
  * Added coverage for Region and child View teardown, owner unlinking, cleared state, and one-time lifecycle callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->