### PR TITLE
test(collection): characterize child helper semantics

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -640,6 +640,16 @@ collection functions, including:
 These methods can be called directly on the container, to iterate and process
 the views held by the container.
 
+`pluck(key)` reads `key` directly from each child View. For example,
+`children.pluck('model')` returns the child Views' model objects, and a child
+without a model contributes `undefined`. It does not read model attributes; use
+an explicit callback such as `children.map(view => view.model?.get('status'))`
+for those values. An empty container returns `[]`.
+
+`contains(value)` checks for the exact child View instance. A child View's model
+or another object with the same properties is not considered contained. An empty
+container returns `false`.
+
 ```javascript
 import Backbone from 'backbone';
 import { CollectionView } from 'backbone.marionette';

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -22,6 +22,50 @@ describe('#ChildViewContainer', function() {
     });
   });
 
+  describe('view property collection helpers', function() {
+    let container;
+    let model;
+    let view;
+
+    beforeEach(function() {
+      model = new Backbone.Model({ status: 'model status' });
+      view = new Backbone.View({ model });
+      view.status = 'view status';
+
+      container = new ChildViewContainer();
+      container._set([view, new Backbone.View()], true);
+    });
+
+    describe('#pluck', function() {
+      it('reads properties directly from child views', function() {
+        const [viewModel, missingModel] = container.pluck('model');
+
+        expect(viewModel).to.equal(model);
+        expect(missingModel).to.be.undefined;
+      });
+
+      it('does not read model attributes', function() {
+        expect(container.pluck('status')).to.deep.equal(['view status', undefined]);
+      });
+
+      it('returns an empty array for an empty container', function() {
+        expect(new ChildViewContainer().pluck('model')).to.deep.equal([]);
+      });
+    });
+
+    describe('#contains', function() {
+      it('matches the exact child view instance', function() {
+        expect(container.contains(view)).to.be.true;
+        expect(container.contains(model)).to.be.false;
+        expect(container.contains({ cid: view.cid })).to.be.false;
+      });
+
+      it('returns false for an empty container', function() {
+        expect(new ChildViewContainer().contains(view)).to.be.false;
+      });
+    });
+  });
+
   describe('#_init', function() {
     let container;
 


### PR DESCRIPTION
Related #241

## What
- Characterize `children.pluck(key)` as direct child-View property access, including exact model identity, no-model children, model-attribute separation, and empty containers.
- Characterize `children.contains(value)` as child-View identity, including model/lookalike rejection and empty containers.
- Document those explicit contracts in the current CollectionView reference.

## Why
Underscore removal must preserve useful Marionette ergonomics without retaining ambiguous View-versus-model semantics. This pins two already-adopted public behaviors before the proxy is replaced.

## Scope
- ChildViewContainer unit tests and CollectionView documentation only.
- No runtime source, aliases, iterator, package metadata, performance configuration, generated artifacts, workflows, GitHub settings, website, or publication behavior changed.
- The remaining documented container methods and the runtime Underscore replacement stay in later #241 slices.

## Deployment Impact
No deployment or redeploy is required.

## Testing
- `npm ci`
- `npm test -- test/unit/child-view-container.spec.js --reporter=dot` — 40 tests
- `npm run coverage` — 70 files, 1,227 tests, 100% statements/branches/functions/lines; 19 agent benchmark contract tests
- `npm run docs:check`
- `npm run lint:ci`
- `npm run size`
- `git diff --check`

The production bundle remains 51,878 Brotli-11 bytes against the 51,975-byte ceiling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the existing contracts for `children.pluck()` and `children.contains()` with tests and documentation ahead of the Underscore proxy replacement in #241.

- `pluck(key)` reads properties directly from child Views and ignores model attributes; empty containers return `[]`.
- `contains(value)` matches only the exact child View instance, rejecting model objects and lookalikes.
- No runtime code changes; only the child-view container spec and `CollectionView` docs are touched.

<sup>Written for commit dbcfd9837a175861030e154d4c478bc38f5cdeca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

