### PR TITLE
docs(reference): update entity event package imports

### DIFF
--- a/docs/events.entity.md
+++ b/docs/events.entity.md
@@ -11,7 +11,7 @@ and called with the context of the view instance.
 For example, to listen to a model's events:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   modelEvents: {
@@ -37,7 +37,7 @@ The `modelEvents` attribute can also take a
 You can also bind a function callback directly in the `modelEvents` attribute:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   modelEvents: {
@@ -56,7 +56,7 @@ Collection events work exactly the same way as [`modelEvents`](#model-events)
 with their own `collectionEvents` key:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   collectionEvents: {
@@ -78,7 +78,7 @@ Just as in `modelEvents`, you can bind function callbacks directly inside the
 `collectionEvents` object:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   collectionEvents: {
@@ -97,7 +97,7 @@ If your view has a `model` and `collection` attached, it will listen for events
 on both:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
 


### PR DESCRIPTION
Related #147

## What

- Update all five `docs/events.entity.md` examples to import `View` from the published `marionette` root package.

## Why

The entity-event examples still use the obsolete v4 package name even though v5 publishes `View` from `marionette`. Keeping canonical examples importable is part of the final reference-documentation evidence.

## Scope

- Documentation only: `docs/events.entity.md`.
- No entity-event behavior, runtime, distribution, package map, lockfile, workflow, migration, or website-publication changes.
- This completes the package-name correction for this reference page, not the repository-wide obsolete-language sweep.

## Deployment Impact

No application redeploy or package publication is required. The public documentation website remains unpublished until the post-v5 publication phase.

## Testing

- `npm run docs:check`
- `npm run lint:ci`
- `git diff --check origin/master...HEAD`
- Verified `docs/events.entity.md` contains no remaining `backbone.marionette` references.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `docs/events.entity.md` to import `View` from the published `marionette` package instead of the obsolete `backbone.marionette` in all five examples. This makes the reference examples importable under v5 and completes the package-name correction for this page. No runtime or build changes are included.

<sup>Written for commit b8f479bbc06bf495d00be7fe2fcc206ef3ec1add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

