### PR TITLE
fix(performance): allow profile digest transitions

### DIFF
--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -313,6 +313,30 @@ function exactObjectFields(value, fields) {
     isDeepStrictEqual(Object.keys(value).sort(), [...fields].sort());
 }
 
+function validReleaseProfileTransition(authorityToolchain, candidateToolchain) {
+  const authorityProfile = authorityToolchain?.releaseProfile;
+  const candidateProfile = candidateToolchain?.releaseProfile;
+  if (!authorityToolchain || typeof authorityToolchain !== 'object' ||
+      Array.isArray(authorityToolchain) || !candidateToolchain ||
+      typeof candidateToolchain !== 'object' || Array.isArray(candidateToolchain) ||
+      !authorityProfile || typeof authorityProfile !== 'object' ||
+      Array.isArray(authorityProfile) || !candidateProfile ||
+      typeof candidateProfile !== 'object' || Array.isArray(candidateProfile) ||
+      typeof candidateProfile.sha256 !== 'string' ||
+      !/^[a-f\d]{64}$/.test(candidateProfile.sha256)) {
+    return false;
+  }
+
+  const expectedToolchain = {
+    ...authorityToolchain,
+    releaseProfile: {
+      ...authorityProfile,
+      sha256: candidateProfile.sha256,
+    },
+  };
+  return isDeepStrictEqual(candidateToolchain, expectedToolchain);
+}
+
 export function validateCandidateGrowthContract(authority, candidate, { budgetAmendment } = {}) {
   const violations = [];
   if (!authority || typeof authority !== 'object' || !candidate || typeof candidate !== 'object') {
@@ -325,6 +349,12 @@ export function validateCandidateGrowthContract(authority, candidate, { budgetAm
   }
   for (const key of authorityKeys) {
     if (key === 'runtimeArtifacts' || key === 'productionGraphs') {
+      continue;
+    }
+    if (key === 'toolchain') {
+      if (!validReleaseProfileTransition(authority.toolchain, candidate.toolchain)) {
+        violations.push('Candidate performance contract changes exact-base toolchain beyond releaseProfile.sha256');
+      }
       continue;
     }
     if (key === 'baseline' && budgetAmendment?.status === 'accepted' &&

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -252,13 +252,15 @@ approved path list must exactly match all existing artifacts above the strict
 greater-than-one-percent threshold. New subpaths and new artifact path/size pairs must
 exactly match the additive candidate contract and measured report. A candidate may
 only add runtime artifact and production graph entries: it cannot change the base
-thresholds, allowlist, baseline, ceiling, toolchain, forbidden modules, resource
-contract, timing contract, or any existing artifact or graph. New artifact Phase 0
-baselines remain zero, so their full size counts against the original absolute ceiling;
-after adoption, the exact merged artifact becomes the comparison base for later pull
-requests. Unmeasured graphs, forbidden modules, removed or renamed base entries,
-non-integer sizes, report-contract drift, and cumulative growth above the ceiling fail
-closed.
+thresholds, allowlist, baseline, ceiling, forbidden modules, resource contract, timing
+contract, or any existing artifact or graph. The only permitted toolchain transition is
+a valid SHA-256 revision at `toolchain.releaseProfile.sha256`; every other toolchain
+field remains exact-base, and the candidate report must prove that digest matches the
+actual candidate release-profile file. New artifact Phase 0 baselines remain zero, so
+their full size counts against the original absolute ceiling; after adoption, the exact
+merged artifact becomes the comparison base for later pull requests. Unmeasured graphs,
+forbidden modules, removed or renamed base entries, non-integer sizes, report-contract
+drift, and cumulative growth above the ceiling fail closed.
 
 Evidence is limited to durable issue-comment
 permalinks in this repository; Actions artifacts and external mutable pages cannot

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -900,6 +900,14 @@ describe('performance contract validation', () => {
     const contract = JSON.parse(await readFile(new URL('../../config/performance.json', import.meta.url)));
 
     assert.deepEqual(await validateToolchain(contract, root), []);
+
+    const mismatchedProfile = structuredClone(contract);
+    mismatchedProfile.toolchain.releaseProfile.sha256 = '0'.repeat(64);
+    assert.match(
+      (await validateToolchain(mismatchedProfile, root)).join('\n'),
+      /Release profile SHA-256 [a-f\d]{64} does not match 0{64}/
+    );
+
     assert.ok(
       contract.forbiddenProductionModules.includes('config/performance-resources.mjs')
     );

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -57,6 +57,29 @@ function growthContract() {
       totalBrotliBytes: 100,
       absoluteCeilingBytes: 105,
     },
+    toolchain: {
+      releaseProfile: {
+        path: 'config/release-profile.json',
+        sha256: 'a'.repeat(64),
+        node: '24.19.0',
+        npm: '11.17.0',
+        lockfileVersion: 3,
+        canonicalHost: {
+          id: 'linux-x64',
+          runner: 'ubuntu-24.04',
+          platform: 'linux',
+          architecture: 'x64',
+        },
+      },
+      lockedDependencies: {
+        backbone: '1.4.0',
+        rollup: '4.63.0',
+      },
+      commands: {
+        deterministic: ['npm run size'],
+        hostedTiming: ['npm run performance:timing'],
+      },
+    },
     thresholds: {
       cumulativeGrowthPercent: 5,
       pullRequestApprovalPercent: 1,
@@ -442,9 +465,91 @@ describe('exact-head performance growth approval contract', () => {
     );
   });
 
+  test('permits only a valid release-profile SHA-256 transition in the toolchain', () => {
+    const authorityContract = growthContract();
+    const candidateContract = growthContract();
+    candidateContract.toolchain.releaseProfile.sha256 = 'b'.repeat(64);
+
+    assert.deepEqual(
+      validateCandidateGrowthContract(authorityContract, candidateContract),
+      []
+    );
+
+    const mutations = [
+      ['an invalid digest', contract => {
+        contract.toolchain.releaseProfile.sha256 = 'B'.repeat(64);
+      }],
+      ['a missing digest', contract => {
+        delete contract.toolchain.releaseProfile.sha256;
+      }],
+      ['a short digest', contract => {
+        contract.toolchain.releaseProfile.sha256 = 'b'.repeat(63);
+      }],
+      ['a non-string digest', contract => {
+        contract.toolchain.releaseProfile.sha256 = 1;
+      }],
+      ['another release-profile field', contract => {
+        contract.toolchain.releaseProfile.node = '26.0.0';
+      }],
+      ['a locked dependency', contract => {
+        contract.toolchain.lockedDependencies.rollup = '5.0.0';
+      }],
+      ['a command', contract => {
+        contract.toolchain.commands.deterministic.push('npm run unsafe');
+      }],
+      ['a new toolchain field', contract => {
+        contract.toolchain.untrusted = true;
+      }],
+      ['a removed release-profile field', contract => {
+        delete contract.toolchain.releaseProfile.path;
+      }],
+    ];
+
+    for (const [label, mutate] of mutations) {
+      const changedContract = growthContract();
+      mutate(changedContract);
+      assert.match(
+        validateCandidateGrowthContract(authorityContract, changedContract).join('\n'),
+        /changes exact-base toolchain/,
+        label
+      );
+    }
+  });
+
+  test('requires the candidate report to prove the release-profile digest', () => {
+    const candidateContract = growthContract();
+    candidateContract.toolchain.releaseProfile.sha256 = 'b'.repeat(64);
+
+    assert.deepEqual(requiredNewProductionApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract,
+      currentReport: productionReport(),
+    }), {
+      artifacts: [],
+      enforced: true,
+      subpaths: [],
+    });
+
+    const mismatchedReport = productionReport();
+    mismatchedReport.violations = [
+      `Release profile SHA-256 ${'a'.repeat(64)} does not match ${'b'.repeat(64)}`,
+    ];
+    assert.throws(
+      () => requiredNewProductionApproval({
+        authorityContract: growthContract(),
+        baseReport: productionReport(),
+        candidateContract,
+        currentReport: mismatchedReport,
+      }),
+      /Pull request report has contract violations: Release profile SHA-256/
+    );
+  });
+
   test('requires an independent exact-head approval when consuming a base-owned budget', () => {
     const candidateContract = growthContract();
     candidateContract.baseline.absoluteCeilingBytes = 110;
+    candidateContract.toolchain.releaseProfile.sha256 = 'b'.repeat(64);
     const currentReport = productionReport();
     currentReport.artifacts[0].size = 106;
     currentReport.cumulative.size = 106;


### PR DESCRIPTION
Closes #246
Related #127
Related #238

## What

- Permit a candidate performance contract to change only toolchain.releaseProfile.sha256 when the new value is a valid lowercase SHA-256.
- Keep every other toolchain field bound to the exact base through a full deep comparison.
- Test both halves of the trust boundary: candidate-contract validation and the exact-base measurer hashing the actual release-profile file.

## Why

The candidate measurement path can validate an intentional release-profile update, but the exact-base growth evaluator rejected every toolchain difference. That left PR #243 logically blocked even after the deferred ruleset workflow-pin refresh. This narrow transition preserves exact-base authority while allowing the profile digest to advance with its file.

## Scope

This changes performance-governance tooling, its tests, and the performance contract documentation. It does not change the release profile, active performance budget, workflows, GitHub rules, runtime source, distribution output, or package metadata.

## Deployment Impact

No redeploy, package publication, tag, or release is needed. The change affects only repository validation.

## Testing

- npm run test:performance — 91 passed
- npm run coverage — 70 files, 1,236 tests, 100% statements/branches/functions/lines; 19 agent benchmark contract tests passed
- npm run docs:check — 34 HTML files and 320 internal links validated
- npm run lint:ci
- npm run check:dist
- npm run size — 51,878 Brotli-11 bytes, unchanged
- git diff HEAD^ --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Permits candidate performance contracts to update only `toolchain.releaseProfile.sha256` to a valid lowercase SHA-256 while keeping every other toolchain field bound to the exact base, so intentional release-profile digest updates no longer fail the growth evaluator. The candidate report must still prove the new digest matches the actual release-profile file.

<sup>Written for commit c7e69ca28ce2ca69c4be07ffb375ff9d307855af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

