### PR TITLE
docs(behavior): make examples native v5

### DIFF
--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -13,7 +13,7 @@ allowing you to share common user-facing operations between your views.
 collection interactions to be utilized across your application. Unlike the other
 Marionette classes, `Behavior`s are not meant to be instantiated directly.
 Instead a `Behavior` should be instantiated by the view it is related to by
-[attaching the a behavior class definition to the view](#using-behaviors).
+[attaching a behavior class definition to the view](#using-behaviors).
 
 ## Documentation Index
 
@@ -44,9 +44,13 @@ The easiest way to see how to use the `Behavior` class is to take an example
 view and factor out common behavior to be shared across other views.
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
+  template() {
+    return '<button class="destroy-btn" type="button">Destroy</button>';
+  },
+
   ui: {
     destroy: '.destroy-btn'
   },
@@ -61,14 +65,10 @@ const MyView = View.extend({
   },
 
   onRender() {
-    this.ui.destroy.tooltip({
-      text: 'What a nice mouse you have.'
-    });
+    this.getUI('destroy')[0].title = 'What a nice mouse you have.';
   }
 });
 ```
-
-[Live example](https://jsfiddle.net/marionettejs/pa8ryv03/)
 
 Interaction points, such as tooltips and warning messages, are generic concepts.
 There is no need to recode them within your Views so they are prime candidates
@@ -76,8 +76,9 @@ to be extracted into `Behavior` classes.
 
 ### Defining and Attaching Behaviors
 
+<!-- executable-example: behavior-defining-attaching -->
 ```javascript
-import { Behavior, View } from 'backbone.marionette';
+import { Behavior, View } from 'marionette';
 
 const DestroyWarn = Behavior.extend({
   // You can set default options
@@ -90,7 +91,7 @@ const DestroyWarn = Behavior.extend({
     destroy: '.destroy-btn'
   },
 
-  // Behaviors have events that are bound to the views DOM.
+  // Behaviors have events that are bound to the view's DOM.
   events: {
     'click @ui.destroy': 'warnBeforeDestroy'
   },
@@ -114,18 +115,21 @@ const ToolTip = Behavior.extend({
   },
 
   onRender() {
-    this.ui.tooltip.tooltip({
-      text: this.getOption('text')
-    });
+    this.getUI('tooltip')[0].title = this.getOption('text');
   }
 });
 
-const MyView = View.extend({
+export const MyView = View.extend({
+  template() {
+    return [
+      '<button class="destroy-btn" type="button">Destroy</button>',
+      '<span class="tooltip">More information</span>'
+    ].join('');
+  },
+
   behaviors: [DestroyWarn, ToolTip]
 });
 ```
-
-[Live example](https://jsfiddle.net/marionettejs/b1awta6u/)
 
 Each behavior will now be able to respond to user interactions as though the
 event handlers were attached to the view directly. In addition to using array
@@ -166,8 +170,6 @@ const MyView = View.extend({
   ]
 });
 ```
-
-[Live example](https://jsfiddle.net/marionettejs/vq9k3c69/)
 
 There are several properties, if passed, that will be attached directly to the instance:
 `collectionEvents`, `events`, `modelEvents`, `triggers`, `ui`
@@ -244,7 +246,7 @@ In addition to extending a `View` with `Behavior`, a `Behavior` can itself use
 other Behaviors. The syntax is identical to that used for a `View`:
 
 ```javascript
-import { Behavior } from 'backbone.marionette';
+import { Behavior } from 'marionette';
 
 const Modal = Behavior.extend({
   behaviors: [
@@ -256,8 +258,6 @@ const Modal = Behavior.extend({
 });
 ```
 
-[Live example](https://jsfiddle.net/marionettejs/7ffnqff3/)
-
 Nesting groups Behavior declarations; it does not transfer cleanup ownership to
 the declaring Behavior. Nested Behaviors act as direct Behaviors of the same host
 view, so destroying the declarer leaves them active until they are removed
@@ -267,7 +267,7 @@ directly or the host is destroyed.
 The `view` is a reference to the `View` instance that the `Behavior` is attached to.
 
 ```javascript
-import { Behavior } from 'backbone.marionette';
+import { Behavior } from 'marionette';
 
 Behavior.extend({
   handleDestroyClick() {
@@ -275,8 +275,6 @@ Behavior.extend({
   }
 });
 ```
-
-[Live example](https://jsfiddle.net/marionettejs/p8vymo4j/)
 
 ## Host Communication and Event Proxies
 
@@ -370,7 +368,7 @@ including:
 * [`collectionEvents`](./events.entity.md#collection-events)
 
 ```javascript
-import { Behavior } from 'backbone.marionette';
+import { Behavior } from 'marionette';
 
 Behavior.extend({
   events: {
@@ -415,10 +413,10 @@ This means that the behavior can access the view during its own `initialize` met
 It can also access state established by the View's `preinitialize` method.
 Callable `events` and `triggers` may use state established by that method before
 the View initializes.
-The view `initialize` is called later with the information eventually injected by the behavior.
+The View's `initialize` is called later with its original constructor arguments.
+It can observe Behavior-driven state only when a Behavior explicitly sets that
+state or calls a host method; Marionette does not inject Behavior information.
 The `initialize` event is triggered on the behavior indicating that the view is fully initialized.
-
-[Live example](https://jsfiddle.net/marionettejs/qb9go1y3/)
 
 #### Using `ui`
 
@@ -427,7 +425,7 @@ listeners. For more details, see the [`ui` documentation](./dom.interactions.md#
 These can be defined on either the Behavior or the View:
 
 ```javascript
-import { Behavior } from 'backbone.marionette';
+import { Behavior } from 'marionette';
 
 const MyBehavior = Behavior.extend({
   ui: {
@@ -451,8 +449,6 @@ const MyBehavior = Behavior.extend({
   }
 });
 ```
-
-[Live example](https://jsfiddle.net/marionettejs/6b8o3pmz/)
 
 ### UI resolution and binding
 
@@ -552,7 +548,7 @@ does not need to retarget the Behavior separately.
 Each Behavior can also reference its host through the `view` attribute:
 
 ```javascript
-import { Behavior } from 'backbone.marionette';
+import { Behavior } from 'marionette';
 
 const ViewBehavior = Behavior.extend({
   onRender() {

--- a/test/fixtures/docs-behavior-host/validate.mjs
+++ b/test/fixtures/docs-behavior-host/validate.mjs
@@ -11,6 +11,10 @@ const markdown = await readFile(docsPath, 'utf8');
 const distDir = resolve(__dirname, 'dist');
 const examples = [
   {
+    marker: '<!-- executable-example: behavior-defining-attaching -->',
+    path: resolve(distDir, 'defining-attaching.mjs'),
+  },
+  {
     marker: '<!-- executable-example: behavior-host-communication -->',
     path: resolve(distDir, 'host-communication.mjs'),
   },
@@ -46,6 +50,7 @@ const dom = new JSDOM(`<!doctype html>
       <button class="save" id="outside-save" type="button">Outside</button>
       <button class="btn-primary" id="outside-primary" type="button">Outside primary</button>
       <main id="communication-host"></main>
+      <main id="defining-host"></main>
       <main id="ui-host"></main>
       <main id="selection-host"></main>
     </body>
@@ -56,10 +61,44 @@ globalThis.document = dom.window.document;
 
 try {
   const [
+    { MyView: DefiningView },
     { FormView: CommunicationView },
     { FormView: UiResolutionView },
     { SelectionView },
   ] = await Promise.all(examples.map(example => import(pathToFileURL(example.path))));
+
+  {
+    const view = new DefiningView();
+
+    view.render();
+    document.querySelector('#defining-host').append(view.el);
+
+    const destroyButton = view.el.querySelector('.destroy-btn');
+    const tooltip = view.el.querySelector('.tooltip');
+
+    assert.ok(destroyButton, 'the defining example must render the Behavior event target');
+    assert.ok(tooltip, 'the defining example must render the Behavior UI target');
+    assert.equal(
+      tooltip.title,
+      'Tooltip text',
+      'the Behavior must set the native title through its bound UI element',
+    );
+
+    const messages = [];
+    const originalAlert = window.alert;
+    window.alert = message => messages.push(message);
+
+    try {
+      destroyButton.click();
+      assert.deepEqual(messages, ['You are destroying!']);
+      assert.equal(view.isDestroyed(), true, 'the Behavior event must destroy its host View');
+    } finally {
+      window.alert = originalAlert;
+      if (!view.isDestroyed()) {
+        view.destroy();
+      }
+    }
+  }
 
   {
     const view = new CommunicationView();

--- a/test/unit/behavior-lifecycle.spec.js
+++ b/test/unit/behavior-lifecycle.spec.js
@@ -40,6 +40,32 @@ describe('Behavior lifecycle contract', function() {
     view.destroy();
   });
 
+  it('keeps host constructor arguments separate from explicit Behavior state', function() {
+    const options = { source: 'options' };
+    const extra = { source: 'extra' };
+    const initialize = this.sinon.spy(function(receivedOptions, receivedExtra) {
+      expect(this.behaviorState).to.equal('set explicitly');
+      expect(receivedOptions).to.equal(options);
+      expect(receivedExtra).to.equal(extra);
+    });
+    const TestBehavior = Behavior.extend({
+      initialize(behaviorOptions, hostView) {
+        expect(behaviorOptions).to.deep.equal({});
+        hostView.behaviorState = 'set explicitly';
+      },
+    });
+    const TestView = View.extend({
+      behaviors: [TestBehavior],
+      initialize,
+    });
+
+    const view = new TestView(options, extra);
+
+    expect(initialize).to.have.been.calledOnce.and.calledWithExactly(options, extra);
+
+    view.destroy();
+  });
+
   describe.each([
     ['View', View],
     ['CollectionView', CollectionView],


### PR DESCRIPTION
Related #147

## What

- Replace retired `backbone.marionette` imports and incidental jQuery tooltip calls in the Behavior reference with the canonical `marionette` package and native DOM behavior.
- Remove unowned v4-era JSFiddle links and clarify the View/Behavior initialization boundary.
- Execute the defining/attaching example in the existing packed-package fixture and pin its click, destroy, native UI, and constructor-argument contracts.

## Why

The page mixed recently reconciled v5 Behavior contracts with examples inherited from the jQuery-first v3/v4 environment. Those examples made a third-party `.tooltip()` plugin and the retired package name look like Marionette v5 APIs. The updated examples keep the historical intent—reusable warning and tooltip behavior—without locking core Behavior UI to the optional jQuery adapter.

## Scope

- Behavior reference documentation and its existing executable fixture.
- One focused lifecycle contract test for explicit Behavior state versus unchanged host constructor arguments.
- No runtime implementation, jQuery adapter, public alias, fallback path, site manifest, or unrelated documentation changes.

## Deployment Impact

No application redeploy is required. The normal documentation pipeline validates the change, but this PR does not publish the website, package, tag, or release.

## Testing

- `npx vitest run test/unit/behavior-dom-delegation-contract.spec.js test/unit/behavior-lifecycle.spec.js test/unit/behavior.spec.js test/unit/behavior-dependencies-contract.spec.js test/unit/behavior-composition.spec.js test/unit/mixins/behaviors-composition.spec.js test/unit/mixins/behaviors.spec.js test/unit/behavior-ui-contract.spec.js test/unit/behavior-communication-contract.spec.js --reporter=dot` — 9 files, 130 tests passed.
- `npm run test:fixtures` — all packed-package fixtures passed, including the revised Behavior docs example.
- `npm run docs:check` — 10 executable examples, 41 pages built, 42 HTML files and 386 internal links validated.
- `npm run lint:ci`
- `git diff --check`
- Stale-pattern scan confirmed no retired package imports, `.tooltip()` calls, JSFiddle links, or corrected phrases remain in `docs/marionette.behavior.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Behavior reference examples to use native Marionette v5 APIs instead of the retired `backbone.marionette` package and the jQuery `.tooltip()` plugin.

- Replaces remaining `backbone.marionette` imports and jQuery tooltip calls with `marionette` and native DOM `title` assignment.
- Removes v4-era JSFiddle links and clarifies that Marionette does not inject Behavior state into the View's constructor arguments.
- Adds the defining/attaching example as an executable fixture covering click, destroy, native UI, and options behavior.
- Adds a lifecycle test confirming Behavior state is set explicitly and host constructor arguments pass through unchanged.

<sup>Written for commit 70aa9cad36e690a9ed54ed3c020f58510acdbcde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Behavior API examples to use current import paths and native DOM updates.
  * Clarified View and Behavior initialization order and constructor argument handling.
  * Added an executable example demonstrating collaborator injection and option access.
  * Removed outdated live-example links and expanded behavior attachment guidance.

* **Tests**
  * Added coverage for executable documentation examples, rendering, tooltips, destruction, and alerts.
  * Verified View constructor arguments are preserved while Behavior initialization receives the expected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->