### PR TITLE
perf(build): authorize runtime budget BA0001

### DIFF
--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -1,4 +1,46 @@
 {
   "schemaVersion": 1,
-  "entries": []
+  "entries": [
+    {
+      "kind": "authorization",
+      "id": "BA0001",
+      "target": "aggregate-shipped-package",
+      "previousCeilingBytes": 51975,
+      "proposedCeilingBytes": 52369,
+      "prototypeBaseCommit": "6d7c33a65766540f9266bfe21192c48fceb8c813",
+      "prototypeCommit": "2bac1e5afb3f294ee553d77a8e58fcaf9380f48a",
+      "implementationIssueUrl": "https://github.com/marionettejs/marionette/issues/226",
+      "authorizedArtifactPaths": [
+        "dist/marionette.cjs",
+        "dist/marionette.js",
+        "dist/marionette.min.js",
+        "dist/marionette.umd.js"
+      ],
+      "authorizedNewSubpaths": [],
+      "reports": [
+        {
+          "path": "evidence/performance-budget-amendments/BA0001/base.json",
+          "role": "base",
+          "sha256": "658d7cb338db6cbfd75c39636fe4951a2e2c17299bd547ccfceea7b3023aaa60"
+        },
+        {
+          "path": "evidence/performance-budget-amendments/BA0001/prototype.json",
+          "role": "prototype",
+          "sha256": "dbbf0b9eb56198eb1709c1e851b7f647b4e97c0f653215dbd4f27b38302464b5"
+        }
+      ],
+      "prototypeContract": {
+        "path": "evidence/performance-budget-amendments/BA0001/prototype-contract.json",
+        "sha256": "636c9246d075352cf9a938891abf41fa88dbf01160cef7462edc46367980719e"
+      },
+      "approvalUrls": [
+        "https://github.com/marionettejs/marionette/pull/227#issuecomment-5459577374"
+      ],
+      "evidenceUrls": [
+        "https://github.com/marionettejs/marionette/issues/127#issuecomment-5459577259"
+      ],
+      "rationale": "Authorize the exact measured distribution cost of a uniform retryable before:destroy contract and stable lazy MN0022 validation for CollectionView emptyView definitions. The combined prototype avoids divergent lifecycle semantics and incidental errors without speculative padding, new production subpaths, normal-path helper calls, or changes to the immutable Phase 0 baseline.",
+      "rollbackCondition": "If #224 is abandoned before consumption, append a governance-only BA0001 revocation. Never edit or delete this authorization. If a final runtime implementation exceeds 52369 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
+    }
+  ]
 }

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -63,8 +63,8 @@ garbage-collector proof.
 ## Budget amendments
 
 [`config/release/performance-budget-amendments.json`](https://github.com/marionettejs/marionette/blob/master/config/release/performance-budget-amendments.json)
-is an append-only governance ledger outside the production package. The initial
-ledger is empty. Its entries are either authorizations with sequential `BA0001`
+is an append-only governance ledger outside the production package. The ledger
+began empty. Its entries are either authorizations with sequential `BA0001`
 identifiers or revocations with sequential `BR0001` identifiers. There is no mutable
 status field. The active ceiling and entry order derive whether the latest
 authorization is pending, consumed, or revoked.
@@ -79,6 +79,13 @@ approval URL must resolve to a canonical exact-head pull-request comment from a
 base-allowed maintainer. Evidence URLs remain durable issue #127 comments from trusted
 repository participants. The record also preserves its rationale and rollback
 condition.
+
+BA0001 authorizes a pending aggregate-ceiling increase from 51,975 to 52,369
+bytes for the exact-base lifecycle-retry and CollectionView `emptyView`
+diagnostic prototype tracked by [#226](https://github.com/marionettejs/marionette/issues/226).
+The proposal equals the measured combined prototype total without padding. It
+does not change the active ceiling until a later implementation consumes the
+authorization, and it adds no production subpath.
 
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole

--- a/evidence/performance-budget-amendments/BA0001/base.json
+++ b/evidence/performance-budget-amendments/BA0001/base.json
@@ -1,0 +1,365 @@
+{
+  "schemaVersion": 1,
+  "revision": "6d7c33a65766540f9266bfe21192c48fceb8c813",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 13418,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 13563,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 13822,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 10481,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 121,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 135,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 51878,
+      "baselineSize": 49500,
+      "absoluteCeiling": 51975
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/view-region.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/proxy.js",
+          "version.js"
+        ],
+        "externalImports": [
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette",
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      }
+    ],
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": []
+  }
+}

--- a/evidence/performance-budget-amendments/BA0001/prototype-contract.json
+++ b/evidence/performance-budget-amendments/BA0001/prototype-contract.json
@@ -1,0 +1,343 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "sourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "totalBrotliBytes": 49500,
+    "absoluteCeilingBytes": 51975
+  },
+  "toolchain": {
+    "releaseProfile": {
+      "path": "config/release-profile.json",
+      "sha256": "a0a7b0330fc84feae7766616f4a651abbc822d268a566a0350ebb2c0f1818ce5",
+      "node": "24.19.0",
+      "npm": "11.17.0",
+      "lockfileVersion": 3,
+      "canonicalHost": {
+        "id": "linux-x64",
+        "runner": "ubuntu-24.04",
+        "platform": "linux",
+        "architecture": "x64"
+      }
+    },
+    "lockedDependencies": {
+      "backbone": "1.4.0",
+      "jsdom": "30.0.1",
+      "rollup": "4.63.0"
+    },
+    "commands": {
+      "deterministic": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run size"
+      ],
+      "hostedTiming": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run performance:timing"
+      ]
+    }
+  },
+  "thresholds": {
+    "cumulativeGrowthPercent": 5,
+    "pullRequestApprovalPercent": 1,
+    "hostedTimingWarningPercent": 10,
+    "controlledMedianRegressionPercent": 5,
+    "controlledP95RegressionPercent": 10
+  },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
+  "runtimeArtifacts": [
+    {
+      "name": "Main ES module",
+      "path": "dist/marionette.js",
+      "baselineBrotliBytes": 12776
+    },
+    {
+      "name": "Main CommonJS",
+      "path": "dist/marionette.cjs",
+      "baselineBrotliBytes": 12932
+    },
+    {
+      "name": "Main UMD",
+      "path": "dist/marionette.umd.js",
+      "baselineBrotliBytes": 13197
+    },
+    {
+      "name": "Main minified UMD",
+      "path": "dist/marionette.min.js",
+      "baselineBrotliBytes": 10001,
+      "additionalShippedArtifact": true
+    },
+    {
+      "name": "Backbone shim ES module",
+      "path": "dist/backbone.js",
+      "baselineBrotliBytes": 121
+    },
+    {
+      "name": "Backbone shim CommonJS",
+      "path": "dist/backbone.cjs",
+      "baselineBrotliBytes": 135
+    },
+    {
+      "name": "jQuery DomApi ES module",
+      "path": "dist/jquery-dom-api.js",
+      "baselineBrotliBytes": 169
+    },
+    {
+      "name": "jQuery DomApi CommonJS",
+      "path": "dist/jquery-dom-api.cjs",
+      "baselineBrotliBytes": 169
+    }
+  ],
+  "productionGraphs": [
+    {
+      "subpath": ".",
+      "input": "index.js",
+      "output": "dist/marionette.js",
+      "baselineModules": [
+        "config/dom.js",
+        "config/event-delegator.js",
+        "config/features.js",
+        "config/renderer.js",
+        "index.js",
+        "mixins/behaviors.js",
+        "mixins/common.js",
+        "mixins/delegate-entity-events.js",
+        "mixins/destroy.js",
+        "mixins/events.js",
+        "mixins/radio.js",
+        "mixins/requests.js",
+        "mixins/template-render.js",
+        "mixins/ui.js",
+        "mixins/view-events.js",
+        "mixins/view.js",
+        "modules/application.js",
+        "modules/behavior.js",
+        "modules/child-view-container.js",
+        "modules/collection-view.js",
+        "modules/common/bind-events.js",
+        "modules/common/bind-requests.js",
+        "modules/common/get-option.js",
+        "modules/common/merge-options.js",
+        "modules/common/monitor-view-events.js",
+        "modules/common/normalize-methods.js",
+        "modules/common/radio.js",
+        "modules/common/trigger-method.js",
+        "modules/common/view.js",
+        "modules/object.js",
+        "modules/radio.js",
+        "modules/view-region.js",
+        "utils/build-event-args.js",
+        "utils/call-handler.js",
+        "utils/error.js",
+        "utils/extend.js",
+        "utils/make-callback.js",
+        "utils/once-wrap.js",
+        "utils/proxy.js",
+        "version.js"
+      ],
+      "baselineExternalImports": [
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./backbone",
+      "input": "backbone.js",
+      "output": "dist/backbone.js",
+      "baselineModules": [
+        "backbone.js"
+      ],
+      "baselineExternalImports": [
+        "backbone",
+        "marionette",
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./jquery-dom-api",
+      "input": "jquery-dom-api.js",
+      "output": "dist/jquery-dom-api.js",
+      "baselineModules": [
+        "jquery-dom-api.js"
+      ],
+      "baselineExternalImports": [
+        "jquery"
+      ]
+    }
+  ],
+  "forbiddenProductionModulePrefixes": [
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "docs-site/",
+    "node_modules/",
+    "test/",
+    "config/diagnostics/",
+    "config/docs/",
+    "config/release/"
+  ],
+  "forbiddenProductionModules": [
+    "config/bundle-size.mjs",
+    "config/performance-growth-approval.mjs",
+    "config/performance-resources.mjs",
+    "config/performance.json",
+    "config/release-profile.json",
+    "config/release-promotion.json"
+  ],
+  "deterministicResources": {
+    "attachDetachCycles": 100,
+    "mountDestroyCycles": 1000,
+    "instanceShapes": {
+      "View": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_domEvents",
+        "_eventPrefix",
+        "_isAttached",
+        "_isRendered",
+        "_rdEvents",
+        "_regions",
+        "cid",
+        "el",
+        "options",
+        "regions"
+      ],
+      "Region": [
+        "_initEl",
+        "cid",
+        "el",
+        "options"
+      ],
+      "Behavior": [
+        "_domEvents",
+        "_rdListenId",
+        "_rdListeningTo",
+        "cid",
+        "el",
+        "options",
+        "ui",
+        "view"
+      ],
+      "CollectionView": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_children",
+        "_collectionEvents",
+        "_domEvents",
+        "_emptyRegion",
+        "_eventPrefix",
+        "_isAttached",
+        "_rdEvents",
+        "childView",
+        "children",
+        "cid",
+        "collection",
+        "el",
+        "options"
+      ]
+    },
+    "allocationShapes": {
+      "View": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "_regions",
+          "options",
+          "regions"
+        ],
+        "marionetteEventRegistrations": 6
+      },
+      "Behavior": {
+        "emptyArrays": [
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "options",
+          "ui"
+        ],
+        "listeningContainers": 1
+      },
+      "CollectionView": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyChildViewContainers": [
+          "_children",
+          "children"
+        ],
+        "eagerEmptyRegion": true,
+        "marionetteEventRegistrations": 6
+      }
+    },
+    "retentionShapes": {
+      "regionRegistrationsWhileShown": 1,
+      "collectionRegistrationsWhileMounted": 3,
+      "modelRegistrationsWhileMounted": 1,
+      "externalListenerOwnersWhileMounted": 1,
+      "collectionViewListeningToWhileMounted": 1,
+      "behaviorListeningToWhileMounted": 2,
+      "destroyedBehaviorRetainsHostReference": true,
+      "destroyedHostRetainsBehaviorCount": 1,
+      "externalRegistrationsAfterDestroy": 0,
+      "externalListenerOwnersAfterDestroy": 0,
+      "frameworkListeningToAfterDestroy": 0,
+      "childContainerEntriesAfterDestroy": 0,
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
+    }
+  },
+  "timing": {
+    "harnessSchemaVersion": 1,
+    "harnessRevision": "271128bee00c66b3168424d65220dbe6c5dbea1f336082c21b45a07a344bb1d9",
+    "sampleCount": 20,
+    "warmupBatches": 5,
+    "cases": [
+      {
+        "id": "view-construct-destroy",
+        "iterationsPerSample": 200
+      },
+      {
+        "id": "view-render-rerender",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "behavior-view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "region-show-empty",
+        "iterationsPerSample": 50
+      },
+      {
+        "id": "collection-view-render-destroy",
+        "iterationsPerSample": 10
+      },
+      {
+        "id": "collection-view-add-remove",
+        "iterationsPerSample": 20
+      }
+    ],
+    "controlledRunner": {
+      "status": "pending-pr-b"
+    }
+  }
+}

--- a/evidence/performance-budget-amendments/BA0001/prototype.json
+++ b/evidence/performance-budget-amendments/BA0001/prototype.json
@@ -1,0 +1,367 @@
+{
+  "schemaVersion": 1,
+  "revision": "2bac1e5afb3f294ee553d77a8e58fcaf9380f48a",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "../marionette-ba0001-reports/prototype-contract.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 13540,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 13702,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 13969,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 10564,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 121,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 135,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 52369,
+      "baselineSize": 49500,
+      "absoluteCeiling": 51975
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/view-region.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/proxy.js",
+          "version.js"
+        ],
+        "externalImports": [
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette",
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      }
+    ],
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": [
+      "Cumulative Brotli-11 size 52369 exceeds the absolute ceiling 51975"
+    ]
+  }
+}


### PR DESCRIPTION
Related #226
Related #127

## What

- Record immutable exact-base and combined-prototype bundle reports for BA0001.
- Authorize an aggregate shipped-package ceiling increase from 51,975 to exactly 52,369 Brotli-11 bytes.
- Bind the authorization to the measured lifecycle-retry and `MN0022` prototype, existing main artifact scope, durable evidence, and rollback conditions.

## Why

The uniform destruction contract and stable CollectionView `emptyView` diagnostic are agent-readiness correctness changes, not optional packaging growth. Their exact-base combined prototype measures 52,369 bytes. The current five-percent backstop would otherwise force inconsistent lifecycle semantics or code-golfed runtime paths.

## Scope

- Governance ledger, immutable BA0001 evidence, and synchronized performance documentation only.
- The active ceiling, immutable Phase 0 baseline, production runtime, package exports, graphs, tests, and workflows remain unchanged.
- #224 will consume the authorization later; #134 will remain a separate runtime implementation.

## Deployment Impact

No deployment, website publication, npm publication, tag, or release is performed. No application redeploy is required.

## Testing

- Exact base report at `6d7c33a65766540f9266bfe21192c48fceb8c813`: 51,878 bytes.
- Exact prototype report at `2bac1e5afb3f294ee553d77a8e58fcaf9380f48a`: 52,369 bytes.
- Combined prototype: 1,260 tests, 100% coverage, 89/89 performance-contract tests, diagnostics, lint, docs, source/dist, packed fixtures, and reproducible builds.
- Governance validation and exact-head CI will run after the ledger and canonical approval permalink are added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorizes a one-time shipped-package ceiling increase for the BA0001 prototype so the lifecycle-destruction contract and stable CollectionView `emptyView` diagnostic can land without tripping the five-percent growth backstop. The aggregate Brotli-11 ceiling is raised from 51,975 to exactly 52,369 bytes, matching the measured combined-prototype bundle.

**Scope**
- Adds the BA0001 authorization entry to the append-only governance ledger and three immutable evidence files.
- The authorization is pending and does not change the active ceiling until #224 consumes it.
- No runtime code, package exports, graphs, tests, or workflows change.
- #134 remains a separate runtime implementation.

**Testing**
- Combined prototype passes 1,260 tests with 100% coverage and 89/89 performance-contract tests.
- Governance validation and exact-head CI remain as next steps.

<sup>Written for commit 7a1ef9f30c55961e177d933e164b4176715b82a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

