### PR TITLE
chore(diagnostics): preserve retired lifecycle codes

### DIFF
--- a/config/diagnostics/catalog.json
+++ b/config/diagnostics/catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./catalog.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "diagnostics": [
     {
       "code": "MN0001",
@@ -463,6 +463,39 @@
       ],
       "remediation": "Pass a non-empty string feature name to setEnabled; documented Marionette names and application-owned names are supported.",
       "docsAnchor": "/errors/MN0027/",
+      "surfaces": [
+        "runtime"
+      ],
+      "benchmarkCategory": "view"
+    },
+    {
+      "code": "MN0028",
+      "slug": "region-destroyed-operation",
+      "status": "retired",
+      "category": "lifecycle",
+      "severity": "error",
+      "objects": [
+        "Region"
+      ],
+      "remediation": "Calls to show, empty, or reset after Region destruction are lifecycle-safe no-ops. Use a live Region when the operation must take effect.",
+      "docsAnchor": "/errors/MN0028/",
+      "surfaces": [
+        "runtime"
+      ],
+      "benchmarkCategory": "region"
+    },
+    {
+      "code": "MN0029",
+      "slug": "view-destroyed-set-element",
+      "status": "retired",
+      "category": "lifecycle",
+      "severity": "error",
+      "objects": [
+        "CollectionView",
+        "View"
+      ],
+      "remediation": "Calls to setElement after View or CollectionView destruction begins are lifecycle-safe no-ops. Use a live instance when element replacement must take effect.",
+      "docsAnchor": "/errors/MN0029/",
       "surfaces": [
         "runtime"
       ],

--- a/config/diagnostics/catalog.schema.json
+++ b/config/diagnostics/catalog.schema.json
@@ -13,7 +13,7 @@
       "const": "./catalog.schema.json"
     },
     "schemaVersion": {
-      "const": 1
+      "const": 2
     },
     "diagnostics": {
       "type": "array",
@@ -56,7 +56,8 @@
           "enum": [
             "defined",
             "active",
-            "deprecated"
+            "deprecated",
+            "retired"
           ]
         },
         "category": {

--- a/docs/diagnostic-catalog.md
+++ b/docs/diagnostic-catalog.md
@@ -9,6 +9,7 @@ and the public agent benchmark. The catalog is stored in
 The catalog is static project metadata. Production entrypoints must not import the
 catalog, and the catalog is not part of the production package surface. Runtime
 diagnostics may embed a compact catalog code, but they must not load the full catalog.
+Schema version 2 adds explicit retired identities without restoring their emissions.
 
 ## Runtime error contract
 
@@ -44,7 +45,9 @@ Every entry has these fields:
   diagnostic category, object, severity, or implementation order.
 - `slug`: a unique lowercase kebab-case name used by tools and people.
 - `status`: `defined` before the code is emitted, `active` once a supported surface
-  emits it, or `deprecated` after it has a replacement.
+  emits it, `deprecated` after it has a replacement, or `retired` after the
+  diagnostic is removed without a replacement. Retired entries remain cataloged
+  permanently but cannot be emitted.
 - `category`: the kind of contract involved: `configuration`, `communication`,
   `dom`, `lifecycle`, or `ownership`.
 - `severity`: `error`, `warning`, or `info`, following the model below.
@@ -53,12 +56,12 @@ Every entry has these fields:
   and may improve without changing the diagnostic identity.
 - `docsAnchor`: the permanent version-neutral documentation route. It is always
   `/errors/<code>/`.
-- `surfaces`: the places that can report the diagnostic: `runtime`, `lint`,
-  `development`, `test`, or `benchmark`.
+- `surfaces`: the places that report the diagnostic, or historically reported it
+  for a retired entry: `runtime`, `lint`, `development`, `test`, or `benchmark`.
 - `benchmarkCategory`: the public benchmark category used to classify the violation.
 
 A deprecated entry also has `replacementCode`, which must identify another catalog
-entry. Defined and active entries cannot declare a replacement.
+entry. Defined, active, and retired entries cannot declare a replacement.
 
 ### Severity model
 
@@ -71,17 +74,25 @@ entry. Defined and active entries cannot declare a replacement.
 - `info` records deterministic context or guidance without indicating incorrect
   behavior. It does not fail an operation, check, or benchmark result by itself.
 
+For a retired entry, the stored severity and surfaces retain the diagnostic's
+historical classification. The generated reference labels those values as historical
+for display only. The `retired` status is authoritative: the entry is not a current
+error, warning, informational report, or supported-surface mapping.
+
 ## Stability policy
 
 Codes and slugs are unique and are never reassigned. The numeric portion of a code is
 allocated monotonically, gaps are allowed, and entries are never renumbered to close
 a gap. Deprecation retains both the catalog entry and its `/errors/<code>/` route and
-names the replacement; deletion and reuse are not supported.
+names the replacement. Retirement retains the identity and route without implying a
+replacement. Deletion and reuse are not supported.
 
 Before stable v5, defined catalog fields may be revised through reviewed changes.
-After stable v5, active and deprecated entries follow these rules:
+After stable v5, active, deprecated, and retired entries follow these rules:
 
 - adding a diagnostic or deprecating one is a minor change;
+- retiring an active diagnostic changes supported behavior and requires
+  major-version review;
 - clarifying remediation without changing its meaning is a patch change;
 - changing the meaning of a machine-readable field or the schema is a breaking
   change and requires a new schema version and major-version review;
@@ -101,6 +112,7 @@ second identifier.
 Runtime diagnostic options and lint-rule metadata cannot use computed keys, spreads,
 or duplicate mapping properties. This keeps the emitted code statically decidable.
 A `defined` entry must move to `active` in the same change that first emits it.
+A retired entry cannot be emitted or mapped by a supported surface.
 
 `npm run check:diagnostics` derives the shipped source graph from the production
 Rollup inputs, rejects runtime codes or lint-rule mappings that are not in the
@@ -111,8 +123,9 @@ maintained as a second hand-written list.
 ## Initial scope
 
 The initial active entries describe only deliberate errors already thrown by the
-framework. They do not reserve codes for planned validation, incidental JavaScript
-exceptions, or benchmark hypotheses. New invariants receive codes when their
+framework. Retired entries reserve identities that were formerly active; they do not
+reserve codes for planned validation. Defined entries likewise are not placeholders
+for incidental JavaScript exceptions or benchmark hypotheses. New invariants receive codes when their
 behavior and remediation are implemented and reviewed.
 
 The generated [diagnostic reference](/errors/) lists the current catalog directly

--- a/scripts/diagnostics/catalog.mjs
+++ b/scripts/diagnostics/catalog.mjs
@@ -235,8 +235,8 @@ function addRuntimeSourceErrors(runtimeSources, diagnosticsByCode, errors) {
           errors.push(`${path} must emit a literal diagnostic code`);
         } else if (!diagnostic) {
           errors.push(`${path} emits uncataloged diagnostic code ${code}`);
-        } else if (diagnostic.status === 'defined') {
-          errors.push(`${path} emits ${code}, but its catalog status is defined`);
+        } else if (['defined', 'retired'].includes(diagnostic.status)) {
+          errors.push(`${path} emits ${code}, but its catalog status is ${diagnostic.status}`);
         } else if (!diagnostic.surfaces.includes('runtime')) {
           errors.push(`${path} emits ${code}, but its catalog surfaces do not include runtime`);
         }
@@ -274,8 +274,8 @@ function addEslintRuleErrors(eslintRuleSources, diagnosticsByCode, errors) {
     const diagnostic = diagnosticsByCode.get(code);
     if (!diagnostic) {
       errors.push(`${path} maps to uncataloged diagnostic code ${code}`);
-    } else if (diagnostic.status === 'defined') {
-      errors.push(`${path} maps to ${code}, but its catalog status is defined`);
+    } else if (['defined', 'retired'].includes(diagnostic.status)) {
+      errors.push(`${path} maps to ${code}, but its catalog status is ${diagnostic.status}`);
     } else if (!diagnostic.surfaces.includes('lint')) {
       errors.push(`${path} maps to ${code}, but its catalog surfaces do not include lint`);
     }

--- a/scripts/docs/build.mjs
+++ b/scripts/docs/build.mjs
@@ -13,16 +13,16 @@ const docRoutes = new Map();
 const markdownRenderer = new Renderer();
 let packageVersion;
 
-function diagnosticIndex(diagnostics) {
-  const rows = diagnostics.map(({ code, slug, severity }) => {
-    return `| [${code}](/errors/${code}/) | ${slug} | ${severity} |`;
+export function diagnosticIndex(diagnostics) {
+  const rows = diagnostics.map(({ code, slug, severity, status }) => {
+    return `| [${code}](/errors/${code}/) | ${slug} | ${status} | ${severity} |`;
   });
 
   return [
     '## Catalog',
     '',
-    '| Code | Diagnostic | Severity |',
-    '| --- | --- | --- |',
+    '| Code | Diagnostic | Status | Severity |',
+    '| --- | --- | --- | --- |',
     ...rows,
   ].join('\n');
 }
@@ -30,6 +30,7 @@ function diagnosticIndex(diagnostics) {
 export function diagnosticPage(diagnostic) {
   const objects = diagnostic.objects.map(object => `\`${object}\``).join(', ');
   const surfaces = diagnostic.surfaces.map(surface => `\`${surface}\``).join(', ');
+  const historical = diagnostic.status === 'retired' ? ' (historical)' : '';
   const replacement = diagnostic.replacementCode ?
     `\n| Replacement | [${diagnostic.replacementCode}](/errors/${diagnostic.replacementCode}/) |` :
     '';
@@ -40,9 +41,9 @@ export function diagnosticPage(diagnostic) {
 | --- | --- |
 | Status | ${diagnostic.status} |
 | Category | ${diagnostic.category} |
-| Severity | ${diagnostic.severity} |
+| Severity | ${diagnostic.severity}${historical} |
 | Objects | ${objects} |
-| Surfaces | ${surfaces} |
+| Surfaces | ${surfaces}${historical} |
 | Benchmark category | ${diagnostic.benchmarkCategory} |${replacement}
 
 ## Remediation

--- a/test/unit/config/diagnostic-catalog.spec.js
+++ b/test/unit/config/diagnostic-catalog.spec.js
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -6,7 +6,7 @@ import {
   discoverProductionSources,
   validateDiagnosticCatalog,
 } from '../../../scripts/diagnostics/catalog.mjs';
-import { diagnosticPage } from '../../../scripts/docs/build.mjs';
+import { diagnosticIndex, diagnosticPage } from '../../../scripts/docs/build.mjs';
 
 describe('diagnostic catalog validation', function() {
   function createDiagnostic(overrides = {}) {
@@ -28,7 +28,7 @@ describe('diagnostic catalog validation', function() {
   function createCatalog(diagnostics = [createDiagnostic()]) {
     return {
       $schema: './catalog.schema.json',
-      schemaVersion: 1,
+      schemaVersion: 2,
       diagnostics,
     };
   }
@@ -75,6 +75,20 @@ describe('diagnostic catalog validation', function() {
     ]);
 
     expect(() => validate(catalog)).to.throw(DiagnosticCatalogValidationError, /duplicate diagnostic code MN0001/);
+  });
+
+  it('does not allow a retired slug to be reused by another code', function() {
+    const catalog = createCatalog([
+      createDiagnostic({ status: 'retired' }),
+      createDiagnostic({
+        code: 'MN0002',
+        docsAnchor: '/errors/MN0002/',
+        slug: 'unknown-region',
+      }),
+    ]);
+
+    expect(() => validate(catalog))
+      .to.throw(DiagnosticCatalogValidationError, 'duplicate diagnostic slug unknown-region');
   });
 
   it('requires diagnostics to be sorted by code', function() {
@@ -146,6 +160,22 @@ describe('diagnostic catalog validation', function() {
     const catalog = createCatalog([createDiagnostic({
       replacementCode: 'MN0002',
       status: 'active',
+    })]);
+
+    expect(() => validate(catalog))
+      .to.throw(DiagnosticCatalogValidationError, /replacementCode/);
+  });
+
+  it('accepts a retired diagnostic without a replacement', function() {
+    const catalog = createCatalog([createDiagnostic({ status: 'retired' })]);
+
+    expect(validate(catalog)).to.equal(catalog);
+  });
+
+  it('rejects a replacement on a retired diagnostic', function() {
+    const catalog = createCatalog([createDiagnostic({
+      replacementCode: 'MN0002',
+      status: 'retired',
     })]);
 
     expect(() => validate(catalog))
@@ -239,6 +269,20 @@ describe('diagnostic catalog validation', function() {
     })).to.throw(
       DiagnosticCatalogValidationError,
       'modules/example.js emits MN0001, but its catalog status is defined',
+    );
+  });
+
+  it('rejects runtime emissions for a retired diagnostic', function() {
+    const catalog = createCatalog([createDiagnostic({ status: 'retired' })]);
+
+    expect(() => validate(catalog, {
+      runtimeSources: [{
+        contents: 'throw new MarionetteError({ code: \'MN0001\' });',
+        path: 'modules/example.js',
+      }],
+    })).to.throw(
+      DiagnosticCatalogValidationError,
+      'modules/example.js emits MN0001, but its catalog status is retired',
     );
   });
 
@@ -359,6 +403,20 @@ describe('diagnostic catalog validation', function() {
     );
   });
 
+  it('rejects ESLint mappings for a retired diagnostic', function() {
+    const catalog = createCatalog([createDiagnostic({ status: 'retired' })]);
+
+    expect(() => validate(catalog, {
+      eslintRuleSources: [{
+        contents: 'export default { meta: { diagnosticCode: \'MN0001\' } };',
+        path: 'eslint-rules/example.js',
+      }],
+    })).to.throw(
+      DiagnosticCatalogValidationError,
+      'eslint-rules/example.js maps to MN0001, but its catalog status is retired',
+    );
+  });
+
   it('rejects ESLint metadata that can override the mapping', function() {
     const unsafeSources = [
       'export default { meta: { diagnosticCode: \'MN0001\', ...meta } };',
@@ -383,5 +441,59 @@ describe('diagnostic catalog validation', function() {
     }));
 
     expect(markdown).to.contain('| Replacement | [MN0002](/errors/MN0002/) |');
+  });
+
+  it('renders a retired diagnostic as historical guidance', function() {
+    const markdown = diagnosticPage(createDiagnostic({
+      remediation: 'The retired operation is now a lifecycle-safe no-op.',
+      status: 'retired',
+    }));
+
+    expect(markdown).to.contain('| Status | retired |');
+    expect(markdown).to.contain('| Severity | error (historical) |');
+    expect(markdown).to.contain('| Surfaces | `lint`, `runtime`, `test` (historical) |');
+    expect(markdown).to.contain('The retired operation is now a lifecycle-safe no-op.');
+  });
+
+  it('distinguishes retired diagnostics in the catalog index', function() {
+    const markdown = diagnosticIndex([
+      createDiagnostic(),
+      createDiagnostic({
+        code: 'MN0002',
+        docsAnchor: '/errors/MN0002/',
+        slug: 'retired-operation',
+        status: 'retired',
+      }),
+    ]);
+
+    expect(markdown).to.contain('| Code | Diagnostic | Status | Severity |');
+    expect(markdown).to.contain('| [MN0002](/errors/MN0002/) | retired-operation | retired | error |');
+  });
+
+  it('reserves the retired MN0028 and MN0029 identities', async function() {
+    const catalog = JSON.parse(await readFile(
+      join(process.cwd(), 'config/diagnostics/catalog.json'),
+      'utf8',
+    ));
+    const retired = catalog.diagnostics.filter(({ status }) => status === 'retired');
+
+    expect(retired.map(({ code, slug }) => ({ code, slug }))).to.deep.equal([
+      { code: 'MN0028', slug: 'region-destroyed-operation' },
+      { code: 'MN0029', slug: 'view-destroyed-set-element' },
+    ]);
+    expect(retired.map(({ severity, surfaces }) => ({ severity, surfaces }))).to.deep.equal([
+      { severity: 'error', surfaces: ['runtime'] },
+      { severity: 'error', surfaces: ['runtime'] },
+    ]);
+
+    expect(() => validate(catalog, {
+      runtimeSources: [{
+        contents: 'throw new MarionetteError({ code: \'MN0028\' });',
+        path: 'modules/region.js',
+      }],
+    })).to.throw(
+      DiagnosticCatalogValidationError,
+      'modules/region.js emits MN0028, but its catalog status is retired',
+    );
   });
 });


### PR DESCRIPTION
Related #147

## What
- add a `retired` diagnostic status and bump the internal catalog schema to version 2
- restore MN0028 and MN0029 as permanently reserved historical identities without restoring their runtime throws
- reject retired runtime/lint mappings and keep generated reference routes with clearly historical severity and surface labels

## Why
MN0028 and MN0029 reached merged public master before their strict lifecycle errors were replaced with lifecycle-safe no-ops. Deleting them left their published identities available for accidental reuse despite the catalog policy prohibiting deletion and reuse. `retired` is distinct from `deprecated`: it is never emitted and has no replacement.

The original severity and surfaces remain stored as historical classification; `status` is authoritative and the docs mark those values as historical for display. The permanent routes avoid dead references to the former identities. Schema version 2 explicitly signals the new enum value.

## Scope
- diagnostic catalog schema, validation, and generated reference pages
- diagnostic policy documentation and focused validator/docs tests
- no production runtime, package entrypoint, lifecycle behavior, or distribution changes
- app-frontend and marionette.toolkit were audited and do not consume Marionette diagnostic codes or numbering

## Deployment Impact
No application or form redeploy is required. This PR does not publish documentation, npm artifacts, tags, releases, or deployment refs.

## Testing
- `npm run coverage` — 93 files, 1,695 tests, 100% statements/branches/functions/lines, 19/19 agent benchmark contract tests
- `npm run check:diagnostics` — 29 catalog entries
- `npm run docs:check` — 41 pages, 42 HTML files, 386 internal links
- `npm run lint:ci`
- `git diff --check`

Test-first evidence: focused tests initially failed because `retired` was not schema-valid and MN0028/MN0029 were absent. The final focused catalog suite passes 36 tests, including generic retired runtime/lint rejection, exact MN0028 reintroduction rejection, no retired slug reuse, preserved raw historical values, and generated historical labels.

Claude review challenged the status, schema-version, and historical-field decisions. The implementation now explicitly distinguishes retirement from deprecation, bumps the schema version, preserves raw classification values, labels them only at render time, and adds regression coverage. The follow-up review conditionally approved the direction; its two requested gaps are covered by the existing synthetic retired tests plus the added raw-value assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `retired` diagnostic status so MN0028 and MN0029 keep their published identities without being reusable. Previously, deleting those lifecycle errors left their codes open to accidental reuse; now they stay cataloged permanently and cannot be emitted or mapped.

- Bumps the catalog schema to version 2 to add the new enum value.
- `check:diagnostics` rejects retired runtime emissions and lint mappings.
- Generated reference pages label retired severity and surfaces as historical.
- No production runtime, package, or distribution changes, so no redeploy is needed.

<sup>Written for commit 85f68ff57294bf8e52e294f4de5871408920bf7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

