### PR TITLE
refactor(backbone): replace Underscore shim assignment

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1,10 +1,9 @@
-import { extend } from 'underscore';
 import Backbone from 'backbone';
 import { Events } from './index.js';
 
-extend(Backbone.Model.prototype, Events);
-extend(Backbone.Collection.prototype, Events);
-extend(Backbone.View.prototype, Events);
-extend(Backbone.Router.prototype, Events);
+Object.assign(Backbone.Model.prototype, Events);
+Object.assign(Backbone.Collection.prototype, Events);
+Object.assign(Backbone.View.prototype, Events);
+Object.assign(Backbone.Router.prototype, Events);
 
 export default Backbone;

--- a/dist/backbone.cjs
+++ b/dist/backbone.cjs
@@ -1,12 +1,11 @@
 'use strict';
 
-var underscore = require('underscore');
 var Backbone = require('backbone');
 var marionette = require('marionette');
 
-underscore.extend(Backbone.Model.prototype, marionette.Events);
-underscore.extend(Backbone.Collection.prototype, marionette.Events);
-underscore.extend(Backbone.View.prototype, marionette.Events);
-underscore.extend(Backbone.Router.prototype, marionette.Events);
+Object.assign(Backbone.Model.prototype, marionette.Events);
+Object.assign(Backbone.Collection.prototype, marionette.Events);
+Object.assign(Backbone.View.prototype, marionette.Events);
+Object.assign(Backbone.Router.prototype, marionette.Events);
 
 module.exports = Backbone;

--- a/dist/backbone.js
+++ b/dist/backbone.js
@@ -1,9 +1,8 @@
-import { extend } from 'underscore';
 import Backbone from 'backbone';
 export { default } from 'backbone';
 import { Events } from 'marionette';
 
-extend(Backbone.Model.prototype, Events);
-extend(Backbone.Collection.prototype, Events);
-extend(Backbone.View.prototype, Events);
-extend(Backbone.Router.prototype, Events);
+Object.assign(Backbone.Model.prototype, Events);
+Object.assign(Backbone.Collection.prototype, Events);
+Object.assign(Backbone.View.prototype, Events);
+Object.assign(Backbone.Router.prototype, Events);

--- a/test/unit/backbone-shim.spec.js
+++ b/test/unit/backbone-shim.spec.js
@@ -10,6 +10,8 @@ describe('Backbone shim', function() {
   let historyMethods;
   let namespaceMethods;
   let prototypes;
+  let prototypeKeys;
+  let prototypeParents;
   let previousDocument;
   let previousWindow;
 
@@ -36,6 +38,10 @@ describe('Backbone shim', function() {
       Router: Backbone.Router.prototype,
       View: Backbone.View.prototype
     };
+    prototypeKeys = Object.fromEntries(Object.entries(prototypes)
+      .map(([name, prototype]) => [name, Object.keys(prototype)]));
+    prototypeParents = Object.fromEntries(Object.entries(prototypes)
+      .map(([name, prototype]) => [name, Object.getPrototypeOf(prototype)]));
     namespaceMethods = {
       on: Backbone.on,
       off: Backbone.off,
@@ -48,7 +54,13 @@ describe('Backbone shim', function() {
       triggerMethod: Backbone.History.prototype.triggerMethod
     };
 
-    ShimmedBackbone = (await import('../../backbone.js')).default;
+    const eventsPrototype = Object.getPrototypeOf(Marionette.Events);
+    Object.setPrototypeOf(Marionette.Events, { inheritedShimPollution: true });
+    try {
+      ShimmedBackbone = (await import('../../backbone.js')).default;
+    } finally {
+      Object.setPrototypeOf(Marionette.Events, eventsPrototype);
+    }
   });
 
   after(function() {
@@ -77,6 +89,27 @@ describe('Backbone shim', function() {
     Object.keys(constructors).forEach(name => {
       expect(Backbone[name]).to.equal(constructors[name]);
       expect(Backbone[name].prototype).to.equal(prototypes[name]);
+      expect(Object.getPrototypeOf(Backbone[name].prototype)).to.equal(prototypeParents[name]);
+    });
+  });
+
+  it('copies only the own enumerable Events surface with assignment descriptors', function() {
+    const eventKeys = Object.keys(Marionette.Events);
+
+    Object.entries(prototypes).forEach(([name, prototype]) => {
+      const expectedKeys = [...new Set([...prototypeKeys[name], ...eventKeys])].sort();
+
+      expect(Object.keys(prototype).sort()).to.deep.equal(expectedKeys);
+      expect(prototype).to.not.have.own.property('inheritedShimPollution');
+
+      eventKeys.forEach(key => {
+        expect(Object.getOwnPropertyDescriptor(prototype, key)).to.deep.equal({
+          configurable: true,
+          enumerable: true,
+          value: Marionette.Events[key],
+          writable: true
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Linked issue

- Related #241

## What

- Replace the optional Backbone shim's Underscore `extend` calls with native `Object.assign` for the fixed Marionette `Events` source.
- Preserve the four Backbone constructor/prototype identities and installed Events method descriptors.
- Add focused pollution-hardening coverage and regenerate the ESM/CJS shim artifacts.

## Agent-development failure addressed

- Makes shim installation a direct standard-language operation so agents can reason about the package subpath without following a third-party helper or an unnecessary local helper bundle.

## Public behavior contract

- Canonical behavior after this PR: the eight own enumerable Marionette Events methods are assigned onto Model, Collection, View, and Router prototypes without replacing those prototypes.
- Superseded behavior removed, if any: the shim's direct Underscore import and accidental copying of unrelated inherited enumerable pollution from the fixed Events source.
- Compatibility exception and removal condition, if any: none. Inherited pollution was never part of the Events surface and is intentionally excluded.

## Runtime cost

- [ ] Static or documentation only
- [ ] Development or test only; excluded from production entrypoints
- [x] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: shim Brotli decreases from 121 B to 116 B (ESM) and 135 B to 129 B (CJS); direct external imports decrease from three to two.
- Startup/hot path: four native fixed-source assignments replace four Underscore calls.
- Allocations/retention: no helper/rest allocation is introduced.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npx vitest run test/unit/backbone-shim.spec.js test/unit/events-parity.spec.js --coverage.enabled=false
npm test
npm run test:source
npm run build
npm run check:dist
npm run test:dist
npm run test:fixtures
npm run lint:ci
npm run check:size
npm run test:performance
git diff --check
```

Results: 14 focused/parity tests; full/source/dist/fixture/lint/build/size/performance validation passed serially. Independent exact-head differential review found zero defects.

## Package and browser impact

- Entry points or install fixtures affected: `./backbone` ESM/CJS shim artifacts and package fixtures are exercised; the default Backbone export is unchanged.
- Browser contracts affected: none; `Object.assign` is within the repository's modern browser baseline.
- Production/dev/test module-graph impact: removes the optional shim's direct Underscore edge; Backbone remains its legitimate external dependency and may retain its own transitive dependency.

## Rollback or deprecation

- Revert this commit to restore the direct Underscore shim assignment; no data migration or deprecation sequence is involved.

## Scope

Impacts only the optional Backbone shim, its focused tests, and generated ESM/CJS shim artifacts. It does not change the main Marionette entrypoint, Backbone internals, or Backbone's transitive dependency graph.

## Deployment Impact

No website, npm package, tag, release, or deployment is performed. No consumer redeploy is required for this repository-only change.

## Review notes

- Review the actual eight-key own Events surface, target/prototype identity, ordinary assignment descriptors, repeated assignment, exclusion of inherited pollution, ESM/CJS fixtures, and the direct-versus-transitive module graph distinction.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the `backbone` shim’s `underscore` `extend` calls with `Object.assign`, so the shim copies only the eight own enumerable `Marionette.Events` methods and no longer picks up inherited enumerable pollution. The Backbone constructor/prototype identities and the installed Events method descriptors stay the same.

Related to #241.

**Notes**
- Removes the shim’s direct `underscore` import; `backbone` can still use its own transitive `underscore`.
- Regenerates the ESM/CJS shim artifacts in `dist/`.
- Adds tests that temporarily pollute the `Marionette.Events` prototype to verify inherited keys are not copied.

<sup>Written for commit 5394eeb859d4f3bc7e681594c8c04dd15209ae9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

