### PR TITLE
test(docs): execute Behavior UI example

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -459,36 +459,41 @@ constructs Behaviors. This contract pins only that construction ordering. It
 intentionally leaves the mixed Behavior UI representation for that path unresolved;
 do not infer the selector-before-binding sequence above or rely on that representation.
 
+<!-- executable-example: behavior-ui-resolution -->
 ```javascript
-import { Behavior, View } from 'backbone.marionette';
+import { Behavior, View } from 'marionette';
 
-const MyBehavior = Behavior.extend({
+const SaveBehavior = Behavior.extend({
   ui: {
-    saveForm: '.btn-save'
+    save: '.btn-save'
   },
 
   events: {
-    'click @ui.saveForm': 'saveForm'  // .btn-primary when used with `FirstView`
+    'click @ui.save': 'requestSave'
   },
 
-  saveForm() {
-    this.view.model.save();
+  requestSave() {
+    this.getUI('save')[0].classList.add('is-saving');
+    this.view.requestSave();
   }
 });
 
-const FirstView = View.extend({
-  behaviors: [MyBehavior],
+export const FormView = View.extend({
+  behaviors: [SaveBehavior],
+
+  template() {
+    return [
+      '<button class="btn-save" type="button">Default save</button>',
+      '<button class="btn-primary" type="button">Save</button>'
+    ].join('');
+  },
 
   ui: {
-    saveForm: '.btn-primary'
+    save: '.btn-primary'
   },
 
-  events: {
-    'click @ui.saveForm': 'checkForm'  // .btn-primary
-  },
-
-  checkForm() {
-    // ...
+  requestSave() {
+    this.triggerMethod('save:requested', this);
   }
 });
 ```

--- a/test/fixtures/docs-behavior-host/validate.mjs
+++ b/test/fixtures/docs-behavior-host/validate.mjs
@@ -6,27 +6,42 @@ import { JSDOM } from 'jsdom';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const docsPath = resolve(__dirname, '../../../docs/marionette.behavior.md');
-const marker = '<!-- executable-example: behavior-host-communication -->';
 const markdown = await readFile(docsPath, 'utf8');
-
-assert.equal(markdown.split(marker).length - 1, 1, 'expected one executable example marker');
-
-const markedContent = markdown.slice(markdown.indexOf(marker) + marker.length);
-const codeFence = markedContent.match(/^\s*```javascript\n([\s\S]*?)\n```/);
-
-assert.ok(codeFence, 'expected a JavaScript fence immediately after the marker');
-
 const distDir = resolve(__dirname, 'dist');
-const examplePath = resolve(distDir, 'example.mjs');
+const examples = [
+  {
+    marker: '<!-- executable-example: behavior-host-communication -->',
+    path: resolve(distDir, 'host-communication.mjs'),
+  },
+  {
+    marker: '<!-- executable-example: behavior-ui-resolution -->',
+    path: resolve(distDir, 'ui-resolution.mjs'),
+  },
+];
 
 await mkdir(distDir, { recursive: true });
-await writeFile(examplePath, codeFence[1], 'utf8');
+
+for (const example of examples) {
+  assert.equal(
+    markdown.split(example.marker).length - 1,
+    1,
+    `expected one ${example.marker} marker`,
+  );
+
+  const markedContent = markdown.slice(markdown.indexOf(example.marker) + example.marker.length);
+  const codeFence = markedContent.match(/^\s*```javascript\n([\s\S]*?)\n```/);
+
+  assert.ok(codeFence, `expected a JavaScript fence immediately after ${example.marker}`);
+  await writeFile(example.path, codeFence[1], 'utf8');
+}
 
 const dom = new JSDOM(`<!doctype html>
   <html>
     <body>
-      <button class="save" id="outside" type="button">Outside</button>
-      <main id="host"></main>
+      <button class="save" id="outside-save" type="button">Outside</button>
+      <button class="btn-primary" id="outside-primary" type="button">Outside primary</button>
+      <main id="communication-host"></main>
+      <main id="ui-host"></main>
     </body>
   </html>`);
 
@@ -34,32 +49,78 @@ globalThis.window = dom.window;
 globalThis.document = dom.window.document;
 
 try {
-  const { FormView } = await import(pathToFileURL(examplePath));
-  const view = new FormView();
-  let requestCount = 0;
-  let requestedView;
+  const [{ FormView: CommunicationView }, { FormView: UiResolutionView }] = await Promise.all(
+    examples.map(example => import(pathToFileURL(example.path))),
+  );
 
-  view.on('save:requested', currentView => {
-    requestCount += 1;
-    requestedView = currentView;
-  });
+  {
+    const view = new CommunicationView();
+    let requestCount = 0;
+    let requestedView;
 
-  view.render();
-  document.querySelector('#host').append(view.el);
+    view.on('save:requested', currentView => {
+      requestCount += 1;
+      requestedView = currentView;
+    });
 
-  const outsideButton = document.querySelector('#outside');
-  const hostButton = view.el.querySelector('.save');
+    view.render();
+    document.querySelector('#communication-host').append(view.el);
 
-  outsideButton.click();
-  assert.equal(requestCount, 0, 'outside-host DOM must not trigger the Behavior');
+    const outsideButton = document.querySelector('#outside-save');
+    const hostButton = view.el.querySelector('.save');
 
-  hostButton.click();
-  assert.equal(requestCount, 1, 'the host button must request save exactly once');
-  assert.equal(requestedView, view, 'the host must receive its View as the request argument');
+    outsideButton.click();
+    assert.equal(requestCount, 0, 'outside-host DOM must not trigger the Behavior');
 
-  view.destroy();
-  hostButton.click();
-  assert.equal(requestCount, 1, 'destroy must undelegate the retained host button');
+    hostButton.click();
+    assert.equal(requestCount, 1, 'the host button must request save exactly once');
+    assert.equal(requestedView, view, 'the host must receive its View as the request argument');
+
+    view.destroy();
+    hostButton.click();
+    assert.equal(requestCount, 1, 'destroy must undelegate the retained host button');
+  }
+
+  {
+    const view = new UiResolutionView();
+    let requestCount = 0;
+    let requestedView;
+
+    view.on('save:requested', currentView => {
+      requestCount += 1;
+      requestedView = currentView;
+    });
+
+    view.render();
+    document.querySelector('#ui-host').append(view.el);
+
+    const outsideButton = document.querySelector('#outside-primary');
+    const defaultButton = view.el.querySelector('.btn-save');
+    const firstPrimaryButton = view.el.querySelector('.btn-primary');
+
+    outsideButton.click();
+    defaultButton.click();
+    assert.equal(requestCount, 0, 'only the host-scoped winning selector must trigger the Behavior');
+
+    firstPrimaryButton.click();
+    assert.equal(requestCount, 1, 'the host UI override must request save exactly once');
+    assert.equal(requestedView, view, 'the UI override must request work from its host View');
+    assert.ok(firstPrimaryButton.classList.contains('is-saving'), 'the current UI must be marked');
+
+    view.render();
+    const secondPrimaryButton = view.el.querySelector('.btn-primary');
+
+    assert.notEqual(secondPrimaryButton, firstPrimaryButton, 'rerender must replace the UI element');
+    assert.ok(!secondPrimaryButton.classList.contains('is-saving'), 'replacement UI must start unmarked');
+
+    secondPrimaryButton.click();
+    assert.equal(requestCount, 2, 'the rebound replacement must request save exactly once');
+    assert.ok(secondPrimaryButton.classList.contains('is-saving'), 'the rebound current UI must be marked');
+
+    view.destroy();
+    secondPrimaryButton.click();
+    assert.equal(requestCount, 2, 'destroy must undelegate the rebound UI element');
+  }
 } finally {
   dom.window.close();
   delete globalThis.document;


### PR DESCRIPTION
Related #139
Related #133

## What

- Promote the existing host-wins Behavior UI example to a canonical executable fence.
- Extend the existing packed-package Behavior fixture to execute both host communication and UI resolution examples.
- Verify host scoping, View UI precedence, current UI lookup, rerender rebinding, and destroy cleanup through public behavior.

## Why

The documentation states that a host View UI key overrides the same Behavior key, but the example was not standalone and no shipped-package fixture executed that selector resolution across render and rerender. Agents need a copyable pattern whose UI ownership and cleanup claims are verified without private fields.

## Agent-development failure addressed

A reader could copy an incomplete example, bind the Behavior default selector instead of the host selector, or retain stale UI after rerender because the documented collision behavior was not executable.

## Public behavior contract

- Canonical behavior after this PR: the host View wins a shared UI key; Behavior events and current getUI lookup use that host-scoped selector; rerender rebinds the replacement element; destroy removes delegation.
- Superseded behavior removed: the incomplete collision example is replaced with a standalone shipped-entrypoint example.
- Compatibility exception and removal condition: none.

## Scope

- Affects Behavior documentation and the existing Behavior packed-package fixture only.
- Does not decide the unresolved pre-rendered mixed-UI representation, inspect private Behavior state, or change runtime code.

## Runtime cost

- Development or test only; excluded from production entrypoints.
- Bundle: zero runtime delta; cumulative remains 51.88/51.98 kB.
- Startup/hot path: unchanged.
- Allocations/retention: unchanged in production.

## Deployment Impact

No application redeploy or package publication is needed. This PR changes repository documentation and tests only.

## Testing

- Test-first marker assertion failed before the documentation marker was added.
- Focused packed-package Behavior fixture.
- npm run test:fixtures, including all executable documentation fixtures.
- npm run docs:check: 33 pages, 34 HTML files, 320 internal links.
- npm run lint:ci.
- npm run check:dist.
- npm run size: cumulative 51.88/51.98 kB.
- git diff --check.

## Package and browser impact

- Entry points or install fixtures affected: extends the existing public marionette package-consumer fixture.
- Browser contracts affected: verifies host-scoped DOM delegation and rerender rebinding with the pinned jsdom environment.
- Production/dev/test module-graph impact: test fixture only.

## Rollback or deprecation

Revert the documentation and paired fixture assertions together if the unresolved #133 UI representation decision changes this host-wins contract before stable v5.

## Review notes

This advances but does not close #139 or #133. It intentionally reuses the existing Behavior fixture and does not modify the shared fixture runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the Behavior UI resolution example into an executable fixture that confirms the host View's UI key overrides the Behavior's default, and that events, current UI lookup, rerender rebinding, and destroy cleanup all use the host-scoped element. The fixture now runs the updated docs example and replaces the previous non-executable collision example; it advances but does not close #133 and #139.

<sup>Written for commit 4e2ea0416b4bd1ea6989548e5d3cea57719d2cd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

