### PR TITLE
perf(build): authorize BA0002 review hardening budget

### DIFF
--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -41,6 +41,47 @@
       ],
       "rationale": "Authorize the exact measured distribution cost of a uniform retryable before:destroy contract and stable lazy MN0022 validation for CollectionView emptyView definitions. The combined prototype avoids divergent lifecycle semantics and incidental errors without speculative padding, new production subpaths, normal-path helper calls, or changes to the immutable Phase 0 baseline.",
       "rollbackCondition": "If #224 is abandoned before consumption, append a governance-only BA0001 revocation. Never edit or delete this authorization. If a final runtime implementation exceeds 52369 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
+    },
+    {
+      "kind": "authorization",
+      "id": "BA0002",
+      "target": "aggregate-shipped-package",
+      "previousCeilingBytes": 52369,
+      "proposedCeilingBytes": 52565,
+      "prototypeBaseCommit": "bb950d819cd066c0ea6e4c4c7efec77892114d91",
+      "prototypeCommit": "90625dcb755940251236cb3420cf866698066d75",
+      "implementationIssueUrl": "https://github.com/marionettejs/marionette/issues/226",
+      "authorizedArtifactPaths": [
+        "dist/marionette.cjs",
+        "dist/marionette.js",
+        "dist/marionette.min.js",
+        "dist/marionette.umd.js"
+      ],
+      "authorizedNewSubpaths": [],
+      "reports": [
+        {
+          "path": "evidence/performance-budget-amendments/BA0002/base.json",
+          "role": "base",
+          "sha256": "72b794a36b9e770fece18a149960b3629be2aba3adedfa404375ee8d6655a837"
+        },
+        {
+          "path": "evidence/performance-budget-amendments/BA0002/prototype.json",
+          "role": "prototype",
+          "sha256": "bd9520d929211b83126463a559f771cbe2d321cf4e9b2f972754d0d8da6df4ae"
+        }
+      ],
+      "prototypeContract": {
+        "path": "evidence/performance-budget-amendments/BA0002/prototype-contract.json",
+        "sha256": "5b2c2d4c9ab7f678448876914222a99bccad33f4438a012a89edaac9f6504a17"
+      },
+      "approvalUrls": [
+        "https://github.com/marionettejs/marionette/pull/255#issuecomment-5462436235"
+      ],
+      "evidenceUrls": [
+        "https://github.com/marionettejs/marionette/issues/127#issuecomment-5462436127"
+      ],
+      "rationale": "Authorize the exact measured distribution cost of readable local lifecycle validation and class-source recognition for CollectionView emptyView definitions after exact-head review found malformed classes that could still leak native TypeError failures instead of MN0022. The prototype adds no production subpath, shared child-view behavior change, speculative padding, or allowance for later Underscore work.",
+      "rollbackCondition": "If #254 is abandoned before consumption, append a governance-only BA0002 revocation. Never edit or delete this authorization. If the final implementation exceeds 52565 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
     }
   ]
 }

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -80,12 +80,20 @@ base-allowed maintainer. Evidence URLs remain durable issue #127 comments from t
 repository participants. The record also preserves its rationale and rollback
 condition.
 
-BA0001 authorizes a pending aggregate-ceiling increase from 51,975 to 52,369
+BA0001 authorized an aggregate-ceiling increase from 51,975 to 52,369
 bytes for the exact-base lifecycle-retry and CollectionView `emptyView`
 diagnostic prototype tracked by [#226](https://github.com/marionettejs/marionette/issues/226).
-The proposal equals the measured combined prototype total without padding. It
-does not change the active ceiling until a later implementation consumes the
-authorization, and it adds no production subpath.
+The proposal equaled the measured combined prototype total without padding and
+added no production subpath. [#224](https://github.com/marionettejs/marionette/pull/224)
+consumed that authorization.
+
+BA0002 authorizes a pending aggregate-ceiling increase from 52,369 to 52,565
+bytes for readable local validation of malformed CollectionView `emptyView`
+classes found during exact-head review of
+[#254](https://github.com/marionettejs/marionette/pull/254). The proposal equals
+the reviewed prototype total without padding, adds no production subpath, and
+does not include allowance for later Underscore work. It does not change the
+active ceiling until #254 consumes the authorization.
 
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole

--- a/evidence/performance-budget-amendments/BA0002/base.json
+++ b/evidence/performance-budget-amendments/BA0002/base.json
@@ -1,0 +1,365 @@
+{
+  "schemaVersion": 1,
+  "revision": "bb950d819cd066c0ea6e4c4c7efec77892114d91",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 13440,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 13595,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 13859,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 10507,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 121,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 135,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 51995,
+      "baselineSize": 49500,
+      "absoluteCeiling": 52369
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/view-region.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/proxy.js",
+          "version.js"
+        ],
+        "externalImports": [
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette",
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      }
+    ],
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": []
+  }
+}

--- a/evidence/performance-budget-amendments/BA0002/prototype-contract.json
+++ b/evidence/performance-budget-amendments/BA0002/prototype-contract.json
@@ -1,0 +1,344 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "sourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "totalBrotliBytes": 49500,
+    "absoluteCeilingBytes": 52369
+  },
+  "toolchain": {
+    "releaseProfile": {
+      "path": "config/release-profile.json",
+      "sha256": "405b0135261d44bc5c1cb7832f7bbdbcadfe8415704e40e14abee217ce2e5162",
+      "node": "24.19.0",
+      "npm": "11.17.0",
+      "lockfileVersion": 3,
+      "canonicalHost": {
+        "id": "linux-x64",
+        "runner": "ubuntu-24.04",
+        "platform": "linux",
+        "architecture": "x64"
+      }
+    },
+    "lockedDependencies": {
+      "backbone": "1.4.0",
+      "jsdom": "30.0.1",
+      "rollup": "4.63.0"
+    },
+    "commands": {
+      "deterministic": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run size"
+      ],
+      "hostedTiming": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run performance:timing"
+      ]
+    }
+  },
+  "thresholds": {
+    "cumulativeGrowthPercent": 5,
+    "pullRequestApprovalPercent": 1,
+    "hostedTimingWarningPercent": 10,
+    "controlledMedianRegressionPercent": 5,
+    "controlledP95RegressionPercent": 10
+  },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
+  "runtimeArtifacts": [
+    {
+      "name": "Main ES module",
+      "path": "dist/marionette.js",
+      "baselineBrotliBytes": 12776
+    },
+    {
+      "name": "Main CommonJS",
+      "path": "dist/marionette.cjs",
+      "baselineBrotliBytes": 12932
+    },
+    {
+      "name": "Main UMD",
+      "path": "dist/marionette.umd.js",
+      "baselineBrotliBytes": 13197
+    },
+    {
+      "name": "Main minified UMD",
+      "path": "dist/marionette.min.js",
+      "baselineBrotliBytes": 10001,
+      "additionalShippedArtifact": true
+    },
+    {
+      "name": "Backbone shim ES module",
+      "path": "dist/backbone.js",
+      "baselineBrotliBytes": 121
+    },
+    {
+      "name": "Backbone shim CommonJS",
+      "path": "dist/backbone.cjs",
+      "baselineBrotliBytes": 135
+    },
+    {
+      "name": "jQuery DomApi ES module",
+      "path": "dist/jquery-dom-api.js",
+      "baselineBrotliBytes": 169
+    },
+    {
+      "name": "jQuery DomApi CommonJS",
+      "path": "dist/jquery-dom-api.cjs",
+      "baselineBrotliBytes": 169
+    }
+  ],
+  "productionGraphs": [
+    {
+      "subpath": ".",
+      "input": "index.js",
+      "output": "dist/marionette.js",
+      "baselineModules": [
+        "config/dom.js",
+        "config/event-delegator.js",
+        "config/features.js",
+        "config/renderer.js",
+        "index.js",
+        "mixins/behaviors.js",
+        "mixins/common.js",
+        "mixins/delegate-entity-events.js",
+        "mixins/destroy.js",
+        "mixins/events.js",
+        "mixins/radio.js",
+        "mixins/requests.js",
+        "mixins/template-render.js",
+        "mixins/ui.js",
+        "mixins/view-events.js",
+        "mixins/view.js",
+        "modules/application.js",
+        "modules/behavior.js",
+        "modules/child-view-container.js",
+        "modules/collection-view.js",
+        "modules/common/bind-events.js",
+        "modules/common/bind-requests.js",
+        "modules/common/get-option.js",
+        "modules/common/merge-options.js",
+        "modules/common/monitor-view-events.js",
+        "modules/common/normalize-methods.js",
+        "modules/common/radio.js",
+        "modules/common/trigger-method.js",
+        "modules/common/view.js",
+        "modules/object.js",
+        "modules/radio.js",
+        "modules/view-region.js",
+        "utils/build-event-args.js",
+        "utils/call-handler.js",
+        "utils/error.js",
+        "utils/extend.js",
+        "utils/make-callback.js",
+        "utils/once-wrap.js",
+        "utils/proxy.js",
+        "version.js"
+      ],
+      "baselineExternalImports": [
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./backbone",
+      "input": "backbone.js",
+      "output": "dist/backbone.js",
+      "baselineModules": [
+        "backbone.js"
+      ],
+      "baselineExternalImports": [
+        "backbone",
+        "marionette",
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./jquery-dom-api",
+      "input": "jquery-dom-api.js",
+      "output": "dist/jquery-dom-api.js",
+      "baselineModules": [
+        "jquery-dom-api.js"
+      ],
+      "baselineExternalImports": [
+        "jquery"
+      ]
+    }
+  ],
+  "forbiddenProductionModulePrefixes": [
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "docs-site/",
+    "node_modules/",
+    "scripts/",
+    "test/",
+    "config/diagnostics/",
+    "config/docs/",
+    "config/release/"
+  ],
+  "forbiddenProductionModules": [
+    "config/bundle-size.mjs",
+    "config/performance-growth-approval.mjs",
+    "config/performance-resources.mjs",
+    "config/performance.json",
+    "config/release-profile.json",
+    "config/release-promotion.json"
+  ],
+  "deterministicResources": {
+    "attachDetachCycles": 100,
+    "mountDestroyCycles": 1000,
+    "instanceShapes": {
+      "View": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_domEvents",
+        "_eventPrefix",
+        "_isAttached",
+        "_isRendered",
+        "_rdEvents",
+        "_regions",
+        "cid",
+        "el",
+        "options",
+        "regions"
+      ],
+      "Region": [
+        "_initEl",
+        "cid",
+        "el",
+        "options"
+      ],
+      "Behavior": [
+        "_domEvents",
+        "_rdListenId",
+        "_rdListeningTo",
+        "cid",
+        "el",
+        "options",
+        "ui",
+        "view"
+      ],
+      "CollectionView": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_children",
+        "_collectionEvents",
+        "_domEvents",
+        "_emptyRegion",
+        "_eventPrefix",
+        "_isAttached",
+        "_rdEvents",
+        "childView",
+        "children",
+        "cid",
+        "collection",
+        "el",
+        "options"
+      ]
+    },
+    "allocationShapes": {
+      "View": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "_regions",
+          "options",
+          "regions"
+        ],
+        "marionetteEventRegistrations": 6
+      },
+      "Behavior": {
+        "emptyArrays": [
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "options",
+          "ui"
+        ],
+        "listeningContainers": 1
+      },
+      "CollectionView": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyChildViewContainers": [
+          "_children",
+          "children"
+        ],
+        "eagerEmptyRegion": true,
+        "marionetteEventRegistrations": 6
+      }
+    },
+    "retentionShapes": {
+      "regionRegistrationsWhileShown": 1,
+      "collectionRegistrationsWhileMounted": 3,
+      "modelRegistrationsWhileMounted": 1,
+      "externalListenerOwnersWhileMounted": 1,
+      "collectionViewListeningToWhileMounted": 1,
+      "behaviorListeningToWhileMounted": 2,
+      "destroyedBehaviorRetainsHostReference": true,
+      "destroyedHostRetainsBehaviorCount": 1,
+      "externalRegistrationsAfterDestroy": 0,
+      "externalListenerOwnersAfterDestroy": 0,
+      "frameworkListeningToAfterDestroy": 0,
+      "childContainerEntriesAfterDestroy": 0,
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
+    }
+  },
+  "timing": {
+    "harnessSchemaVersion": 1,
+    "harnessRevision": "271128bee00c66b3168424d65220dbe6c5dbea1f336082c21b45a07a344bb1d9",
+    "sampleCount": 20,
+    "warmupBatches": 5,
+    "cases": [
+      {
+        "id": "view-construct-destroy",
+        "iterationsPerSample": 200
+      },
+      {
+        "id": "view-render-rerender",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "behavior-view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "region-show-empty",
+        "iterationsPerSample": 50
+      },
+      {
+        "id": "collection-view-render-destroy",
+        "iterationsPerSample": 10
+      },
+      {
+        "id": "collection-view-add-remove",
+        "iterationsPerSample": 20
+      }
+    ],
+    "controlledRunner": {
+      "status": "pending-pr-b"
+    }
+  }
+}

--- a/evidence/performance-budget-amendments/BA0002/prototype.json
+++ b/evidence/performance-budget-amendments/BA0002/prototype.json
@@ -1,0 +1,367 @@
+{
+  "schemaVersion": 1,
+  "revision": "90625dcb755940251236cb3420cf866698066d75",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 13602,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 13753,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 14018,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 10598,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 121,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 135,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 169,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 52565,
+      "baselineSize": 49500,
+      "absoluteCeiling": 52369
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/view-region.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/proxy.js",
+          "version.js"
+        ],
+        "externalImports": [
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette",
+          "underscore"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": []
+      }
+    ],
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": [
+      "Cumulative Brotli-11 size 52565 exceeds the absolute ceiling 52369"
+    ]
+  }
+}


### PR DESCRIPTION
Related #226
Related #127

## What

- Record immutable exact-base and reviewed-prototype bundle reports for BA0002.
- Authorize an aggregate shipped-package ceiling increase from 52,369 to exactly 52,565 Brotli-11 bytes.
- Bind the authorization to the malformed-class MN0022 hardening requested during review of #254, with no new production subpaths.

## Why

The exact-head review of #254 found two valid invalid-class paths that could still leak native `TypeError`s instead of stable `MN0022`. The clean local validation adds 196 bytes beyond the fully consumed BA0001 ceiling. This amendment records that measured cost without code-golfing the runtime or adding speculative allowance for later Underscore work.

## Scope

- Governance ledger, immutable BA0002 evidence, and synchronized performance documentation only.
- The active ceiling, immutable Phase 0 baseline, production runtime, package exports, graphs, tests, and workflows remain unchanged.
- #254 will consume the authorization later. Planned Underscore work remains a separate exact-prototype budget decision.

## Deployment Impact

No deployment, website publication, npm publication, tag, or release is performed. No application redeploy is required.

## Testing

- Exact base `bb950d819cd066c0ea6e4c4c7efec77892114d91`: 51,995 cumulative Brotli-11 bytes.
- Exact prototype `90625dcb755940251236cb3420cf866698066d75`: 52,565 cumulative Brotli-11 bytes.
- Positive delta is limited to the four main Marionette distribution artifacts; no production subpath or module graph changes.
- Governance validation and exact-head CI will run after the ledger and canonical approval permalink are added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the immutable BA0002 evidence and raises the approved aggregate shipped-package ceiling from 52,369 to exactly 52,565 Brotli-11 bytes. The extra 196 bytes cover the MN0022 malformed-class hardening requested during the #254 review, which the fully consumed BA0001 ceiling could not absorb.

**Scope**
- Adds BA0002 evidence (base report, prototype report, contract) under `evidence/performance-budget-amendments/BA0002/`, the authorization entry in `config/release/performance-budget-amendments.json`, and docs updates showing BA0001 consumed by #224.
- The 196-byte delta affects only the four main `marionette` distribution artifacts; no production subpaths or module graphs change.
- The hardening keeps two valid invalid-class paths from leaking native `TypeError`s and returns a stable `MN0022` instead.
- No deployment, publication, or release ships here; #254 will consume the authorization later, and Underscore work remains a separate budget decision.

<sup>Written for commit 917c46c8c351587d47a5833b64c9131b8ed253a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

