### PR TITLE
docs(application): use the v5 package name

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -29,7 +29,7 @@ that will be attached directly to the instance:
 `channelName`, `radioEvents`, `radioRequests`, `region`, `regionClass`
 
 ```javascript
-import { Application } from 'backbone.marionette';
+import { Application } from 'marionette';
 
 const myApplication = new Application({ ... });
 ```
@@ -43,7 +43,7 @@ This function takes a single optional argument to pass along to the events.
 
 ```javascript
 import Bb from 'backbone';
-import { Application } from 'backbone.marionette';
+import { Application } from 'marionette';
 
 const MyApp = Application.extend({
   region: '#root-element',
@@ -80,7 +80,7 @@ An `Application` provides a single [region](./marionette.region.md) for attachin
 The `region` property can be [defined in multiple ways](./marionette.region.md#defining-regions)
 
 ```javascript
-import { Application } from 'backbone.marionette';
+import { Application } from 'marionette';
 import RootView from './views/root';
 
 const MyApp = Application.extend({
@@ -109,7 +109,7 @@ By default the [`Region`](./marionette.region.md) is used to instantiate the `Ap
 An extended Region can be provided to the `Application` definition to override the default.
 
 ```javascript
-import { Application, Region } from 'backbone.marionette';
+import { Application, Region } from 'marionette';
 
 const MyRegion = Region.extend({
   isSpecial: true


### PR DESCRIPTION
Related #147

## What
- Update every Application reference example to import named exports from the v5 `marionette` package.

## Why
- The Application page still taught the retired v3/v4 `backbone.marionette` package name even though v5 publishes `marionette`.
- This is a page-scoped package correction; it does not change Application behavior.

## Scope
- Documentation only: `docs/marionette.application.md`.
- No runtime, compatibility, lifecycle, or public-API behavior changes.
- Adjacent example defects and broader documentation modernization remain separate #147 slices.

## Deployment Impact
- No application or package deployment is required.
- The documentation site would include the corrected imports in its next normal publication; this PR does not publish it.

## Testing
- `npm run docs:check`
- `npm run lint:ci`
- `git diff --check`

The documentation checks validate the site build, links, and marked executable examples. These particular unmarked snippets are not executed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Application documentation to import from the v5 `marionette` package instead of the retired `backbone.marionette` package. This is a docs-only change with no effect on runtime behavior.

<sup>Written for commit 124dbc3d8faaf293f1e33abf235260d2a9c6cfa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

