### PR TITLE
test(backbone): prove root import leaves shim inactive

### DIFF
--- a/test/fixtures/shim/validate-cjs-backbone-first.cjs
+++ b/test/fixtures/shim/validate-cjs-backbone-first.cjs
@@ -11,6 +11,9 @@ const constructors = {
 assert.strictEqual(Backbone.Model.prototype.triggerMethod, undefined);
 
 const Marionette = require('marionette');
+for (const Constructor of Object.values(constructors)) {
+  assert.strictEqual(Constructor.prototype.triggerMethod, undefined);
+}
 const ShimmedBackbone = require('marionette/backbone');
 
 assertInterop({

--- a/test/fixtures/shim/validate-esm-backbone-first.mjs
+++ b/test/fixtures/shim/validate-esm-backbone-first.mjs
@@ -11,6 +11,9 @@ const constructors = {
 assert.strictEqual(Backbone.Model.prototype.triggerMethod, undefined);
 
 const Marionette = await import('marionette');
+for (const Constructor of Object.values(constructors)) {
+  assert.strictEqual(Constructor.prototype.triggerMethod, undefined);
+}
 const { default: ShimmedBackbone } = await import('marionette/backbone');
 
 assertInterop({


### PR DESCRIPTION
Closes #71

## What

- Assert in the packed CommonJS and ESM fixtures that importing root `marionette` leaves Backbone prototypes unchanged.
- Keep the assertion between the root import and the explicit `marionette/backbone` shim import.

## Why

The existing fixtures proved that the optional shim patches supported Backbone constructors, but did not explicitly prove that the root package remains independent before the shim is imported. This closes the final package-contract gap in #71.

## Scope

This changes only packed-package fixture assertions for Backbone-first CommonJS and ESM consumers. Runtime source, package exports, generated distributions, documentation, and shim behavior are unchanged.

## Deployment Impact

No deployment, website publication, npm publication, tag, or release is needed. This is test-only repository work.

## Testing

- `npm run build`
- `npm run test:fixtures`
- `npm test -- test/unit/backbone-shim.spec.js` — 1 file, 5 tests
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds assertions to the packed CommonJS and ESM fixtures to prove that importing the root `marionette` package leaves all Backbone prototypes unmodified, so the optional `marionette/backbone` shim remains inactive until explicitly imported. This closes the package-contract gap in #71 and is test-only, with no impact on runtime, exports, or deployment.

<sup>Written for commit 5da0d5a92977e67af5f4477b3d9059e845ac6c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded compatibility checks to verify that `triggerMethod` is not unexpectedly added to Backbone constructor prototypes.
  * Added coverage for both CommonJS and ES module integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->