### PR TITLE
fix(performance): honor budget consumption in reports

### DIFF
--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -592,9 +592,16 @@ function sameNewArtifacts(supplied, expected) {
 
 function growthApprovalReport(base, current, supplied) {
   const thresholdPercent = current.thresholds.pullRequestApprovalPercent;
+  const consumingBudget = supplied?.budgetAmendment?.status === 'accepted' &&
+    supplied.budgetAmendment.mode === 'consume';
+  const approvalThresholdPercent = consumingBudget ? 0 : thresholdPercent;
   const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
   const required = current.artifacts
-    .map(result => approvalRequirement(baseByPath.get(result.path), result, thresholdPercent))
+    .map(result => approvalRequirement(
+      baseByPath.get(result.path),
+      result,
+      approvalThresholdPercent
+    ))
     .filter(Boolean)
     .sort((left, right) => left.path.localeCompare(right.path));
   const newProduction = newProductionReportDelta(base, current);

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -385,6 +385,41 @@ describe('performance contract validation', () => {
     }
   });
 
+  test('accepts exact artifact growth approval while consuming an authorized budget', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-budget-consumption-report-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvalReport = join(fixtureRoot, 'approval.json');
+    const approval = growthApproval();
+    approval.budgetAmendment = { mode: 'consume', status: 'accepted' };
+    approval.required[0] = {
+      ...approval.required[0],
+      currentBytes: 101,
+      deltaBytes: 1,
+      growthBasisPoints: 100,
+    };
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(bundleReport(100))),
+        writeFile(currentReport, JSON.stringify(bundleReport(101))),
+        writeFile(approvalReport, JSON.stringify(approval)),
+      ]);
+
+      const approved = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(approved, /\| Main \| 100 B \| 101 B \| \+1 B \(\+1\.00%\) 🔺 \| Approved \|/);
+      assert.match(approved, /## Artifact growth approval\n\nStatus: \*\*Approved\*\*\./);
+
+      delete approval.budgetAmendment;
+      await writeFile(approvalReport, JSON.stringify(approval));
+      const ordinary = await createReport(baseReport, currentReport, approvalReport);
+      assert.match(ordinary, /Growth approval requirements do not match the exact report comparison/);
+      assert.match(ordinary, /must be not-required when no approval condition is present/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   test('reports exact new subpath and full-size approval without accepting malformed results', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-new-subpath-report-'));
     const baseReport = join(fixtureRoot, 'base.json');


### PR DESCRIPTION
Related #226
Related #224

## What

- Make bundle-report consistency use a zero artifact-growth threshold only when an accepted budget amendment is being consumed.
- Add a regression proving an exact +1% artifact delta is approved during consumption but remains below the ordinary `>1%` approval threshold.

## Why

The budget evaluator correctly required exact-head approval for every positive artifact delta while consuming BA0001, but the report layer recomputed requirements at the ordinary 1% threshold. It then rejected the evaluator’s approved four-path result as inconsistent, leaving #224 blocked after the required-workflow pin was refreshed.

## Scope

This changes repository-only performance reporting and its contract test. Ordinary pull requests retain the configured `>1%` rule. Runtime source, generated artifacts, performance ceilings, amendment records, GitHub settings, and release behavior are unchanged.

## Deployment Impact

No deployment, website publication, npm publication, tag, or release is needed. This only corrects CI validation of an already authorized budget-consumption path.

## Testing

- red regression reproduced both #224 report diagnostics before the fix
- focused budget-consumption report regression
- `npm run test:performance` — 92 tests across 5 suites
- `npm run lint:ci`
- `npm run size` — 51.88 kB / 51.98 kB
- `npm run check:dist`
- SHA-256 comparison of all non-map `dist/` artifacts — byte-identical
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the performance report layer to honor accepted budget amendments, so artifact growth approved at exact-head during budget consumption is no longer rejected as inconsistent with the ordinary 1% threshold.

- Report approvals now use a 0% growth threshold only while an accepted amendment is set to `consume`; ordinary PRs keep the configured `>1%` rule.
- Adds a regression test covering an exact +1% artifact delta accepted during consumption and rejected under ordinary rules.

<sup>Written for commit 17109f5d63dce744334583318e830f837eae2a6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

