### PR TITLE
docs(reference): repair package and source links

### DIFF
--- a/docs/common.md
+++ b/docs/common.md
@@ -49,7 +49,7 @@ The [Backbone.Events API](http://backbonejs.org/#Events) is available to all cla
 Each Marionette class can both `listenTo` any object with this API and have events
 triggered on the instance.
 
-**Note** The events API should not be confused with [view `events`](/.dom.interactions.md#view-events)
+**Note** The events API should not be confused with [view `events`](./dom.interactions.md#view-events)
 which capture DOM events.
 
 ### `triggerMethod`

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -21,7 +21,7 @@ use Backbone.View or Backbone.Model or another Backbone object to grab the
 method from.
 
 ```javascript
-import { extend } from 'backbone.marionette';
+import { extend } from 'marionette';
 
 const Foo = function(){};
 
@@ -51,7 +51,7 @@ in [common utilities](./common.md) except that the target of the method is added
 
 For instance:
 ```javascript
-import { View, triggerMethod, getOption } from 'backbone.marionette';
+import { View, triggerMethod, getOption } from 'marionette';
 
 const MyView = View.extend({
   initialize() {


### PR DESCRIPTION
Related #147

## What

- Repair the malformed relative link from the common Events API note to the current DOM-interactions reference.
- Update both `docs/utils.md` examples to import the documented utilities from the published `marionette` root package.

## Why

The current-reference documentation still contains one path that source-level validation cannot resolve and two examples that use the obsolete v4 package name. This bounded slice keeps the examples aligned with the v5 package contract while the remaining source-link repairs wait for the lifecycle PR files they overlap.

## Scope

- Documentation only: `docs/common.md` and `docs/utils.md`.
- No runtime, distribution, package map, lockfile, workflow, migration, or website-publication behavior changes.
- This completes the `docs/utils.md` package-name correction, not the repository-wide obsolete-language sweep.

## Deployment Impact

No application redeploy or package publication is required. The public documentation website remains unpublished until the post-v5 publication phase.

## Testing

- `npm run docs:check`
- `npm run lint:ci`
- `git diff --check`
- Verified `docs/utils.md` contains no remaining `backbone.marionette` references.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the malformed relative link in the Events API note so the view events reference resolves correctly, and updates `docs/utils.md` examples to import utilities from the published `marionette` root package instead of the obsolete `backbone.marionette`.

This is documentation-only; no runtime, package, or publication behavior changes.

<sup>Written for commit 9974635c55d7af3d73765908f9e34595e2b57329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

