### PR TITLE
docs(collectionview): repair source links

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -39,7 +39,7 @@ A `CollectionView` can have [`Behavior`s](./marionette.behavior.md).
   * [Passing Data to the `emptyView`](#passing-data-to-the-emptyview)
   * [Defining When an `emptyView` shows](#defining-when-an-emptyview-shows)
 * [Accessing a Child View](#accessing-a-child-view)
-  * [CollectionView `children` Iterators And Collection Functions](collectionview-children-iterators-and-collection-functions)
+  * [CollectionView `children` Iterators And Collection Functions](#collectionview-children-iterators-and-collection-functions)
 * [Listening to Events on the `children`](#listening-to-events-on-the-children)
 * [Self Managed `children`](#self-managed-children)
   * [Adding a Child View](#adding-a-child-view)
@@ -285,7 +285,7 @@ CollectionView.extend({
 
 The first parameter is the HTML buffer, and the second parameter
 is the expected container for the children which by default equates
-to the view's `el` unless a [`childViewContainer`](#defining-the-childViewContainer)
+to the view's `el` unless a [`childViewContainer`](#defining-the-childviewcontainer)
 is set.
 
 ### Destroying All `children`
@@ -511,7 +511,7 @@ This region can be useful for handling the
 
 ### Passing Data to the `emptyView`
 
-Similar to [`childView`](#collectionviews-childview) and [`childViewOptions`](#padding-data-to-the-childview),
+Similar to [`childView`](#collectionviews-childview) and [`childViewOptions`](#passing-data-to-the-childview),
 there is an `emptyViewOptions` property that will be passed to the `emptyView` constructor.
 It can be provided as an object literal or as a function.
 


### PR DESCRIPTION
Related #147

## What

- Restore the missing same-page marker on the CollectionView child-iterator link.
- Correct the `childViewContainer` heading target to its lowercase generated anchor.
- Correct the `padding-data` typo in the `childViewOptions` heading target.

## Why

These three links look plausible in source but resolve to nonexistent paths or anchors. Repairing them advances #147's source-reference baseline before the complete source-level link validator is enabled.

## Scope

- Affects only `docs/marionette.collectionview.md`.
- Does not change runtime source, tests, distribution artifacts, package metadata, dependencies, workflows, performance contracts, repository rules, or website publication.

## Deployment Impact

No website, npm package, tag, or release is published by this PR. No consumer redeploy is required.

## Testing

- Targeted verification of all three source links and destination headings.
- `npm run docs:check`: 34 HTML files, 320 internal links.
- `npm run lint:ci`
- `npm run check:dist`
- `npm run size`: 51.88 kB / 51.98 kB.
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three broken internal links in `docs/marionette.collectionview.md`: restores the missing same-page marker on the `children` iterators link and corrects the `childViewContainer` and `childViewOptions` anchor targets. This advances issue #147's source-reference baseline before the source-level link validator is enabled.

<sup>Written for commit f6a067b9b350f8d554c3d7d333af0c7d7ba438e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

