### PR TITLE
test(collection): characterize boundary helpers

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -650,6 +650,20 @@ for those values. An empty container returns `[]`.
 or another object with the same properties is not considered contained. An empty
 container returns `false`.
 
+`toArray()` returns a new array containing the current child Views in container
+order. Changing the returned array's membership or order does not change the
+container. An empty container returns `[]`.
+
+Without a count, `first()` and `last()` return the first or last child View. With
+a nonnegative integer count, they return a new ordered array containing up to
+that many Views from the corresponding end of the container. A count of `0`
+returns `[]`. For an empty container, the no-count forms return `undefined` and
+the count forms return `[]`.
+
+`children.isEmpty()` reports whether the child container currently has zero
+Views. It is distinct from the overridable `CollectionView#isEmpty()` method,
+which controls whether a CollectionView renders its `emptyView`.
+
 ```javascript
 import Backbone from 'backbone';
 import { CollectionView } from 'backbone.marionette';

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -66,6 +66,104 @@ describe('#ChildViewContainer', function() {
     });
   });
 
+  describe('ordered collection helpers', function() {
+    let container;
+    let views;
+
+    beforeEach(function() {
+      views = [
+        new Backbone.View(),
+        new Backbone.View(),
+        new Backbone.View()
+      ];
+
+      container = new ChildViewContainer();
+      container._set(views, true);
+    });
+
+    describe('#toArray', function() {
+      it('returns a new ordered array of the child views', function() {
+        const snapshot = container.toArray();
+
+        expect(container.toArray()).to.not.equal(snapshot);
+        expect(snapshot[0]).to.equal(views[0]);
+        expect(snapshot[1]).to.equal(views[1]);
+        expect(snapshot[2]).to.equal(views[2]);
+
+        snapshot.pop();
+
+        expect(container).to.have.lengthOf(3);
+        expect(container.toArray()).to.deep.equal(views);
+      });
+
+      it('returns an empty array for an empty container', function() {
+        expect(new ChildViewContainer().toArray()).to.deep.equal([]);
+      });
+    });
+
+    describe('#first', function() {
+      it('returns the first child view', function() {
+        expect(container.first()).to.equal(views[0]);
+      });
+
+      it('returns a new ordered array when given a count', function() {
+        const firstViews = container.first(2);
+        const allViews = container.first(5);
+
+        expect(firstViews).to.have.lengthOf(2);
+        expect(firstViews[0]).to.equal(views[0]);
+        expect(firstViews[1]).to.equal(views[1]);
+        expect(container.first(2)).to.not.equal(firstViews);
+        expect(allViews).to.have.lengthOf(3);
+        expect(allViews[2]).to.equal(views[2]);
+        expect(container.first(0)).to.deep.equal([]);
+      });
+
+      it('returns the empty-container values', function() {
+        const emptyContainer = new ChildViewContainer();
+
+        expect(emptyContainer.first()).to.be.undefined;
+        expect(emptyContainer.first(2)).to.deep.equal([]);
+      });
+    });
+
+    describe('#last', function() {
+      it('returns the last child view', function() {
+        expect(container.last()).to.equal(views[2]);
+      });
+
+      it('returns a new ordered array when given a count', function() {
+        const lastViews = container.last(2);
+        const allViews = container.last(5);
+
+        expect(lastViews).to.have.lengthOf(2);
+        expect(lastViews[0]).to.equal(views[1]);
+        expect(lastViews[1]).to.equal(views[2]);
+        expect(container.last(2)).to.not.equal(lastViews);
+        expect(allViews).to.have.lengthOf(3);
+        expect(allViews[0]).to.equal(views[0]);
+        expect(container.last(0)).to.deep.equal([]);
+      });
+
+      it('returns the empty-container values', function() {
+        const emptyContainer = new ChildViewContainer();
+
+        expect(emptyContainer.last()).to.be.undefined;
+        expect(emptyContainer.last(2)).to.deep.equal([]);
+      });
+    });
+
+    describe('#isEmpty', function() {
+      it('reports whether the container has child views without mutating it', function() {
+        expect(container.isEmpty()).to.be.false;
+        expect(container).to.have.lengthOf(3);
+        expect(container.first()).to.equal(views[0]);
+        expect(container.last()).to.equal(views[2]);
+        expect(new ChildViewContainer().isEmpty()).to.be.true;
+      });
+    });
+  });
+
   describe('#_init', function() {
     let container;
 


### PR DESCRIPTION
Related #241

## What

- Characterize ChildViewContainer.toArray, first, last, and isEmpty.
- Pin child View order and identity, fresh-array behavior, count forms, and empty-container results.
- Document these contracts separately from CollectionView.isEmpty.

## Why

Issue #241 removes the required Underscore runtime dependency while retaining useful collection ergonomics. These tests make the current non-callback boundary-helper behavior executable before the proxy is replaced.

## Scope

This changes only ChildViewContainer unit tests and CollectionView reference documentation. It does not change runtime source, aliases, package metadata, performance configuration, distribution artifacts, or the remaining Underscore-backed helpers.

## Deployment Impact

No redeploy or package publication is needed. This is test and documentation coverage only.

## Testing

- npm test -- test/unit/child-view-container.spec.js --reporter=dot — 49 passed
- npm run coverage — 70 files, 1,236 tests, 100% statements/branches/functions/lines; 19 agent benchmark contract tests passed
- npm run docs:check — 34 HTML files and 320 internal links validated
- npm run lint:ci
- npm run size — 51,878 Brotli-11 bytes, unchanged
- npm run check:dist
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins down the current `ChildViewContainer` boundary helper behavior with tests and docs before the Underscore-backed helpers are replaced in #241. This is test and documentation coverage only; runtime source, package metadata, and distribution artifacts are unchanged.

**Tests**
- Characterizes `toArray`, `first`, `last`, and `isEmpty` on `ChildViewContainer`.
- Verifies child view order, identity, fresh-array returns, count forms, and empty-container results.

**Docs**
- Documents the boundary helper contracts in `docs/marionette.collectionview.md`.
- Clarifies that `children.isEmpty()` is distinct from the overridable `CollectionView#isEmpty()`.

<sup>Written for commit 26675166721cb225e22eba0929968c07ca17f7e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

