### PR TITLE
test(region): contract detach after destruction

### DIFF
--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -77,7 +77,7 @@ change which lifecycle operations are valid.
 | Operation | Empty Region | Occupied Region | Destroyed Region |
 | --- | --- | --- | --- |
 | `show(view)` when the Region element resolves | Renders the View if needed, shows it, and enters occupied. | Showing the same View is a no-op. Showing a different View destroys the old View and swaps to the new one. | Throws `MN0028` before resolving the element or changing the View. |
-| `detachView()` | Returns `undefined`; state is unchanged. | Detaches and returns the live View, then enters empty. | Reuse is unsupported. |
+| `detachView()` | Returns `undefined`; state is unchanged. | Detaches and returns the live View, then enters empty. | Returns `undefined` without changing state or DOM or emitting lifecycle events. |
 | `empty()` | Returns the Region and, when its element resolves, removes unmanaged contents from that element. | Destroys the current View, clears `currentView`, and enters empty. | Reuse is unsupported. |
 | Current View is destroyed externally | No effect. | Runs the Region's empty lifecycle once, clears `currentView`, and enters empty. | No effect. |
 | `destroy()` | Runs the destroy lifecycle and enters destroyed. | Emits `before:destroy`, enters destroyed, destroys and empties the current View, then emits `destroy`. | Returns the Region without repeating cleanup or lifecycle events. |
@@ -87,8 +87,9 @@ operation completes. With `allowMissingEl: true`, `show` instead returns `undefi
 and leaves the Region empty when its element does not resolve. A View returned
 by `detachView()` remains the caller's responsibility until another Region shows it
 or it is destroyed. Calling `show()` after Region destruction throws `MN0028`;
-repeated `destroy()` remains a no-op. Other operations after destruction remain
-unsupported; this contract does not make a destroyed Region reusable.
+`detachView()` after destruction is an idempotent no-op that returns `undefined`,
+and repeated `destroy()` remains a no-op. Other operations after destruction
+remain unsupported; this contract does not make a destroyed Region reusable.
 
 The following example preserves a View by detaching it before showing it again.
 Calling `empty()` afterward destroys the View and returns the Region to its empty state.

--- a/test/unit/region-lifecycle.spec.js
+++ b/test/unit/region-lifecycle.spec.js
@@ -306,6 +306,32 @@ describe('Region lifecycle contract', function() {
     view.destroy();
   });
 
+  it('treats detachView after destruction as an idempotent no-op', function() {
+    const view = new TestView();
+    region.show(view);
+    region.destroy();
+
+    const sentinel = document.createElement('span');
+    sentinel.textContent = 'unmanaged';
+    const regionEl = document.querySelector('#region');
+    regionEl.appendChild(sentinel);
+    const beforeEmpty = this.sinon.spy();
+    const empty = this.sinon.spy();
+    region.on('before:empty', beforeEmpty);
+    region.on('empty', empty);
+
+    expect(region.detachView()).to.be.undefined;
+    expect(region.detachView()).to.be.undefined;
+    expect(region.isDestroyed()).to.be.true;
+    expect(region.hasView()).to.be.false;
+    expect(region.currentView).to.be.undefined;
+    expect(regionEl.childNodes).to.have.length(1);
+    expect(regionEl.firstChild).to.equal(sentinel);
+    expect(sentinel.textContent).to.equal('unmanaged');
+    expect(beforeEmpty).to.not.have.been.called;
+    expect(empty).to.not.have.been.called;
+  });
+
   it('clears the Region once when its current View is destroyed externally', function() {
     const view = new TestView();
     const beforeEmpty = this.sinon.spy();


### PR DESCRIPTION
Related #131

## What

- Add lifecycle coverage for repeated `Region#detachView()` calls after Region destruction.
- Document post-destroy `detachView()` as an idempotent no-op returning `undefined`.

## Why

The Region lifecycle table previously left this operation as unsupported even though the implementation has stable, side-effect-free behavior. Publishing the existing contract removes ambiguity for callers and agents without changing runtime behavior.

## Scope

- Region lifecycle tests and Region reference documentation only.
- No runtime implementation, generated distribution, diagnostics, Application lifecycle, or ownership-topology behavior changes.
- Post-destroy `empty()` and `reset()` remain intentionally out of scope because Region destruction invokes them internally after marking the Region destroyed.

## Agent-development failure addressed

- Agents no longer need to infer whether post-destroy `detachView()` is safe or mutating from implementation details.

## Public behavior contract

- Canonical behavior after this PR: post-destroy `detachView()` repeatedly returns `undefined`, preserves destroyed/empty state and DOM, and emits no empty lifecycle events.
- Superseded behavior removed, if any: documentation no longer labels this stable behavior as unsupported.
- Compatibility exception and removal condition, if any: none; runtime behavior is unchanged.

## Runtime cost

- [x] Static or documentation only
- [x] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: no runtime or distribution changes.
- Startup/hot path: no change.
- Allocations/retention: no production change.

## Deployment Impact

- No application, form, website, package, or release deployment is required.
- This affects source tests and future documentation output only.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

## Testing

Commands and results:

```sh
npx vitest run test/unit/region-lifecycle.spec.js --coverage.enabled=false
# 1 file, 11 tests passed

npm run docs:check
# 7 documentation tests passed; 40 pages, 41 HTML files, and 376 links validated

npm run lint:ci
# passed with zero warnings

git diff --check
# passed
```

The lifecycle test covers two calls after destruction, destroyed/empty state, absent current View, preserved unmanaged DOM, and suppressed `before:empty`/`empty` events.

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: Region lifecycle behavior is documented and tested; runtime behavior is unchanged.
- Production/dev/test module-graph impact: test and documentation sources only.

## Rollback or deprecation

- Revert the test/docs commit if this existing behavior is intentionally redesigned in a later #131 lifecycle slice.

## Review notes

- The narrow contract is intentionally separate from post-destroy `empty()` and `reset()`, whose teardown path requires broader lifecycle design.
- No changelog entry is included because this PR characterizes existing behavior rather than changing it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and tests the existing post-destroy `detachView()` behavior as an idempotent no-op, so callers no longer need to infer whether it is safe.

- The Region lifecycle table now lists post-destroy `detachView()` as returning `undefined` without changing state or DOM or emitting lifecycle events, replacing the previous "unsupported" label.
- Adds test coverage for repeated calls after destruction, destroyed/empty state, preserved unmanaged DOM, and suppressed `before:empty`/`empty` events.
- No runtime behavior or production entrypoints change; this is test and documentation only.

<sup>Written for commit 539287a252654dc135256529fef66a9d45368e97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

