### PR TITLE
docs(view): align reference with v5 contracts

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -2,8 +2,8 @@
 
 A `View` is used for managing portions of the DOM via a single parent DOM element or `el`.
 It provides a consistent interface for managing the content of the `el` which is typically
-administered by serializing a `Backbone.Model` or `Backbone.Collection` and rendering
-a template with the serialized data into the `View`s `el`.
+administered by serializing attached model or collection data and rendering a template
+with that data into the `View`'s `el`.
 
 The `View` provides event delegation for capturing and handling DOM interactions as well as
 the ability to separate concerns into smaller, managed child views.
@@ -48,13 +48,12 @@ that will be attached directly to the instance:
 `tagName`, `template`, `templateContext`, `triggers`, `ui`
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const myView = new View({ ... });
 ```
 
-Some of these properties come from Marionette, but many are inherited from
-[`Backbone.View`](http://backbonejs.org/#View-constructor).
+These properties are defined by Marionette's standalone `View` constructor.
 
 ## Rendering a View
 
@@ -63,8 +62,8 @@ The Marionette View implements a powerful render method which, given a
 HTML from that template, mixing in `model` or `collection` data and any
 extra [template context](./view.rendering.md#adding-context-data).
 
-Unlike `Backbone.View` Marionette defines `render` and this method should
-not be overridden. To add functionality to the render use the
+Marionette `View` defines `render`, and this method should not be overridden.
+To add functionality around rendering, use the
 [`render` and `before:render` events](./events.class.md#render-and-beforerender-events).
 
 [Live example](https://jsfiddle.net/marionettejs/dhsjcka4/)
@@ -99,8 +98,7 @@ Read More:
 
 ## DOM Interactions
 
-In addition to what Backbone provides the views, Marionette has additional API
-for DOM interactions: `events`, `triggers`, and `ui`.
+`View` provides `events`, `triggers`, and `ui` for DOM interactions.
 
 Read More:
 - [DOM Interactions](./dom.interactions.md)
@@ -124,7 +122,7 @@ We will cover this here but for more advanced information, see the
 
 ### Laying Out Views - Regions
 
-The `Marionette.View` class lets us manage a hierarchy of views using `regions`.
+The `View` class lets us manage a hierarchy of views using `regions`.
 Regions are a hook point that lets us show views inside views, manage the
 show/hide lifecycles, and act on events inside the children.
 
@@ -144,7 +142,7 @@ where the new view will be displayed:
 
 ```javascript
 import _ from 'underscore';
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   template: _.template(`
@@ -163,8 +161,7 @@ const MyView = View.extend({
 
 When we show views in the region, the contents of `#first-region` and
 `#second-region` will be replaced with the contents of the view we show. The
-value in the `regions` hash is just a jQuery selector, and any valid jQuery
-syntax will suffice.
+string values in this example are CSS selectors scoped to the `View`'s `el`.
 
 ### Showing a Child View
 
@@ -261,7 +258,7 @@ paint: just render all of the children in the `onRender` callback for the
 [`render` event](./events.class.md#render-and-beforerender-events).
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const ParentView = View.extend({
   // ...


### PR DESCRIPTION
Related #147

## What

- Update the View reference examples to import from the published `marionette` root package.
- Describe View construction, rendering, DOM interaction, and Region selectors using the v5 standalone/native contracts.
- Remove obsolete claims that the core View inherits Backbone.View behavior or requires jQuery selector syntax.

## Why

The canonical View page still mixed v4 package and dependency assumptions into otherwise current v5 guidance. Agent-authored code needs the reference to state the framework-owned contract directly so examples do not reintroduce Backbone or jQuery coupling accidentally.

## Scope

- Documentation only: `docs/marionette.view.md`.
- No View runtime, serialization, DOM API, package, lockfile, workflow, migration, or website-publication changes.
- The retained backbone-events reference describes the supported event protocol, not a core dependency.

## Deployment Impact

No application redeploy or package publication is required. The public documentation website remains unpublished until the post-v5 publication phase.

## Testing

- `npm run docs:check`
- `npm run lint:ci`
- `git diff --check origin/master...HEAD`
- Verified all 40 unique links in `docs/marionette.view.md` resolve against current headings and repository targets.
- Verified the removed Backbone/jQuery/package claims against current View source, package exports, optional-peer contracts, and native DOM behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the View reference docs with v5 contracts by updating imports and removing Backbone and jQuery references.

- Replace `backbone.marionette` imports with `marionette` in examples.
- Remove claims that View inherits from `Backbone.View` and that region selectors use jQuery syntax.
- Clarify that View properties and `render` are defined by Marionette's standalone `View`.
- Documentation-only changes; no runtime, package, or deployment impact.

<sup>Written for commit 0ef05076c4792cfc5c777945c61c2518aa0acc2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

