### PR TITLE
fix(ci): resolve performance tooling layouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,12 @@ jobs:
         continue-on-error: true
         env:
           PERFORMANCE_DIR: ${{ steps.performance_workspace.outputs.directory }}
-        run: node config/bundle-size.mjs --json > "${PERFORMANCE_DIR}/bundle-size-current.json"
+        run: |
+          set -euo pipefail
+          IFS=$'\t' read -r bundle_script approval_script timing_script < <(
+            node scripts/resolve-performance-tools.mjs --root .
+          )
+          node "${bundle_script}" --json > "${PERFORMANCE_DIR}/bundle-size-current.json"
 
       - name: Collect performance growth approval records
         env:
@@ -225,9 +230,16 @@ jobs:
         run: |
           set -euo pipefail
           base_contract='bundle-size-base/config/performance.json'
-          authority_script='bundle-size-base/config/bundle-size.mjs'
-          approval_script='bundle-size-base/config/performance-growth-approval.mjs'
+          IFS=$'\t' read -r authority_script approval_script timing_script < <(
+            node scripts/resolve-performance-tools.mjs --root bundle-size-base
+          )
           test -f "${base_contract}"
+          resolved_layout="${authority_script}"$'\t'"${approval_script}"$'\t'"${timing_script}"
+          case "${resolved_layout}" in
+            $'bundle-size-base/config/bundle-size.mjs\tbundle-size-base/config/performance-growth-approval.mjs\tbundle-size-base/benchmarks/performance.mjs'|\
+            $'bundle-size-base/scripts/performance/bundle-size.mjs\tbundle-size-base/scripts/performance/growth-approval.mjs\tbundle-size-base/scripts/performance/timing.mjs') ;;
+            *) echo "Resolved performance tool outside a known exact-base layout" >&2; exit 1 ;;
+          esac
           test -f "${authority_script}"
           test -f "${approval_script}"
 
@@ -311,9 +323,23 @@ jobs:
 
       - name: Measure hosted timing
         run: |
-          node benchmarks/performance.mjs --root performance-base --config config/performance.json --json > performance-timing-base.json
-          node benchmarks/performance.mjs --config config/performance.json --json > performance-timing-current.json
-          node benchmarks/performance.mjs --report performance-timing-base.json performance-timing-current.json > performance-timing-report.md
+          set -euo pipefail
+          IFS=$'\t' read -r current_bundle_script current_approval_script current_timing_script < <(
+            node scripts/resolve-performance-tools.mjs --root .
+          )
+          IFS=$'\t' read -r base_bundle_script base_approval_script base_timing_script < <(
+            node scripts/resolve-performance-tools.mjs --root performance-base
+          )
+          resolved_layout="${base_bundle_script}"$'\t'"${base_approval_script}"$'\t'"${base_timing_script}"
+          case "${resolved_layout}" in
+            $'performance-base/config/bundle-size.mjs\tperformance-base/config/performance-growth-approval.mjs\tperformance-base/benchmarks/performance.mjs'|\
+            $'performance-base/scripts/performance/bundle-size.mjs\tperformance-base/scripts/performance/growth-approval.mjs\tperformance-base/scripts/performance/timing.mjs') ;;
+            *) echo "Resolved performance tool outside a known exact-base layout" >&2; exit 1 ;;
+          esac
+          test -f "${base_timing_script}"
+          node "${base_timing_script}" --root performance-base --config performance-base/config/performance.json --json > performance-timing-base.json
+          node "${current_timing_script}" --config config/performance.json --json > performance-timing-current.json
+          node "${current_timing_script}" --report performance-timing-base.json performance-timing-current.json > performance-timing-report.md
           cat performance-timing-report.md >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload hosted timing report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,8 @@ jobs:
       - name: Run configured coverage
         run: npm run coverage
 
-      - name: Build once
-        run: npm run build
-
-      - name: Verify committed distributable projection
-        run: node config/check-dist.mjs
+      - name: Build and verify committed distributable projection
+        run: npm run check:dist
 
       - name: Test built distributables
         run: npm run test:dist

--- a/scripts/resolve-performance-tools.mjs
+++ b/scripts/resolve-performance-tools.mjs
@@ -1,0 +1,72 @@
+import { stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const layouts = [
+  {
+    name: 'config',
+    bundle: 'config/bundle-size.mjs',
+    approval: 'config/performance-growth-approval.mjs',
+    timing: 'benchmarks/performance.mjs',
+  },
+  {
+    name: 'scripts',
+    bundle: 'scripts/performance/bundle-size.mjs',
+    approval: 'scripts/performance/growth-approval.mjs',
+    timing: 'scripts/performance/timing.mjs',
+  },
+];
+
+async function isFile(path) {
+  try {
+    return (await stat(path)).isFile();
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+// Transitional for issue #237. Remove after every supported checkout uses scripts/performance.
+export async function resolvePerformanceTools(root) {
+  const results = await Promise.all(layouts.map(async layout => {
+    const paths = [layout.bundle, layout.approval, layout.timing]
+      .map(path => join(root, path));
+    const present = await Promise.all(paths.map(isFile));
+    return { layout, paths, present };
+  }));
+  const complete = results.filter(result => result.present.every(Boolean));
+  const presentFiles = results.reduce((count, result) => {
+    return count + result.present.filter(Boolean).length;
+  }, 0);
+
+  if (complete.length !== 1 || presentFiles !== 3) {
+    const summary = results
+      .map(({ layout, present }) => `${layout.name} ${present.filter(Boolean).length}/3`)
+      .join('; ');
+    throw new Error(`Expected exactly one complete performance-tool layout; ${summary}`);
+  }
+
+  return {
+    bundleScript: complete[0].paths[0],
+    approvalScript: complete[0].paths[1],
+    timingScript: complete[0].paths[2],
+  };
+}
+
+async function main(args = process.argv.slice(2)) {
+  if (args.length !== 2 || args[0] !== '--root') {
+    throw new Error('Usage: resolve-performance-tools.mjs --root <checkout>');
+  }
+  const tools = await resolvePerformanceTools(args[1]);
+  process.stdout.write(
+    `${tools.bundleScript}\t${tools.approvalScript}\t${tools.timingScript}\n`
+  );
+}
+
+const entryUrl = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (entryUrl === import.meta.url) {
+  await main();
+}

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -656,9 +656,8 @@ describe('performance contract validation', () => {
       command.startsWith('node "${approval_script}"')
     );
 
-    assert.ok(commands.includes('authority_script=\'bundle-size-base/config/bundle-size.mjs\''));
     assert.ok(commands.includes(
-      'approval_script=\'bundle-size-base/config/performance-growth-approval.mjs\''
+      'node scripts/resolve-performance-tools.mjs --root bundle-size-base'
     ));
     assert.notEqual(measurementIndex, -1);
     assert.notEqual(resourceValidationIndex, -1);
@@ -674,6 +673,61 @@ describe('performance contract validation', () => {
     assert.ok(commands[approvalIndex].includes('--candidate-contract config/performance.json'));
     assert.ok(measurementIndex < approvalIndex);
     assert.ok(resourceValidationIndex < approvalIndex);
+  });
+
+  test('resolves current and exact-base performance tools in CI workflows', async() => {
+    const workflow = await readFile(join(root, '.github/workflows/ci.yml'), 'utf8');
+
+    assert.match(
+      workflow,
+      /node scripts\/resolve-performance-tools\.mjs --root \./
+    );
+    assert.match(
+      workflow,
+      /node "\$\{bundle_script\}" --json > "\$\{PERFORMANCE_DIR\}\/bundle-size-current\.json"/
+    );
+    assert.match(
+      workflow,
+      /node scripts\/resolve-performance-tools\.mjs --root performance-base/
+    );
+    assert.match(
+      workflow,
+      /node "\$\{base_timing_script\}" --root performance-base --config performance-base\/config\/performance\.json/
+    );
+    assert.match(
+      workflow,
+      /bundle-size-base\/config\/bundle-size\.mjs\\tbundle-size-base\/config\/performance-growth-approval\.mjs\\tbundle-size-base\/benchmarks\/performance\.mjs/
+    );
+    assert.match(
+      workflow,
+      /bundle-size-base\/scripts\/performance\/bundle-size\.mjs\\tbundle-size-base\/scripts\/performance\/growth-approval\.mjs\\tbundle-size-base\/scripts\/performance\/timing\.mjs/
+    );
+    assert.match(
+      workflow,
+      /performance-base\/config\/bundle-size\.mjs\\tperformance-base\/config\/performance-growth-approval\.mjs\\tperformance-base\/benchmarks\/performance\.mjs/
+    );
+    assert.match(
+      workflow,
+      /performance-base\/scripts\/performance\/bundle-size\.mjs\\tperformance-base\/scripts\/performance\/growth-approval\.mjs\\tperformance-base\/scripts\/performance\/timing\.mjs/
+    );
+    assert.match(workflow, /test -f "\$\{authority_script\}"/);
+    assert.match(workflow, /test -f "\$\{approval_script\}"/);
+    assert.match(workflow, /test -f "\$\{base_timing_script\}"/);
+    assert.equal(
+      workflow.match(/resolved_layout="\$\{[^}]+\}"\$'\\t'"\$\{[^}]+\}"\$'\\t'"\$\{[^}]+\}"/g)?.length,
+      2
+    );
+    assert.match(
+      workflow,
+      /node "\$\{current_timing_script\}" --config config\/performance\.json/
+    );
+
+    const releaseWorkflow = await readFile(
+      join(root, '.github/workflows/release.yml'),
+      'utf8'
+    );
+    assert.match(releaseWorkflow, /run: npm run check:dist/);
+    assert.doesNotMatch(releaseWorkflow, /node config\/check-dist\.mjs/);
   });
 
   test('refreshes checks when budget-amendment approvals or evidence change', async() => {

--- a/test/performance/tool-layout.test.mjs
+++ b/test/performance/tool-layout.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { resolvePerformanceTools } from '../../scripts/resolve-performance-tools.mjs';
+
+const oldPaths = [
+  'config/bundle-size.mjs',
+  'config/performance-growth-approval.mjs',
+  'benchmarks/performance.mjs',
+];
+const newPaths = [
+  'scripts/performance/bundle-size.mjs',
+  'scripts/performance/growth-approval.mjs',
+  'scripts/performance/timing.mjs',
+];
+
+async function writePaths(root, paths) {
+  for (const path of paths) {
+    const file = join(root, path);
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, '');
+  }
+}
+
+test('resolves only one complete known performance-tool layout', async() => {
+  const root = await mkdtemp(join(tmpdir(), 'marionette-performance-tools-'));
+
+  try {
+    await assert.rejects(
+      resolvePerformanceTools(root),
+      /config 0\/3; scripts 0\/3/
+    );
+
+    await writePaths(root, ['tools/bundle-size.mjs', 'tools/growth.mjs', 'tools/timing.mjs']);
+    await assert.rejects(
+      resolvePerformanceTools(root),
+      /config 0\/3; scripts 0\/3/
+    );
+
+    await writePaths(root, oldPaths);
+    assert.deepEqual(await resolvePerformanceTools(root), {
+      bundleScript: join(root, oldPaths[0]),
+      approvalScript: join(root, oldPaths[1]),
+      timingScript: join(root, oldPaths[2]),
+    });
+
+    await rm(join(root, 'config'), { recursive: true });
+    await rm(join(root, 'benchmarks'), { recursive: true });
+    await writePaths(root, newPaths);
+    assert.deepEqual(await resolvePerformanceTools(root), {
+      bundleScript: join(root, newPaths[0]),
+      approvalScript: join(root, newPaths[1]),
+      timingScript: join(root, newPaths[2]),
+    });
+
+    await writePaths(root, [oldPaths[0]]);
+    await assert.rejects(
+      resolvePerformanceTools(root),
+      /config 1\/3; scripts 3\/3/
+    );
+    await writePaths(root, oldPaths.slice(1));
+    await assert.rejects(
+      resolvePerformanceTools(root),
+      /config 3\/3; scripts 3\/3/
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects every partial and mixed known layout', async() => {
+  for (let mask = 1; mask < 63; mask += 1) {
+    const selected = mask.toString(2).padStart(6, '0')
+      .split('')
+      .map(value => value === '1');
+    const oldCount = selected.slice(0, 3).filter(Boolean).length;
+    const newCount = selected.slice(3).filter(Boolean).length;
+    if ((oldCount === 3 && newCount === 0) || (oldCount === 0 && newCount === 3)) {
+      continue;
+    }
+
+    const root = await mkdtemp(join(tmpdir(), 'marionette-performance-tools-'));
+    try {
+      const paths = [
+        ...oldPaths.filter((_, index) => selected[index]),
+        ...newPaths.filter((_, index) => selected[index + 3]),
+      ];
+      await writePaths(root, paths);
+      await assert.rejects(
+        resolvePerformanceTools(root),
+        new RegExp(`config ${oldCount}/3; scripts ${newCount}/3`)
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
Related #237

## What
- Add a fail-closed resolver for the complete legacy and `scripts/performance` tooling layouts.
- Resolve current-head and exact-base performance tools independently in CI.
- Route release distribution verification through the stable package script.

## Why
Pull-request workflows execute the base branch workflow against the candidate checkout. The v5 runtime/tooling layout PR therefore needs the base workflow to recognize both complete layouts before it can move the performance tools without transient missing-module failures.

## Scope
This changes CI/release workflow plumbing, one transitional resolver, and focused resolver contract coverage. It does not change package metadata, shipped runtime code, configuration evidence, performance authority values, or publication behavior.

## Deployment Impact
No deployment or package publication is required. This only prepares repository workflows for the issue #237 layout transition.

## Testing
- `node --test test/performance/tool-layout.test.mjs test/performance/contract.test.mjs` (33/33)
- `node scripts/resolve-performance-tools.mjs --root .`
- `npm run test:performance` (98/98)
- `npm run lint:ci`
- `npm run docs:check`
- `npm run check:dist`
- `npm run test:release-promotion` (5/5)
- Ruby YAML parsing for the CI and release workflows
- `git diff --check`

The Linux release-profile check was not run locally because this macOS/arm64 host correctly rejects host impersonation; GitHub CI covers that profile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI so performance tooling can be resolved from either the legacy `config/`/`benchmarks/` layout or the new `scripts/performance/` layout during the #237 transition.

PR workflows run the base branch workflow against the candidate checkout, so the v5 runtime/tooling layout PR needs the base workflow to recognize both complete layouts before it moves the performance tools.

- Adds a fail-closed resolver that resolves current-head and exact-base performance tools independently.
- Routes release distribution verification through `npm run check:dist`.
- Adds focused resolver contract and workflow tests.

<sup>Written for commit e55cd64fd3d6991ef0a76513147e2e0265f5318b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

