### PR TITLE
fix(performance): allow forbidden import tightening

### DIFF
--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -117,6 +117,12 @@ function difference(left, right) {
   return left.filter(value => !rightSet.has(value));
 }
 
+function canonicalForbiddenExternalImports(values) {
+  return Array.isArray(values) && values.length > 0 &&
+    values.every(value => typeof value === 'string' && value.length > 0) &&
+    values.every((value, index) => index === 0 || values[index - 1] < value);
+}
+
 export function validateContract(contract, packageJson, runtimeFiles, budgetAmendments = null) {
   const violations = [];
   if (contract.schemaVersion !== 1) {
@@ -124,6 +130,10 @@ export function validateContract(contract, packageJson, runtimeFiles, budgetAmen
   }
   violations.push(...validateGrowthApprovalPolicy(contract.pullRequestGrowthApproval)
     .map(({ message }) => message));
+  if (Object.hasOwn(contract, 'forbiddenExternalImports') &&
+      !canonicalForbiddenExternalImports(contract.forbiddenExternalImports)) {
+    violations.push('forbiddenExternalImports must be a sorted, unique array of non-empty strings');
+  }
 
   const baselineTotal = contract.runtimeArtifacts
     .reduce((total, artifact) => total + artifact.baselineBrotliBytes, 0);
@@ -206,6 +216,13 @@ export function findForbiddenModules(modules, contract) {
     return contract.forbiddenProductionModules.includes(module) ||
       contract.forbiddenProductionModulePrefixes.some(prefix => module.startsWith(prefix));
   });
+}
+
+export function findForbiddenExternalImports(externalImports, contract) {
+  const forbiddenExternalImports = Array.isArray(contract.forbiddenExternalImports) ?
+    contract.forbiddenExternalImports : [];
+  const forbidden = new Set(forbiddenExternalImports);
+  return externalImports.filter(externalImport => forbidden.has(externalImport));
 }
 
 async function sha256(file) {
@@ -325,6 +342,7 @@ async function measureGraph(root, configurations, graph, contract) {
       phase0AddedExternalImports: difference(externalImports, graph.baselineExternalImports),
       phase0RemovedExternalImports: difference(graph.baselineExternalImports, externalImports),
       forbiddenModules: findForbiddenModules(modules, contract),
+      forbiddenExternalImports: findForbiddenExternalImports(externalImports, contract),
     };
   } finally {
     await bundle.close();
@@ -425,6 +443,9 @@ export async function measure({
       if (result.forbiddenModules.length) {
         violations.push(`${graph.subpath} includes forbidden production modules: ${result.forbiddenModules.join(', ')}`);
       }
+      if (result.forbiddenExternalImports.length) {
+        violations.push(`${graph.subpath} includes forbidden external imports: ${result.forbiddenExternalImports.join(', ')}`);
+      }
     } catch (error) {
       graphs.push({
         subpath: graph.subpath,
@@ -434,6 +455,7 @@ export async function measure({
         modules: [],
         externalImports: [],
         forbiddenModules: [],
+        forbiddenExternalImports: [],
         error: error.message,
       });
       violations.push(`Unable to measure production graph ${graph.subpath}: ${error.message}`);
@@ -449,6 +471,7 @@ export async function measure({
         modules: [],
         externalImports: [],
         forbiddenModules: [],
+        forbiddenExternalImports: [],
         error: 'New exported runtime subpath is not defined by the authority contract',
       });
     }

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -221,8 +221,11 @@ export function findForbiddenModules(modules, contract) {
 export function findForbiddenExternalImports(externalImports, contract) {
   const forbiddenExternalImports = Array.isArray(contract.forbiddenExternalImports) ?
     contract.forbiddenExternalImports : [];
-  const forbidden = new Set(forbiddenExternalImports);
-  return externalImports.filter(externalImport => forbidden.has(externalImport));
+  return externalImports.filter(externalImport => {
+    return forbiddenExternalImports.some(forbiddenImport => {
+      return externalImport === forbiddenImport || externalImport.startsWith(`${forbiddenImport}/`);
+    });
+  });
 }
 
 async function sha256(file) {

--- a/config/bundle-size.mjs
+++ b/config/bundle-size.mjs
@@ -7,6 +7,7 @@ import { isDeepStrictEqual, promisify } from 'node:util';
 import { brotliCompress, constants } from 'node:zlib';
 import { rollup } from 'rollup';
 import {
+  canonicalForbiddenExternalImports,
   newProductionReportDelta,
   validateGrowthApprovalPolicy,
 } from './performance-growth-approval.mjs';
@@ -115,12 +116,6 @@ export async function listRuntimeFiles(directory, root = directory) {
 function difference(left, right) {
   const rightSet = new Set(right);
   return left.filter(value => !rightSet.has(value));
-}
-
-function canonicalForbiddenExternalImports(values) {
-  return Array.isArray(values) && values.length > 0 &&
-    values.every(value => typeof value === 'string' && value.length > 0) &&
-    values.every((value, index) => index === 0 || values[index - 1] < value);
 }
 
 export function validateContract(contract, packageJson, runtimeFiles, budgetAmendments = null) {
@@ -332,6 +327,9 @@ async function measureGraph(root, configurations, graph, contract) {
       .map(moduleId => normalizePath(relative(root, moduleId)))
       .sort();
     const externalImports = [...new Set(chunks.flatMap(chunk => chunk.imports))].sort();
+    const policyExternalImports = [...new Set(chunks.flatMap(chunk => {
+      return [...chunk.imports, ...chunk.dynamicImports];
+    }))].sort();
 
     return {
       subpath: graph.subpath,
@@ -345,7 +343,7 @@ async function measureGraph(root, configurations, graph, contract) {
       phase0AddedExternalImports: difference(externalImports, graph.baselineExternalImports),
       phase0RemovedExternalImports: difference(graph.baselineExternalImports, externalImports),
       forbiddenModules: findForbiddenModules(modules, contract),
-      forbiddenExternalImports: findForbiddenExternalImports(externalImports, contract),
+      forbiddenExternalImports: findForbiddenExternalImports(policyExternalImports, contract),
     };
   } finally {
     await bundle.close();

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -337,6 +337,24 @@ function validReleaseProfileTransition(authorityToolchain, candidateToolchain) {
   return isDeepStrictEqual(candidateToolchain, expectedToolchain);
 }
 
+function validForbiddenExternalImportsTransition(authority, candidate) {
+  const authorityHasField = Object.hasOwn(authority, 'forbiddenExternalImports');
+  const candidateHasField = Object.hasOwn(candidate, 'forbiddenExternalImports');
+
+  if (!authorityHasField) {
+    return !candidateHasField ||
+      uniqueSortedStrings(candidate.forbiddenExternalImports, pathLimit);
+  }
+  if (!candidateHasField ||
+      !uniqueSortedStrings(authority.forbiddenExternalImports, pathLimit, true) ||
+      !uniqueSortedStrings(candidate.forbiddenExternalImports, pathLimit, true)) {
+    return false;
+  }
+
+  const candidateImports = new Set(candidate.forbiddenExternalImports);
+  return authority.forbiddenExternalImports.every(value => candidateImports.has(value));
+}
+
 export function validateCandidateGrowthContract(authority, candidate, { budgetAmendment } = {}) {
   const violations = [];
   if (!authority || typeof authority !== 'object' || !candidate || typeof candidate !== 'object') {
@@ -344,11 +362,21 @@ export function validateCandidateGrowthContract(authority, candidate, { budgetAm
   }
   const authorityKeys = Object.keys(authority).sort();
   const candidateKeys = Object.keys(candidate).sort();
-  if (!isDeepStrictEqual(authorityKeys, candidateKeys)) {
+  const allowedCandidateKeys = Object.hasOwn(authority, 'forbiddenExternalImports') ?
+    authorityKeys : [...authorityKeys, 'forbiddenExternalImports'].sort();
+  const missingAuthorityKeys = authorityKeys.filter(key => !Object.hasOwn(candidate, key));
+  const unrelatedCandidateKeys = candidateKeys.filter(key => !allowedCandidateKeys.includes(key));
+  if (missingAuthorityKeys.length || unrelatedCandidateKeys.length) {
     violations.push('Candidate performance contract top-level fields differ from the exact-base contract');
+  }
+  if (!validForbiddenExternalImportsTransition(authority, candidate)) {
+    violations.push('Candidate performance contract forbiddenExternalImports must be a sorted, unique, non-empty string superset of the exact-base list');
   }
   for (const key of authorityKeys) {
     if (key === 'runtimeArtifacts' || key === 'productionGraphs') {
+      continue;
+    }
+    if (key === 'forbiddenExternalImports') {
       continue;
     }
     if (key === 'toolchain') {

--- a/config/performance-growth-approval.mjs
+++ b/config/performance-growth-approval.mjs
@@ -30,6 +30,12 @@ function uniqueSortedStrings(values, limit, allowEmpty = false) {
     values.every((value, index) => index === 0 || values[index - 1] < value);
 }
 
+export function canonicalForbiddenExternalImports(values) {
+  return Array.isArray(values) && values.length > 0 &&
+    values.every(value => typeof value === 'string' && value.length > 0) &&
+    values.every((value, index) => index === 0 || values[index - 1] < value);
+}
+
 function validSubpath(subpath) {
   return /^\.\/[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(subpath) &&
     !subpath.includes('//') && !subpath.split('/').includes('..');
@@ -343,11 +349,11 @@ function validForbiddenExternalImportsTransition(authority, candidate) {
 
   if (!authorityHasField) {
     return !candidateHasField ||
-      uniqueSortedStrings(candidate.forbiddenExternalImports, pathLimit);
+      canonicalForbiddenExternalImports(candidate.forbiddenExternalImports);
   }
   if (!candidateHasField ||
-      !uniqueSortedStrings(authority.forbiddenExternalImports, pathLimit, true) ||
-      !uniqueSortedStrings(candidate.forbiddenExternalImports, pathLimit, true)) {
+      !canonicalForbiddenExternalImports(authority.forbiddenExternalImports) ||
+      !canonicalForbiddenExternalImports(candidate.forbiddenExternalImports)) {
     return false;
   }
 

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -276,12 +276,16 @@ The full lowercase head SHA prevents an approval from surviving a code change. T
 approved path list must exactly match all existing artifacts above the strict
 greater-than-one-percent threshold. New subpaths and new artifact path/size pairs must
 exactly match the additive candidate contract and measured report. A candidate may
-only add runtime artifact and production graph entries: it cannot change the base
-thresholds, allowlist, baseline, ceiling, forbidden modules, resource contract, timing
-contract, or any existing artifact or graph. The only permitted toolchain transition is
-a valid SHA-256 revision at `toolchain.releaseProfile.sha256`; every other toolchain
-field remains exact-base, and the candidate report must prove that digest matches the
-actual candidate release-profile file. New artifact Phase 0 baselines remain zero, so
+only add runtime artifact and production graph entries. It may also introduce a
+well-formed `forbiddenExternalImports` list or add entries to an existing list, but it
+cannot remove or replace an existing forbidden import. This is a tightening-only
+transition: Phase 0 `baselineExternalImports` remain immutable historical observations,
+not current allowlists. A candidate cannot change the base thresholds, allowlist,
+baseline, ceiling, forbidden modules, resource contract, timing contract, or any
+existing artifact or graph. The only permitted toolchain transition is a valid SHA-256
+revision at `toolchain.releaseProfile.sha256`; every other toolchain field remains
+exact-base, and the candidate report must prove that digest matches the actual
+candidate release-profile file. New artifact Phase 0 baselines remain zero, so
 their full size counts against the original absolute ceiling; after adoption, the exact
 merged artifact becomes the comparison base for later pull requests. Unmeasured graphs,
 forbidden modules, removed or renamed base entries, non-integer sizes, report-contract

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -332,9 +332,10 @@ parser, contract validator, and evaluator all come from the pull request's exact
 so the first enforcement change cannot authorize itself with candidate-owned policy.
 The bundle tool keeps `forbiddenExternalImports` optional so exact-base contracts from
 before this tightening remain valid. When a candidate introduces the field, the
-exact-base tool requires a sorted, unique, non-empty string list and fails every
-measured production graph that imports a listed package or any rooted subpath of it.
-Similarly prefixed packages are not matched.
+exact-base tool requires a sorted, unique, non-empty string list and
+fails every measured production graph that statically or dynamically imports a
+listed package or any rooted subpath of it. Similarly prefixed packages are not
+matched.
 
 ## Hosted timing
 

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -330,6 +330,10 @@ additive change to the authority contract. New-subpath results carry
 cost therefore require an exact-head approval record. The threshold, approver policy,
 parser, contract validator, and evaluator all come from the pull request's exact base,
 so the first enforcement change cannot authorize itself with candidate-owned policy.
+The bundle tool keeps `forbiddenExternalImports` optional so exact-base contracts from
+before this tightening remain valid. When a candidate introduces the field, the
+exact-base tool requires a sorted, unique, non-empty string list and fails every
+measured production graph whose external imports intersect it.
 
 ## Hosted timing
 

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -333,7 +333,8 @@ so the first enforcement change cannot authorize itself with candidate-owned pol
 The bundle tool keeps `forbiddenExternalImports` optional so exact-base contracts from
 before this tightening remain valid. When a candidate introduces the field, the
 exact-base tool requires a sorted, unique, non-empty string list and fails every
-measured production graph whose external imports intersect it.
+measured production graph that imports a listed package or any rooted subpath of it.
+Similarly prefixed packages are not matched.
 
 ## Hosted timing
 

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -193,6 +193,12 @@ describe('performance contract validation', () => {
     const canonical = contractFor();
     canonical.forbiddenExternalImports = ['jquery', 'underscore'];
     assert.deepEqual(validateContract(canonical, packageJson, ['index.mjs']), []);
+    const large = contractFor();
+    large.forbiddenExternalImports = Array.from(
+      { length: 51 },
+      (_, index) => `package-${String(index).padStart(2, '0')}`
+    );
+    assert.deepEqual(validateContract(large, packageJson, ['index.mjs']), []);
     assert.deepEqual(
       findForbiddenExternalImports([
         'backbone',
@@ -745,7 +751,7 @@ describe('performance contract validation', () => {
     }
   });
 
-  test('rejects a candidate-forbidden import from a measured graph', async() => {
+  test('rejects forbidden dynamic imports without matching prefixed packages', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-external-'));
     const contract = contractFor();
     contract.productionGraphs = [{
@@ -767,12 +773,13 @@ describe('performance contract validation', () => {
       await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
       await writeFile(
         join(fixtureRoot, 'index.js'),
-        'import each from \'underscore/modules/each.js\';\nexport const value = each;\n'
+        'export const forbidden = import(\'underscore/modules/each.js\');\n' +
+          'export const allowed = import(\'underscore-plus\');\n'
       );
       await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
       await writeFile(
         join(fixtureRoot, 'rollup.config.mjs'),
-        'export default [{ input: \'index.js\', external: [\'underscore/modules/each.js\'], output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
+        'export default [{ input: \'index.js\', external: [\'underscore/modules/each.js\', \'underscore-plus\'], output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
       );
 
       const result = await measure({
@@ -781,7 +788,8 @@ describe('performance contract validation', () => {
         checkToolchain: false,
       });
 
-      assert.deepEqual(result.graphs[0].externalImports, ['underscore/modules/each.js']);
+      assert.deepEqual(result.graphs[0].externalImports, []);
+      assert.deepEqual(result.graphs[0].phase0AddedExternalImports, []);
       assert.deepEqual(result.graphs[0].forbiddenExternalImports, ['underscore/modules/each.js']);
       assert.ok(result.violations.includes(
         '. includes forbidden external imports: underscore/modules/each.js'

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -9,6 +9,7 @@ import { describe, test } from 'node:test';
 import {
   collectRuntimePaths,
   createReport,
+  findForbiddenExternalImports,
   findForbiddenModules,
   measure,
   resolveRollupInput,
@@ -181,6 +182,37 @@ describe('performance contract validation', () => {
     ));
   });
 
+  test('keeps forbidden external imports optional and validates canonical candidate lists', () => {
+    const packageJson = {
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+    const absent = contractFor();
+
+    assert.deepEqual(validateContract(absent, packageJson, ['index.mjs']), []);
+
+    const canonical = contractFor();
+    canonical.forbiddenExternalImports = ['jquery', 'underscore'];
+    assert.deepEqual(validateContract(canonical, packageJson, ['index.mjs']), []);
+    assert.deepEqual(
+      findForbiddenExternalImports(['backbone', 'jquery', 'underscore'], canonical),
+      ['jquery', 'underscore']
+    );
+
+    for (const malformed of [
+      'underscore',
+      [],
+      [''],
+      ['underscore', 'jquery'],
+      ['underscore', 'underscore'],
+    ]) {
+      const contract = contractFor();
+      contract.forbiddenExternalImports = malformed;
+      assert.ok(validateContract(contract, packageJson, ['index.mjs']).includes(
+        'forbiddenExternalImports must be a sorted, unique array of non-empty strings'
+      ));
+    }
+  });
+
   test('resolves an amended active ceiling from the append-only ledger', () => {
     const contract = contractFor();
     contract.baseline.absoluteCeilingBytes = 12;
@@ -269,6 +301,14 @@ describe('performance contract validation', () => {
       assert.equal(result.artifacts.find(artifact => artifact.path === 'dist/untracked.mjs').status, 'untracked');
       assert.equal(result.graphs.find(graph => graph.subpath === '.').status, 'measurement-error');
       assert.equal(result.graphs.find(graph => graph.subpath === './feature').status, 'unconfigured');
+      assert.deepEqual(
+        result.graphs.find(graph => graph.subpath === '.').forbiddenExternalImports,
+        []
+      );
+      assert.deepEqual(
+        result.graphs.find(graph => graph.subpath === './feature').forbiddenExternalImports,
+        []
+      );
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }
@@ -333,6 +373,7 @@ describe('performance contract validation', () => {
       });
       assert.equal(result.graphs[0].status, 'measured');
       assert.deepEqual(result.graphs[0].modules, ['index.js']);
+      assert.deepEqual(result.graphs[0].forbiddenExternalImports, []);
 
       const baseReport = join(fixtureRoot, 'base.json');
       const currentReport = join(fixtureRoot, 'current.json');
@@ -693,6 +734,68 @@ describe('performance contract validation', () => {
       );
       assert.equal(enforced.status, 1);
       assert.match(enforced.stderr, /includes forbidden production modules: forbidden\.js/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a candidate-forbidden import from a measured graph', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-external-'));
+    const contract = contractFor();
+    contract.productionGraphs = [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/index.mjs',
+      baselineModules: ['index.js'],
+      baselineExternalImports: [],
+    }];
+    contract.forbiddenExternalImports = ['underscore'];
+    const packageJson = {
+      type: 'module',
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+
+    try {
+      await mkdir(join(fixtureRoot, 'dist'));
+      await writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(packageJson));
+      await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
+      await writeFile(
+        join(fixtureRoot, 'index.js'),
+        'import underscore from \'underscore\';\nexport const value = underscore.identity(1);\n'
+      );
+      await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
+      await writeFile(
+        join(fixtureRoot, 'rollup.config.mjs'),
+        'export default [{ input: \'index.js\', external: [\'underscore\'], output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
+      );
+
+      const result = await measure({
+        root: fixtureRoot,
+        configPath: join(fixtureRoot, 'performance.json'),
+        checkToolchain: false,
+      });
+
+      assert.deepEqual(result.graphs[0].externalImports, ['underscore']);
+      assert.deepEqual(result.graphs[0].forbiddenExternalImports, ['underscore']);
+      assert.ok(result.violations.includes('. includes forbidden external imports: underscore'));
+
+      const enforced = spawnSync(
+        process.execPath,
+        [
+          join(root, 'config/bundle-size.mjs'),
+          '--root', fixtureRoot,
+          '--config', join(fixtureRoot, 'performance.json'),
+          '--artifact-graph-only',
+          '--json',
+        ],
+        { encoding: 'utf8' }
+      );
+      assert.equal(enforced.status, 1);
+      assert.match(enforced.stderr, /includes forbidden external imports: underscore/);
+      assert.deepEqual(
+        JSON.parse(enforced.stdout).graphs[0].forbiddenExternalImports,
+        ['underscore']
+      );
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -194,8 +194,14 @@ describe('performance contract validation', () => {
     canonical.forbiddenExternalImports = ['jquery', 'underscore'];
     assert.deepEqual(validateContract(canonical, packageJson, ['index.mjs']), []);
     assert.deepEqual(
-      findForbiddenExternalImports(['backbone', 'jquery', 'underscore'], canonical),
-      ['jquery', 'underscore']
+      findForbiddenExternalImports([
+        'backbone',
+        'jquery',
+        'underscore',
+        'underscore/modules/each.js',
+        'underscore-plus',
+      ], canonical),
+      ['jquery', 'underscore', 'underscore/modules/each.js']
     );
 
     for (const malformed of [
@@ -761,12 +767,12 @@ describe('performance contract validation', () => {
       await writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract));
       await writeFile(
         join(fixtureRoot, 'index.js'),
-        'import underscore from \'underscore\';\nexport const value = underscore.identity(1);\n'
+        'import each from \'underscore/modules/each.js\';\nexport const value = each;\n'
       );
       await writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const value = 1;\n');
       await writeFile(
         join(fixtureRoot, 'rollup.config.mjs'),
-        'export default [{ input: \'index.js\', external: [\'underscore\'], output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
+        'export default [{ input: \'index.js\', external: [\'underscore/modules/each.js\'], output: { file: \'dist/index.mjs\', format: \'es\' } }];\n'
       );
 
       const result = await measure({
@@ -775,9 +781,11 @@ describe('performance contract validation', () => {
         checkToolchain: false,
       });
 
-      assert.deepEqual(result.graphs[0].externalImports, ['underscore']);
-      assert.deepEqual(result.graphs[0].forbiddenExternalImports, ['underscore']);
-      assert.ok(result.violations.includes('. includes forbidden external imports: underscore'));
+      assert.deepEqual(result.graphs[0].externalImports, ['underscore/modules/each.js']);
+      assert.deepEqual(result.graphs[0].forbiddenExternalImports, ['underscore/modules/each.js']);
+      assert.ok(result.violations.includes(
+        '. includes forbidden external imports: underscore/modules/each.js'
+      ));
 
       const enforced = spawnSync(
         process.execPath,
@@ -791,10 +799,13 @@ describe('performance contract validation', () => {
         { encoding: 'utf8' }
       );
       assert.equal(enforced.status, 1);
-      assert.match(enforced.stderr, /includes forbidden external imports: underscore/);
+      assert.match(
+        enforced.stderr,
+        /includes forbidden external imports: underscore\/modules\/each\.js/
+      );
       assert.deepEqual(
         JSON.parse(enforced.stdout).graphs[0].forbiddenExternalImports,
-        ['underscore']
+        ['underscore/modules/each.js']
       );
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -465,6 +465,59 @@ describe('exact-head performance growth approval contract', () => {
     );
   });
 
+  test('permits only tightening forbidden external imports', () => {
+    const authorityContract = growthContract();
+    const introduced = growthContract();
+    introduced.forbiddenExternalImports = ['underscore'];
+    assert.deepEqual(
+      validateCandidateGrowthContract(authorityContract, introduced),
+      []
+    );
+
+    authorityContract.forbiddenExternalImports = ['jquery'];
+    const extended = structuredClone(authorityContract);
+    extended.forbiddenExternalImports = ['jquery', 'underscore'];
+    assert.deepEqual(
+      validateCandidateGrowthContract(authorityContract, extended),
+      []
+    );
+
+    const removed = structuredClone(authorityContract);
+    delete removed.forbiddenExternalImports;
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, removed).join('\n'),
+      /forbiddenExternalImports must be a sorted, unique, non-empty string superset/
+    );
+
+    const replaced = structuredClone(authorityContract);
+    replaced.forbiddenExternalImports = ['underscore'];
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, replaced).join('\n'),
+      /forbiddenExternalImports must be a sorted, unique, non-empty string superset/
+    );
+
+    for (const forbiddenExternalImports of [
+      ['underscore', 'underscore'],
+      ['underscore', 'jquery'],
+      [''],
+      [1],
+    ]) {
+      const malformed = growthContract();
+      malformed.forbiddenExternalImports = forbiddenExternalImports;
+      assert.match(
+        validateCandidateGrowthContract(growthContract(), malformed).join('\n'),
+        /forbiddenExternalImports must be a sorted, unique, non-empty string superset/
+      );
+    }
+
+    const unrelated = growthContract();
+    unrelated.arbitraryPolicy = true;
+    assert.match(
+      validateCandidateGrowthContract(growthContract(), unrelated).join('\n'),
+      /top-level fields differ/
+    );
+  });
+
   test('permits only a valid release-profile SHA-256 transition in the toolchain', () => {
     const authorityContract = growthContract();
     const candidateContract = growthContract();

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -474,6 +474,23 @@ describe('exact-head performance growth approval contract', () => {
       []
     );
 
+    const largeAuthority = growthContract();
+    largeAuthority.forbiddenExternalImports = Array.from(
+      { length: 51 },
+      (_, index) => `package-${String(index).padStart(2, '0')}`
+    );
+    assert.deepEqual(
+      validateCandidateGrowthContract(largeAuthority, structuredClone(largeAuthority)),
+      []
+    );
+
+    const largeExtension = structuredClone(largeAuthority);
+    largeExtension.forbiddenExternalImports.push('package-51');
+    assert.deepEqual(
+      validateCandidateGrowthContract(largeAuthority, largeExtension),
+      []
+    );
+
     authorityContract.forbiddenExternalImports = ['jquery'];
     const extended = structuredClone(authorityContract);
     extended.forbiddenExternalImports = ['jquery', 'underscore'];


### PR DESCRIPTION
Related #241

## What

- Allow a candidate performance contract to introduce `forbiddenExternalImports` or add entries to an existing list.
- Require the transition to be monotonic: sorted, unique, non-empty string values may be added, but existing forbidden imports cannot be removed or replaced.
- Teach the exact-base bundle check to reject configured package roots and their rooted subpaths without matching similarly prefixed packages.
- Document and test the tightening-only exception while keeping every other top-level contract change fail-closed.

## Why

The performance approval evaluator deliberately runs from the exact base so candidate code cannot weaken its own authority. That also means PR #294 cannot activate a new forbidden-import policy until `master` first knows how to validate that policy field.

This bootstrap adds the narrow schema transition needed for #294 without accepting arbitrary contract-shape drift or changing immutable Phase 0 evidence.

## Agent-development failure addressed

Policy evolution is represented as an explicit, executable transition instead of an ad hoc bypass. Future agents can add a stricter external-import prohibition while the base-owned validator continues rejecting removals, malformed values, unrelated fields, and baseline rewrites.

## Public behavior contract

No Marionette runtime or package behavior changes. This changes only how the exact-base performance authority validates a candidate that tightens forbidden external imports.

## Scope

Impacted: performance growth-approval validation, exact-base bundle graph enforcement, their tests, and performance-governance documentation.

Intentionally unchanged: runtime code, package metadata, artifacts, production graphs, `baselineExternalImports`, Phase 0 evidence, ceilings, thresholds, approvers, resources, website, tags, and publication behavior.

## Deployment Impact

No deployment, redeploy, package publication, website publication, tag, or release is required.

## Testing

- `npm ci`
- `npm run test:performance` — 95 tests
- `npm run lint:ci`
- `npm run docs:check` — 39 HTML files and 360 links
- `git diff --check`

Coverage includes first introduction, monotonic extension, deletion, replacement, malformed/duplicate/unsorted/non-string values, unrelated top-level field rejection, exact package imports, rooted subpaths, and similarly prefixed packages.

## Review notes

This is intentionally a separate bootstrap from #294 because the candidate-contract evaluator is loaded from the exact base. After merge, #294 will merge updated `master` and rerun against this base-owned rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows performance contracts to introduce or extend a `forbiddenExternalImports` list, enabling a tightening-only policy transition. Previously the exact-base evaluator rejected any candidate that added this field; now candidates may add the field or append sorted, unique, non-empty entries, while removals, replacements, malformed values, and unrelated top-level field changes still fail closed. When enforced, the exact-base bundle check rejects statically or dynamically imported listed packages and their rooted subpaths without matching similarly prefixed packages; no runtime, package, or publication behavior changes.

**Testing**
- Covers first introduction, monotonic extension, deletion, replacement, malformed values, unrelated fields, exact imports, dynamic imports, rooted subpaths, and similarly prefixed packages.
- Verified with `npm run test:performance`, `npm run lint:ci`, `npm run docs:check`, and `git diff --check`.

<sup>Written for commit 58333489fce52987f712217b5ba82383f31164eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

