### PR TITLE
test(collection): characterize slice helpers

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -660,6 +660,18 @@ that many Views from the corresponding end of the container. A count of `0`
 returns `[]`. For an empty container, the no-count forms return `undefined` and
 the count forms return `[]`.
 
+`initial(count = 1)` and `rest(count = 1)` return new ordered arrays after
+excluding `count` Views from the end or start of the container, respectively.
+The count is a nonnegative integer: `0` returns a new array of every child View,
+and a count greater than or equal to the container length returns `[]`. An empty
+container also returns `[]`.
+
+`without(...views)` returns a new ordered array excluding the exact child View
+instances supplied. Models and lookalike objects do not exclude their associated
+Views. With no arguments it returns a new array of every child View. Changing the
+returned array's membership or order does not change the container. An empty
+container returns `[]`.
+
 `children.isEmpty()` reports whether the child container currently has zero
 Views. It is distinct from the overridable `CollectionView#isEmpty()` method,
 which controls whether a CollectionView renders its `emptyView`.

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -127,6 +127,80 @@ describe('#ChildViewContainer', function() {
       });
     });
 
+    describe('#initial', function() {
+      it('returns a new ordered array without the last child view by default', function() {
+        const initialViews = container.initial();
+
+        expect(initialViews).to.have.lengthOf(2);
+        expect(initialViews[0]).to.equal(views[0]);
+        expect(initialViews[1]).to.equal(views[1]);
+        expect(container.initial()).to.not.equal(initialViews);
+      });
+
+      it('excludes a nonnegative integer count from the end', function() {
+        const oneView = container.initial(2);
+        const allViews = container.initial(0);
+
+        expect(oneView).to.have.lengthOf(1);
+        expect(oneView[0]).to.equal(views[0]);
+        expect(allViews).to.have.lengthOf(3);
+        expect(allViews[0]).to.equal(views[0]);
+        expect(allViews[1]).to.equal(views[1]);
+        expect(allViews[2]).to.equal(views[2]);
+        allViews.pop();
+        expect(container).to.have.lengthOf(3);
+        expect(container.first()).to.equal(views[0]);
+        expect(container.findByIndex(1)).to.equal(views[1]);
+        expect(container.last()).to.equal(views[2]);
+        expect(container.initial(3)).to.deep.equal([]);
+        expect(container.initial(5)).to.deep.equal([]);
+      });
+
+      it('returns an empty array for an empty container', function() {
+        const emptyContainer = new ChildViewContainer();
+
+        expect(emptyContainer.initial()).to.deep.equal([]);
+        expect(emptyContainer.initial(2)).to.deep.equal([]);
+      });
+    });
+
+    describe('#rest', function() {
+      it('returns a new ordered array without the first child view by default', function() {
+        const remainingViews = container.rest();
+
+        expect(remainingViews).to.have.lengthOf(2);
+        expect(remainingViews[0]).to.equal(views[1]);
+        expect(remainingViews[1]).to.equal(views[2]);
+        expect(container.rest()).to.not.equal(remainingViews);
+      });
+
+      it('excludes a nonnegative integer count from the start', function() {
+        const oneView = container.rest(2);
+        const allViews = container.rest(0);
+
+        expect(oneView).to.have.lengthOf(1);
+        expect(oneView[0]).to.equal(views[2]);
+        expect(allViews).to.have.lengthOf(3);
+        expect(allViews[0]).to.equal(views[0]);
+        expect(allViews[1]).to.equal(views[1]);
+        expect(allViews[2]).to.equal(views[2]);
+        allViews.shift();
+        expect(container).to.have.lengthOf(3);
+        expect(container.first()).to.equal(views[0]);
+        expect(container.findByIndex(1)).to.equal(views[1]);
+        expect(container.last()).to.equal(views[2]);
+        expect(container.rest(3)).to.deep.equal([]);
+        expect(container.rest(5)).to.deep.equal([]);
+      });
+
+      it('returns an empty array for an empty container', function() {
+        const emptyContainer = new ChildViewContainer();
+
+        expect(emptyContainer.rest()).to.deep.equal([]);
+        expect(emptyContainer.rest(2)).to.deep.equal([]);
+      });
+    });
+
     describe('#last', function() {
       it('returns the last child view', function() {
         expect(container.last()).to.equal(views[2]);
@@ -150,6 +224,53 @@ describe('#ChildViewContainer', function() {
 
         expect(emptyContainer.last()).to.be.undefined;
         expect(emptyContainer.last(2)).to.deep.equal([]);
+      });
+    });
+
+    describe('#without', function() {
+      it('returns a new ordered array without the exact child views', function() {
+        const remainingViews = container.without(views[1]);
+        const middleView = container.without(views[0], views[2]);
+
+        expect(remainingViews).to.have.lengthOf(2);
+        expect(remainingViews[0]).to.equal(views[0]);
+        expect(remainingViews[1]).to.equal(views[2]);
+        expect(container.without(views[1])).to.not.equal(remainingViews);
+        expect(middleView).to.have.lengthOf(1);
+        expect(middleView[0]).to.equal(views[1]);
+      });
+
+      it('does not exclude models or lookalikes or mutate the container', function() {
+        const model = new Backbone.Model();
+        views[1].model = model;
+        const remainingViews = container.without(model, { cid: views[1].cid });
+
+        expect(remainingViews).to.have.lengthOf(3);
+        expect(remainingViews[0]).to.equal(views[0]);
+        expect(remainingViews[1]).to.equal(views[1]);
+        expect(remainingViews[2]).to.equal(views[2]);
+        remainingViews.pop();
+
+        expect(container).to.have.lengthOf(3);
+        expect(container.first()).to.equal(views[0]);
+        expect(container.last()).to.equal(views[2]);
+      });
+
+      it('returns a new array of every child view without arguments', function() {
+        const allViews = container.without();
+
+        expect(allViews).to.have.lengthOf(3);
+        expect(allViews[0]).to.equal(views[0]);
+        expect(allViews[1]).to.equal(views[1]);
+        expect(allViews[2]).to.equal(views[2]);
+        expect(container.without()).to.not.equal(allViews);
+      });
+
+      it('returns an empty array for an empty container', function() {
+        const emptyContainer = new ChildViewContainer();
+
+        expect(emptyContainer.without()).to.deep.equal([]);
+        expect(emptyContainer.without(views[0])).to.deep.equal([]);
       });
     });
 


### PR DESCRIPTION
Related #241

## What

- Characterize ChildViewContainer.initial, rest, and without.
- Pin default and count behavior, exact child View identity and order, empty-container results, and fresh-array isolation.
- Document the ordinary v5 contract without adopting Underscore coercion or guard quirks.

## Why

Issue #241 removes the required Underscore runtime dependency while retaining useful collection ergonomics. These tests make the remaining non-callback slice and identity behavior executable before the proxy is replaced.

## Scope

This changes only ChildViewContainer unit tests and CollectionView reference documentation. It does not change runtime source, aliases, package metadata, performance configuration, distribution artifacts, or callback helper semantics.

## Deployment Impact

No redeploy or package publication is needed. This is test and documentation coverage only.

## Testing

- npm test -- test/unit/child-view-container.spec.js --reporter=dot — 59 passed
- npm run coverage — 70 files, 1,246 tests, 100% statements/branches/functions/lines; 19 agent benchmark contract tests passed
- npm run docs:check — 34 HTML files and 320 internal links validated
- npm run lint:ci
- npm run check:dist
- npm run size — 51,878 Brotli-11 bytes, unchanged
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests and reference docs that pin down the contract for `ChildViewContainer`'s `initial`, `rest`, and `without` slice helpers ahead of removing the Underscore runtime dependency (issue #241).

The tests document default and explicit nonnegative count behavior, exact child View identity matching, empty-container results, and fresh-array isolation so callers can't mutate the container through the returned array. The docs describe these helpers in the CollectionView reference without adopting Underscore coercion or guard quirks. No runtime code, aliases, package metadata, or distribution artifacts change.

<sup>Written for commit 006e635eaa2f0cfe92e596b3a2b9d009819f9d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

