### PR TITLE
test(docs): execute Behavior collaborator ownership

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -175,32 +175,49 @@ Behavior options can also provide collaborators that the Behavior needs. These
 values are selected during construction and retained by reference. Read an
 arbitrary collaborator with `getOption()` so that a class default and an
 attachment override follow the same option precedence; arbitrary option names
-are not copied directly onto the Behavior instance.
+are not copied directly onto the Behavior instance. A host can explicitly pass
+an injected service through a `behaviors()` function:
 
+`initialize(options, hostView)` receives the same host View exposed as
+`this.view`.
+
+<!-- executable-example: behavior-collaborator -->
 ```javascript
+import { Behavior, View } from 'marionette';
+
 const SelectionBehavior = Behavior.extend({
-  options: {
-    service: defaultSelectionService
-  },
-
-  initialize(options, hostView) {
-    const service = this.getOption('service');
-    this.listenTo(service, 'selection:change', this.onSelectionChange);
-
-    // The second argument and this.view are the same host View.
-    console.log(hostView === this.view); // true
+  initialize() {
+    this.listenTo(
+      this.getOption('service'),
+      'selection:change',
+      this.onSelectionChange
+    );
   },
 
   onSelectionChange(selection) {
-    // ...
+    this.view.showSelection(selection);
   }
 });
 
-const MyView = View.extend({
-  behaviors: [{
-    behaviorClass: SelectionBehavior,
-    service: applicationSelectionService
-  }]
+export const SelectionView = View.extend({
+  template() {
+    return '<output class="selection"></output>';
+  },
+
+  ui: {
+    selection: '.selection'
+  },
+
+  behaviors() {
+    return [{
+      behaviorClass: SelectionBehavior,
+      service: this.getOption('selectionService')
+    }];
+  },
+
+  showSelection(selection) {
+    this.getUI('selection')[0].textContent = selection.label;
+  }
 });
 ```
 

--- a/test/fixtures/docs-behavior-host/validate.mjs
+++ b/test/fixtures/docs-behavior-host/validate.mjs
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { MnObject } from 'marionette';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const docsPath = resolve(__dirname, '../../../docs/marionette.behavior.md');
@@ -16,6 +17,10 @@ const examples = [
   {
     marker: '<!-- executable-example: behavior-ui-resolution -->',
     path: resolve(distDir, 'ui-resolution.mjs'),
+  },
+  {
+    marker: '<!-- executable-example: behavior-collaborator -->',
+    path: resolve(distDir, 'collaborator.mjs'),
   },
 ];
 
@@ -42,6 +47,7 @@ const dom = new JSDOM(`<!doctype html>
       <button class="btn-primary" id="outside-primary" type="button">Outside primary</button>
       <main id="communication-host"></main>
       <main id="ui-host"></main>
+      <main id="selection-host"></main>
     </body>
   </html>`);
 
@@ -49,9 +55,11 @@ globalThis.window = dom.window;
 globalThis.document = dom.window.document;
 
 try {
-  const [{ FormView: CommunicationView }, { FormView: UiResolutionView }] = await Promise.all(
-    examples.map(example => import(pathToFileURL(example.path))),
-  );
+  const [
+    { FormView: CommunicationView },
+    { FormView: UiResolutionView },
+    { SelectionView },
+  ] = await Promise.all(examples.map(example => import(pathToFileURL(example.path))));
 
   {
     const view = new CommunicationView();
@@ -120,6 +128,42 @@ try {
     view.destroy();
     secondPrimaryButton.click();
     assert.equal(requestCount, 2, 'destroy must undelegate the rebound UI element');
+  }
+
+  {
+    const selectionService = new MnObject();
+    let behaviorDeliveryCount = 0;
+    let unrelatedDeliveryCount = 0;
+    const InstrumentedSelectionView = SelectionView.extend({
+      showSelection(selection) {
+        behaviorDeliveryCount += 1;
+        return SelectionView.prototype.showSelection.call(this, selection);
+      },
+    });
+    const view = new InstrumentedSelectionView({ selectionService });
+
+    selectionService.on('selection:change', () => {
+      unrelatedDeliveryCount += 1;
+    });
+
+    view.render();
+    document.querySelector('#selection-host').append(view.el);
+
+    selectionService.trigger('selection:change', { label: 'First selection' });
+
+    assert.equal(behaviorDeliveryCount, 1, 'the injected collaborator must notify the Behavior once');
+    assert.equal(unrelatedDeliveryCount, 1, 'the collaborator must retain unrelated listeners');
+    assert.equal(view.getUI('selection')[0].textContent, 'First selection');
+
+    view.destroy();
+    selectionService.trigger('selection:change', { label: 'After destroy' });
+
+    assert.equal(behaviorDeliveryCount, 1, 'host destroy must remove the Behavior subscription');
+    assert.equal(unrelatedDeliveryCount, 2, 'host destroy must leave unrelated listeners active');
+    assert.equal(selectionService.isDestroyed(), false, 'host destroy must not destroy the collaborator');
+
+    selectionService.off();
+    selectionService.destroy();
   }
 } finally {
   dom.window.close();


### PR DESCRIPTION
Related #139

## What

- Replace undefined collaborator placeholders with one standalone Behavior ownership example.
- Show a host View explicitly forwarding its injected collaborator through `behaviors()`.
- Execute the published example against the packed package and prove subscription cleanup without collaborator destruction.

## Why

The existing example referenced undefined services and was not executable. Agents need a copyable contract for collaborator injection, Behavior-owned listening, and the ownership boundary between host teardown and an externally owned service.

## Scope

- Affects `docs/marionette.behavior.md` and the existing `docs-behavior-host` packed-package fixture.
- Does not change runtime source, distribution artifacts, package metadata, exports, dependencies, workflows, performance contracts, or repository rules.

## Deployment Impact

No website, npm package, tag, or release is published by this PR. No consumer redeploy is required.

## Testing

- Focused installed-package `docs-behavior-host` fixture.
- `npm run test:fixtures`
- `npm run docs:check`: 33 pages, 34 HTML files, 320 links.
- `npm run lint:ci`
- `npm run check:dist`
- `npm run size`: 51.88 kB / 51.98 kB.
- `git diff --check`

The fixture proves exactly one Behavior delivery, rendered collaborator data, host teardown removing only the Behavior subscription, the collaborator remaining alive, and an unrelated collaborator listener remaining active.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Behavior collaborator docs example executable so the ownership boundary between host teardown and an injected service is proven. The old example referenced undefined services; the new one passes an injected collaborator through `behaviors()` and reads it via `getOption()`.

- Adds fixture assertions that the Behavior gets exactly one delivery, host destroy removes only the Behavior subscription, and the collaborator plus its unrelated listeners stay alive.
- Touches only the docs page and the `docs-behavior-host` fixture; no runtime or package changes.

<sup>Written for commit 12e6dacf3e402eb8a45979193d7a3e69ca22ba3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

