### PR TITLE
docs(reference): repair source links

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -32,7 +32,6 @@ A `View` can have [`Region`s](./marionette.region.md) and [`Behavior`s](./marion
 * [Managing Children](#managing-children)
   * [Laying Out Views - Regions](#laying-out-views---regions)
   * [Showing a Child View](#showing-a-child-view)
-  * [Attaching a Child View](#attaching-a-child-view)
   * [Detaching a Child View](#detaching-a-child-view)
   * [Destroying a Child View](#destroying-a-child-view)
   * [Region Availability](#region-availability)

--- a/docs/upgrade-v2-v3.md
+++ b/docs/upgrade-v2-v3.md
@@ -42,7 +42,7 @@ The `CompositeView` was deprecated in favor of using `View` and
 `CollectionView`. The `CompositeView` will be completely removed in Marionette
 4.
 
-See [`CollectionView`](./marionette.collectionview.md#rendering-collectionviews)
+See [`CollectionView`](./marionette.collectionview.md#rendering-a-collectionview)
 for detail on upgrading to Marionette 3. This technique works in both Marionette
 2.x and Marionette 3.
 
@@ -272,7 +272,7 @@ in Marionette to manage the `CollectionView` children.
 The main difference between Babysitter and the Marionette implementation is the
 removal of `.call` and `.apply` on `CollectionView.children`. Instead you should
 use `.invoke` or
-[any of the methods provided](./marionette.collectionview.md#collectionview-childview-iterators-and-collection-functions).
+[any of the methods provided](./marionette.collectionview.md#collectionview-children-iterators-and-collection-functions).
 
 For example:
 

--- a/docs/view.rendering.md
+++ b/docs/view.rendering.md
@@ -379,7 +379,7 @@ const MyView = View.extend({
 ### Serializing with a `CollectionView`
 
 if you are using a `template` with a `CollectionView` that is not also given a `model`, your `CollectionView`
-will [serialize the collection](serializing-a-collection) for the template. This could be costly and unnecessary.
+will [serialize the collection](#serializing-a-collection) for the template. This could be costly and unnecessary.
 If your `CollectionView` has a `template` it is advised to either use an empty `model` or override the
 [`serializeData`](#serializing-data) method.
 


### PR DESCRIPTION
Related #147

## What

- Remove a stale View table-of-contents link to a heading that no longer exists.
- Retarget two v2-to-v3 CollectionView links to their current headings.
- Repair a same-page serialization link that omitted its anchor marker.

## Why

The current generated-site check does not cover every source reference page, so these links can remain broken for readers using the repository documentation directly. This is the first conflict-free baseline repair toward #147's complete internal-link verification.

## Scope

- Affects only `docs/marionette.view.md`, `docs/upgrade-v2-v3.md`, and `docs/view.rendering.md`.
- Does not change runtime source, tests, distribution artifacts, package metadata, dependencies, workflows, performance contracts, repository rules, or website publication.
- Does not address source-link repairs that overlap #224 or the just-merged DOM ownership files.

## Deployment Impact

No website, npm package, tag, or release is published by this PR. No consumer redeploy is required.

## Testing

- Targeted source-link scan for the three repaired anchors and one removed stale TOC entry.
- `npm run docs:check`: 34 HTML files, 320 internal links.
- `npm run lint:ci`
- `npm run check:dist`
- `npm run size`: 51.88 kB / 51.98 kB.
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs broken internal links in three reference docs files so readers using the repository docs directly no longer hit dead anchors, continuing the internal-link verification in #147.

- Removes a stale table-of-contents entry in `docs/marionette.view.md` for a heading that no longer exists.
- Retargets two v2-to-v3 `CollectionView` links in `docs/upgrade-v2-v3.md` to their current headings.
- Fixes a same-page serialization link in `docs/view.rendering.md` that was missing its `#` anchor marker.
- Docs-only change; no runtime, tests, or distribution artifacts are affected.

<sup>Written for commit 93a936867859a1b397202f0990b0e0d5afd88a14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

