### PR TITLE
test(fixtures): discover package fixtures

### DIFF
--- a/test/fixtures/run.mjs
+++ b/test/fixtures/run.mjs
@@ -8,23 +8,15 @@ const rootDir = resolve(__dirname, '../..');
 const packDir = resolve(rootDir, 'test/tmp/pack-fixtures');
 const npmCli = process.env.npm_execpath;
 const cliArgs = process.argv.slice(2);
-const fixtures = [
-  'cjs-node',
-  'cjs-adapters',
-  'esm-node',
-  'no-default-export',
-  'shim',
-  'shim-types',
-  'jquery-dom-api',
-  'jquery-dom-api-types',
-  'docs-behavior-host',
-  'docs-collectionview-child-ownership',
-  'docs-radio-owner',
-  'docs-region-lifecycle',
-  'docs-view-child-region',
-  'vite',
-  'peer-underscore-min',
-];
+const fixtures = readdirSync(__dirname, { withFileTypes: true })
+  .filter(entry => entry.isDirectory() &&
+    existsSync(resolve(__dirname, entry.name, 'package.json')))
+  .map(entry => entry.name)
+  .sort();
+
+if (fixtures.length === 0) {
+  throw new Error('No packed-package fixtures discovered under test/fixtures');
+}
 
 function run(command, args, options = {}) {
   execFileSync(command, args, {


### PR DESCRIPTION
Related #139

## What

- Discover immediate packed-package fixture directories from their `package.json` files.
- Sort discovered fixture names before running them.
- Remove the obsolete manually maintained fixture registration list.

## Why

The executable-documentation program can currently add a fixture directory without registering it in `test/fixtures/run.mjs`, causing CI to silently skip it. Discovery makes every package fixture part of the validation run by construction.

## Scope

- Affects only `test/fixtures/run.mjs`.
- Ignores non-directory entries and directories without a `package.json`.
- Does not change runtime source, distribution artifacts, package metadata, exports, dependencies, workflows, performance contracts, or repository rules.

## Deployment Impact

No website, npm package, tag, or release is published by this PR. No consumer redeploy is required.

## Testing

- `npm run test:fixtures`: all 15 packed-package fixtures passed.
- `npm run lint:ci`
- `npm run check:dist`
- `npm run size`: 51.88 kB / 51.98 kB.
- `git diff --check`
- Verified discovery returns the same 15 current fixtures in deterministic order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discovers packed-package test fixtures automatically from their `package.json` files instead of relying on a manually maintained list, so new fixture directories can no longer be silently skipped by CI.

- Reads `test/fixtures/` for directories containing a `package.json` and runs them in sorted order.
- Removes the hardcoded fixture registration list from `test/fixtures/run.mjs`.
- Excludes non-directory entries and directories without a `package.json`; fails the run if no fixtures are discovered.
- Affects only the fixture runner; no runtime, package, or consumer impact.
- All 15 existing fixtures pass with the same deterministic order.

<sup>Written for commit 7ce815a6fbcca1d7801bbcca88961edb827f979b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

