### PR TITLE
test(view): cover reentrant destruction

### DIFF
--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -249,6 +249,11 @@ a view's instance is no longer referenced the view can be cleaned up by the brow
 The [`before:destroy` event](./events.class.md#destroy-and-beforedestroy-events) is the best place to clean
 up any added listeners not related to the view's DOM.
 
+Once destruction begins, reentrant `destroy()` calls from `before:destroy` or
+`destroy`, and later repeated calls, return the same View without restarting
+teardown. An attached parent, its managed children, and its owning Region therefore
+complete their detach, destroy, and empty lifecycles once.
+
 The state of the view after the destroy is not attached and not rendered although the `el` is not emptied.
 
 ## Destroying Children

--- a/test/unit/view-lifecycle.spec.js
+++ b/test/unit/view-lifecycle.spec.js
@@ -226,6 +226,70 @@ describe('View lifecycle contract', function() {
     region.destroy();
   });
 
+  it('ignores reentrant and repeated destroy calls while tearing down once', function() {
+    this.setFixtures('<div id="reentrant-destroy-region"></div>');
+    const parent = new View({
+      regions: { child: '.child-region' },
+      template: () => '<div class="child-region"></div>',
+    });
+    const child = new View({ template: () => '<span>Child</span>' });
+    const region = new Region({ el: '#reentrant-destroy-region' });
+    let beforeDestroyReturn;
+    let destroyReturn;
+    const lifecycle = {
+      parentBeforeDestroy: this.sinon.spy(currentView => {
+        beforeDestroyReturn = currentView.destroy();
+      }),
+      parentBeforeDetach: this.sinon.spy(),
+      parentDetach: this.sinon.spy(),
+      parentDestroy: this.sinon.spy(currentView => {
+        destroyReturn = currentView.destroy();
+      }),
+      childBeforeDetach: this.sinon.spy(),
+      childDetach: this.sinon.spy(),
+      childBeforeDestroy: this.sinon.spy(),
+      childDestroy: this.sinon.spy(),
+      regionBeforeEmpty: this.sinon.spy(),
+      regionEmpty: this.sinon.spy(),
+    };
+
+    parent.on({
+      'before:destroy': lifecycle.parentBeforeDestroy,
+      'before:detach': lifecycle.parentBeforeDetach,
+      detach: lifecycle.parentDetach,
+      destroy: lifecycle.parentDestroy,
+    });
+    child.on({
+      'before:detach': lifecycle.childBeforeDetach,
+      detach: lifecycle.childDetach,
+      'before:destroy': lifecycle.childBeforeDestroy,
+      destroy: lifecycle.childDestroy,
+    });
+    region.on({
+      'before:empty': lifecycle.regionBeforeEmpty,
+      empty: lifecycle.regionEmpty,
+    });
+
+    region.show(parent);
+    parent.showChildView('child', child);
+
+    expect(parent.destroy()).to.equal(parent);
+    expect(parent.destroy()).to.equal(parent);
+    expect(beforeDestroyReturn).to.equal(parent);
+    expect(destroyReturn).to.equal(parent);
+
+    expect(state(parent)).to.deep.equal({ rendered: false, attached: false, destroyed: true });
+    expect(state(child)).to.deep.equal({ rendered: false, attached: false, destroyed: true });
+    expect(region.hasView()).to.be.false;
+    expect(region.currentView).to.be.undefined;
+
+    for (const callback of Object.values(lifecycle)) {
+      expect(callback).to.have.been.calledOnce;
+    }
+
+    region.destroy();
+  });
+
   it('follows the normal Region-managed transition sequence', function() {
     this.setFixtures('<div id="lifecycle-region"></div>');
     const region = new Region({ el: '#lifecycle-region' });


### PR DESCRIPTION
Related #131

## What

- Add a public lifecycle contract test for reentrant View destruction.
- Document that destroy calls from before:destroy, destroy, and after completion return the same View without restarting teardown.
- Verify parent, managed child, and owning Region cleanup each complete exactly once.

## Why

The runtime already guards reentrant destruction, but the behavior was only visible in implementation. #131 requires selected reentrant lifecycle cases to be explicit so agents do not infer whether nested destroy calls repeat detach, child destruction, or Region emptying.

## Agent-development failure addressed

A lifecycle handler could reasonably call destroy again without any public test or documentation explaining whether that restarts teardown, duplicates events, or corrupts the owning Region.

## Public behavior contract

- Canonical behavior after this PR: once View destruction starts, reentrant and later repeated destroy calls return the same View and do not restart teardown; parent, child, and owning Region lifecycles each complete once.
- Superseded behavior removed: none; this characterizes the existing guard.
- Compatibility exception and removal condition: none.

## Scope

- Affects View lifecycle tests and documentation only.
- Does not change runtime code, Application lifecycle, State, Region lookup behavior, or post-destroy operations other than repeated destroy.

## Runtime cost

- Static or documentation only.
- Bundle: zero runtime artifact delta.
- Startup/hot path: unchanged.
- Allocations/retention: unchanged.

## Deployment Impact

No application redeploy or package publication is needed. This PR changes repository tests and documentation only.

## Testing

- Narrow View lifecycle suite: 9 tests passed.
- npm run coverage: 70 files, 1,222 tests, 100% statements/branches/functions/lines; agent benchmark contract 19/19.
- npm run docs:check: 33 pages, 34 HTML files, 320 internal links.
- npm run lint:ci.
- npm run check:dist.
- git diff --check.
- Confirmed no changes under runtime, build, dist, entrypoint, or manifest paths.

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: none; the unit test uses the existing DOM harness.
- Production/dev/test module-graph impact: none.

## Rollback or deprecation

Revert the test/documentation commit if the broader #131 lifecycle design intentionally changes reentrant destruction before stable v5; no runtime rollback is required.

## Review notes

This is a partial #131 slice. Application invalidation and other unsupported post-destroy operations remain out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lifecycle contract test and documentation for reentrant View destruction, covering part of #131 by making the existing guard against repeated teardown explicit.

- Calling `destroy()` from `before:destroy`, `destroy`, or after completion returns the same View without restarting teardown.
- Parent detach, managed child destruction, and owning Region empty each fire exactly once.
- No runtime code changes; the PR only updates `test/unit/view-lifecycle.spec.js` and `docs/view.lifecycle.md`.

<sup>Written for commit 3fd05165d919fa1db281238c3af0df45167aef03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

