### PR TITLE
test(collection): characterize predicate helpers

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -620,11 +620,11 @@ collection functions, including:
 * [each](http://underscorejs.org/#each)
 * [map](http://underscorejs.org/#map)
 * [reduce](http://underscorejs.org/#reduce)
-* [find](http://underscorejs.org/#find)
-* [filter](http://underscorejs.org/#filter)
-* [reject](http://underscorejs.org/#reject)
-* [every](http://underscorejs.org/#every)
-* [some](http://underscorejs.org/#some)
+* `find`
+* `filter`
+* `reject`
+* `every`
+* `some`
 * [contains](http://underscorejs.org/#contains)
 * [invoke](http://underscorejs.org/#invoke)
 * [toArray](http://underscorejs.org/#toArray)
@@ -635,7 +635,7 @@ collection functions, including:
 * [without](http://underscorejs.org/#without)
 * [isEmpty](http://underscorejs.org/#isEmpty)
 * [pluck](http://underscorejs.org/#pluck)
-* [partition](http://underscorejs.org/#partition)
+* `partition`
 
 These methods can be called directly on the container, to iterate and process
 the views held by the container.
@@ -649,6 +649,33 @@ for those values. An empty container returns `[]`.
 `contains(value)` checks for the exact child View instance. A child View's model
 or another object with the same properties is not considered contained. An empty
 container returns `false`.
+
+`find`, `filter`, `reject`, `every`, `some`, and `partition` accept a predicate
+function and an optional `context`. Marionette does not define Underscore-style
+property-name or object-matcher shorthand for these methods. The predicate is
+called with the supported arguments `(view, index)`, with `this` set to `context`
+when one is provided. Additional callback arguments are not public API.
+Structurally adding, removing, or reordering children while a predicate runs is
+unsupported, and these methods do not promise call-start snapshot semantics.
+
+`find(predicate, context)` returns the first child View for which the predicate
+is truthy, preserving View identity, and stops iterating at that match. It
+returns `undefined` when no View matches or the container is empty.
+
+`filter(predicate, context)` and `reject(predicate, context)` visit every child
+View and return new ordered arrays containing the Views for which the predicate
+is truthy or falsey, respectively. Changing a returned array does not change the
+container. An empty container returns `[]` without calling the predicate.
+
+`every(predicate, context)` returns `false` and stops at the first falsey result;
+otherwise it returns `true`. `some(predicate, context)` returns `true` and stops
+at the first truthy result; otherwise it returns `false`. For an empty container,
+`every` returns `true` and `some` returns `false`, without calling the predicate.
+
+`partition(predicate, context)` visits every child View and returns
+`[matchingViews, rejectedViews]`. Both members are new arrays that preserve the
+container order and contain the exact child View instances. An empty container
+returns `[[], []]` without calling the predicate.
 
 `toArray()` returns a new array containing the current child Views in container
 order. Changing the returned array's membership or order does not change the

--- a/test/unit/child-view-container.spec.js
+++ b/test/unit/child-view-container.spec.js
@@ -66,6 +66,240 @@ describe('#ChildViewContainer', function() {
     });
   });
 
+  describe('predicate collection helpers', function() {
+    let container;
+    let views;
+
+    function expectPredicateCall(call, index, context) {
+      expect(call.thisValue).to.equal(context);
+      expect(call.args[0]).to.equal(views[index]);
+      expect(call.args[1]).to.equal(index);
+    }
+
+    beforeEach(function() {
+      views = [
+        new Backbone.View(),
+        new Backbone.View(),
+        new Backbone.View()
+      ];
+
+      views.forEach((view, index) => {
+        view.rank = index + 1;
+      });
+
+      container = new ChildViewContainer();
+      container._set(views, true);
+    });
+
+    describe('#find', function() {
+      it('returns the first matching child view and stops iterating', function() {
+        const context = { minimumRank: 2 };
+        const predicate = this.sinon.spy(function(view) {
+          return view.rank >= this.minimumRank ? view : 0;
+        });
+
+        const foundView = container.find(predicate, context);
+
+        expect(foundView).to.equal(views[1]);
+        expect(predicate).to.have.callCount(2);
+        expectPredicateCall(predicate.getCall(0), 0, context);
+        expectPredicateCall(predicate.getCall(1), 1, context);
+      });
+
+      it('returns undefined after every child view fails the predicate', function() {
+        const predicate = this.sinon.spy(() => false);
+
+        expect(container.find(predicate)).to.be.undefined;
+        expect(predicate).to.have.callCount(3);
+        expectPredicateCall(predicate.getCall(0), 0, undefined);
+        expectPredicateCall(predicate.getCall(1), 1, undefined);
+        expectPredicateCall(predicate.getCall(2), 2, undefined);
+      });
+
+      it('does not call the predicate for an empty container', function() {
+        const predicate = this.sinon.spy();
+
+        expect(new ChildViewContainer().find(predicate)).to.be.undefined;
+        expect(predicate).to.not.have.been.called;
+      });
+    });
+
+    describe('#filter', function() {
+      it('returns matching child views in order after visiting every child', function() {
+        const context = { minimumRank: 2 };
+        const predicate = this.sinon.spy(function(view) {
+          return view.rank >= this.minimumRank ? view : 0;
+        });
+
+        const matchingViews = container.filter(predicate, context);
+
+        expect(matchingViews).to.have.lengthOf(2);
+        expect(matchingViews[0]).to.equal(views[1]);
+        expect(matchingViews[1]).to.equal(views[2]);
+        expect(predicate).to.have.callCount(3);
+        expectPredicateCall(predicate.getCall(0), 0, context);
+        expectPredicateCall(predicate.getCall(1), 1, context);
+        expectPredicateCall(predicate.getCall(2), 2, context);
+
+        matchingViews.pop();
+        expect(container).to.have.lengthOf(3);
+        expect(container.last()).to.equal(views[2]);
+        expect(container.filter(view => view.rank >= 2)).to.not.equal(matchingViews);
+      });
+
+      it('returns an empty array without calling the predicate for an empty container', function() {
+        const predicate = this.sinon.spy();
+        const emptyContainer = new ChildViewContainer();
+        const result = emptyContainer.filter(predicate);
+
+        expect(result).to.deep.equal([]);
+        expect(emptyContainer.filter(predicate)).to.not.equal(result);
+        expect(predicate).to.not.have.been.called;
+      });
+    });
+
+    describe('#reject', function() {
+      it('returns rejected child views in order after visiting every child', function() {
+        const context = { minimumRank: 2 };
+        const predicate = this.sinon.spy(function(view) {
+          return view.rank >= this.minimumRank ? view : 0;
+        });
+
+        const rejectedViews = container.reject(predicate, context);
+
+        expect(rejectedViews).to.have.lengthOf(1);
+        expect(rejectedViews[0]).to.equal(views[0]);
+        expect(predicate).to.have.callCount(3);
+        expectPredicateCall(predicate.getCall(0), 0, context);
+        expectPredicateCall(predicate.getCall(1), 1, context);
+        expectPredicateCall(predicate.getCall(2), 2, context);
+
+        rejectedViews.pop();
+        expect(container).to.have.lengthOf(3);
+        expect(container.first()).to.equal(views[0]);
+        expect(container.reject(view => view.rank >= 2)).to.not.equal(rejectedViews);
+      });
+
+      it('returns an empty array without calling the predicate for an empty container', function() {
+        const predicate = this.sinon.spy();
+        const emptyContainer = new ChildViewContainer();
+        const result = emptyContainer.reject(predicate);
+
+        expect(result).to.deep.equal([]);
+        expect(emptyContainer.reject(predicate)).to.not.equal(result);
+        expect(predicate).to.not.have.been.called;
+      });
+    });
+
+    describe('#every', function() {
+      it('returns false at the first child view that fails the predicate', function() {
+        const context = { maximumRank: 1 };
+        const predicate = this.sinon.spy(function(view) {
+          return view.rank <= this.maximumRank ? 'pass' : 0;
+        });
+
+        expect(container.every(predicate, context)).to.be.false;
+        expect(predicate).to.have.callCount(2);
+        expectPredicateCall(predicate.getCall(0), 0, context);
+        expectPredicateCall(predicate.getCall(1), 1, context);
+      });
+
+      it('returns true after every child view passes the predicate', function() {
+        const predicate = this.sinon.spy(() => true);
+
+        expect(container.every(predicate)).to.be.true;
+        expect(predicate).to.have.callCount(3);
+        expectPredicateCall(predicate.getCall(0), 0, undefined);
+        expectPredicateCall(predicate.getCall(1), 1, undefined);
+        expectPredicateCall(predicate.getCall(2), 2, undefined);
+      });
+
+      it('returns true without calling the predicate for an empty container', function() {
+        const predicate = this.sinon.spy();
+
+        expect(new ChildViewContainer().every(predicate)).to.be.true;
+        expect(predicate).to.not.have.been.called;
+      });
+    });
+
+    describe('#some', function() {
+      it('returns true at the first child view that passes the predicate', function() {
+        const context = { minimumRank: 2 };
+        const predicate = this.sinon.spy(function(view) {
+          return view.rank >= this.minimumRank ? view : null;
+        });
+
+        expect(container.some(predicate, context)).to.be.true;
+        expect(predicate).to.have.callCount(2);
+        expectPredicateCall(predicate.getCall(0), 0, context);
+        expectPredicateCall(predicate.getCall(1), 1, context);
+      });
+
+      it('returns false after every child view fails the predicate', function() {
+        const predicate = this.sinon.spy(() => false);
+
+        expect(container.some(predicate)).to.be.false;
+        expect(predicate).to.have.callCount(3);
+        expectPredicateCall(predicate.getCall(0), 0, undefined);
+        expectPredicateCall(predicate.getCall(1), 1, undefined);
+        expectPredicateCall(predicate.getCall(2), 2, undefined);
+      });
+
+      it('returns false without calling the predicate for an empty container', function() {
+        const predicate = this.sinon.spy();
+
+        expect(new ChildViewContainer().some(predicate)).to.be.false;
+        expect(predicate).to.not.have.been.called;
+      });
+    });
+
+    describe('#partition', function() {
+      it('partitions every child view into new ordered arrays', function() {
+        const context = { minimumRank: 2 };
+        const predicate = this.sinon.spy(function(view) {
+          return view.rank >= this.minimumRank ? view : 0;
+        });
+
+        const partitionedViews = container.partition(predicate, context);
+        const [matchingViews, rejectedViews] = partitionedViews;
+
+        expect(matchingViews).to.have.lengthOf(2);
+        expect(matchingViews[0]).to.equal(views[1]);
+        expect(matchingViews[1]).to.equal(views[2]);
+        expect(rejectedViews).to.have.lengthOf(1);
+        expect(rejectedViews[0]).to.equal(views[0]);
+        expect(predicate).to.have.callCount(3);
+        expectPredicateCall(predicate.getCall(0), 0, context);
+        expectPredicateCall(predicate.getCall(1), 1, context);
+        expectPredicateCall(predicate.getCall(2), 2, context);
+
+        matchingViews.pop();
+        rejectedViews.pop();
+        expect(container).to.have.lengthOf(3);
+        expect(container.first()).to.equal(views[0]);
+        expect(container.last()).to.equal(views[2]);
+
+        const nextPartition = container.partition(view => view.rank >= 2);
+        expect(nextPartition).to.not.equal(partitionedViews);
+        expect(nextPartition[0]).to.not.equal(matchingViews);
+        expect(nextPartition[1]).to.not.equal(rejectedViews);
+      });
+
+      it('returns two empty arrays without calling the predicate for an empty container', function() {
+        const predicate = this.sinon.spy();
+        const emptyContainer = new ChildViewContainer();
+        const result = emptyContainer.partition(predicate);
+        const nextResult = emptyContainer.partition(predicate);
+
+        expect(result).to.deep.equal([[], []]);
+        expect(nextResult).to.not.equal(result);
+        expect(nextResult[0]).to.not.equal(result[0]);
+        expect(nextResult[1]).to.not.equal(result[1]);
+        expect(predicate).to.not.have.been.called;
+      });
+    });
+  });
+
   describe('ordered collection helpers', function() {
     let container;
     let views;


### PR DESCRIPTION
Related #241

## What
- Characterize `find`, `filter`, `reject`, `every`, `some`, and `partition` on `ChildViewContainer`.
- Document function-only predicates, `(view, index)` callback arguments, optional callback context, ordering, short-circuiting, and fresh result arrays.
- State that structurally mutating the container during predicate traversal is unsupported.

## Why
These tests make the current public collection-helper behavior explicit before Underscore-backed internals are replaced. The contract keeps useful Marionette APIs while avoiding accidental promises around private storage, shorthand predicates, or mutation snapshots.

## Scope
- Test and current-reference documentation changes only.
- No runtime behavior, package dependencies, build configuration, or generated distribution artifacts change.
- Traversal helpers and the Underscore implementation replacement remain separate work under #241.

## Deployment Impact
No deployment or redeploy is required. This changes tests and documentation only.

## Testing
- `npx mocha --require test/setup/node.js test/unit/child-view-container.spec.js` — 74 passing.
- `npm run coverage` — 70 files and 1,261 tests; 100% statements, branches, functions, and lines.
- `npm run test:agent-benchmark-contract` — 19 passing.
- `npm run docs` — 34 HTML files and 320 links checked.
- `npm run lint`
- `npm run check:dist`
- `npm run size` — 51,878 bytes, unchanged.
- `git diff HEAD^ --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests and documentation that pin down the current behavior of `find`, `filter`, `reject`, `every`, `some`, and `partition` on `ChildViewContainer`, so the Underscore-backed internals can be replaced under #241 without changing public behavior.

- Predicates are function-only; property-name and object-matcher shorthand are not supported.
- Predicates receive `(view, index)` with `this` bound to `context` when provided; additional callback arguments aren't public API.
- Tests and docs cover iteration order, short-circuiting, fresh result arrays, and empty-container results.
- Structurally mutating the container during traversal is documented as unsupported.
- No runtime behavior, dependencies, build configuration, or generated artifacts change; this is tests and docs only.

<sup>Written for commit ee37d292b444be203ce8206e0e1d20cc1bc4bd3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

