### PR TITLE
docs(view): reconcile the v5 lifecycle contract

### DIFF
--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -1,7 +1,7 @@
 # View Lifecycle
 
 Both [`View` and `CollectionView`](./classes.md) are aware of their lifecycle state
-which indicates if the view is rendered, attached to the DOM or destroyed.
+which indicates whether the View is rendered, attached, or destroyed.
 
 ## Documentation Index
 
@@ -19,7 +19,7 @@ which indicates if the view is rendered, attached to the DOM or destroyed.
 * [Attaching a View](#attaching-a-view)
 * [Detaching a View](#detaching-a-view)
 * [Destroying a View](#destroying-a-view)
-* [Destroying Children](#rendering-children)
+* [Destroying Children](#destroying-children)
 
 ## Lifecycle State Methods
 
@@ -57,49 +57,63 @@ following observable transitions:
 
 | Operation | Result | Repeated call |
 | --- | --- | --- |
-| `view.render()` with a renderable template while alive | Rendered becomes `true`; attachment is unchanged | Renders again and runs the render lifecycle again |
+| `View#render()` with a template function while alive | Runs `before:render` and `render`; rendered becomes `true`; attachment is unchanged | Renders again and runs the render lifecycle again |
+| `View#render()` with `template: false` while alive | Returns the View without running the render lifecycle or changing contents or state | Repeated calls are the same no-op |
+| `CollectionView#render()` while alive | Runs `before:render` and `render`, rebuilds its children, and becomes rendered; attachment is unchanged | Rebuilds the children and runs the render lifecycle again |
 | `View#setElement(el)` while alive | Rendered reflects whether the replacement element has contents; attached reflects whether it is in the document | Recomputes the same state from the current element |
+| `CollectionView#setElement(el)` while alive | Rendered is preserved; attached reflects whether the replacement element is in the document | Preserves rendered and recomputes attached from the current element |
 | `region.show(view)` | Ensures the view is rendered; attached becomes `true` only when the Region is in the document | Showing the current view is a no-op |
 | `region.detachView()` | Rendered stays `true`; attached becomes `false`; destroyed stays `false` | Returns `undefined` with no transition |
 | Re-show a detached view | Rendered stays `true`; attachment reflects the Region | Does not render the view again |
 | `region.empty()` or `view.destroy()` | Rendered and attached become `false`; destroyed becomes `true` | Repeated destroy is a no-op |
 | `view.render()` after destruction | Returns the same View with rendered and attached `false` and destroyed `true` | Repeated calls are no-ops |
 | `view.setElement(el)` once destruction begins | Returns the same View before inspecting or replacing the element or changing delegation, DOM, or lifecycle state | Calls during `before:destroy` and repeated calls after destruction are no-ops |
+| `CollectionView#addChildView(view, ...)` once destruction begins | Returns the supplied child before inspecting or taking ownership of it; the caller remains responsible for that child | Repeated calls are no-ops for the destroyed CollectionView |
+| `view.delegateEvents()` or `view.undelegateEvents()` once destruction begins | Returns the same View without changing View or Behavior DOM delegation | Repeated calls are no-ops |
 
 Setting `monitorViewEvents: false` on a Region's owning view intentionally disables
 attachment events and automatic `isAttached()` updates for the shown view.
 
-This table specifies the normal managed lifecycle. Other operations on an already
-destroyed View remain outside this contract until their invalid-transition behavior
-is made consistent.
+This table specifies the managed and terminal operations listed above. Do not
+infer behavior for other calls on a destroyed View; custom overrides also own
+their behavior unless they delegate to a guarded base method.
 
 ## Instantiating a View
 
-Marionette Views are Backbone Views and so when they are instantiated the view
-has an `el`. That `el` will be the root node for the view and other than its contents it
-will not change for the life of the view unless directly manipulated (ie: `view.$el.addClass`)
+Every Marionette `View` and `CollectionView` has a native DOM element in `el`.
+Pass an existing element with `el: document.querySelector('.foo-selector')`, or
+create one first with `document.createElement()`. Selector strings and jQuery
+collections are not valid View `el` values.
 
-The view can be passed an existing `el` either in the DOM (ie: `el: $('.foo-selector')`)
-or in memory (ie: `el: $('<div></div>')`) or most commonly, the view constructs
-its own `el` at instantiation as [documented on backbonejs.org](http://backbonejs.org/#View-el).
+When `el` is omitted, Marionette creates the root element from `tagName` (a
+`div` by default) and applies the resolved `id`, `className`, and `attributes`.
+The element remains the View's root until application code explicitly replaces
+it with [`setElement()`](#using-setelement). Native core does not create `$el`;
+applications that require that compatibility surface can opt into the
+[jQuery DOM adapter](./dom.api.md#optional-jquery-adapter).
 
-Marionette will determine the initial state of the view as to whether the view is considered
-already [rendered](#rendering-a-view) or [attached](#attaching-a-view). If a view is already
-rendered or attached its [state](#lifecycle-state-methods) will reflect that status, but the
+Marionette determines whether the initial root is already
+[rendered](#rendering-a-view) or [attached](#attaching-a-view). If a View starts
+rendered or attached, its [state](#lifecycle-state-methods) reflects that status, but the
 [related events](./events.class.md#dom-change-events) will not have fired.
 
-For more information on instanting a view with pre-rendered DOM see: [Prerendered Content](./dom.prerendered.md).
+For more information on instantiating a view with pre-rendered DOM, see
+[Pre-rendered Content](./dom.prerendered.md).
 
 ### Using `setElement`
 
-`Backbone.View` allows the user to change the view's `el` after instantiaton using
-[`setElement`](http://backbonejs.org/#View-setElement). This method can be used in Marionette
-as well, but should be done with caution. While the View is alive, `setElement` recomputes
-`isRendered()` from the replacement element's contents and `isAttached()` from whether that
-element is in the document. Repeating the call with the same element recomputes the same state.
-View and Behavior DOM events are redelegated to the replacement element, but existing managed
-children and Region contents are not moved. It is usually better to reconstruct a new View with
-the new `el` than to change the `el` of an existing View with managed children.
+While a `View` is alive, `setElement()` replaces its root with a native DOM
+element, recomputes `isRendered()` from the replacement element's contents, and
+recomputes `isAttached()` from whether that element is in the document. A
+`CollectionView` instead preserves its current rendered state and recomputes
+only attachment from the replacement element.
+
+Both classes remove their existing View and Behavior DOM delegation and delegate
+it once against the replacement element. They preserve Region and child-view
+ownership, but do not move any owned child's DOM from the old root to the new
+one. A child can therefore remain physically under the old root with its prior
+lifecycle state. Prefer constructing a new owner when existing children would
+otherwise need to be moved or reconciled manually.
 
 Calling the base `View#setElement` or `CollectionView#setElement` once destruction begins
 returns the same instance before inspecting the supplied element or changing delegation,
@@ -117,116 +131,87 @@ rendered it cannot become unrendered until it is [destroyed](#destroying-a-view)
 
 ### `View` Rendering
 
-For [`View`](./marionette.view.md), rendering entails serializing the view's data, passing it to a template,
-and taking the results of that template and replacing the contents of the view's `el`. So when a `View` is
-instantiated it is considered rendered if the `el` node contains any content. However after instantiation
-a template may render empty in which case the `View` will still be considered "rendered" even though it
-contains no content.
+For [`View`](./marionette.view.md), rendering with a template function runs the
+`before:render` lifecycle, serializes the View's data, passes it to the template,
+places the result in `el`, binds UI, marks the View rendered, and then runs the
+`render` lifecycle. A newly constructed `View` is already considered rendered if
+its initial `el` contains content. A later template may produce empty content;
+the completed render still leaves the View rendered.
+
+`template: false` is different from a template that returns an empty value.
+Calling `View#render()` with `template: false` returns the View without running
+the render lifecycle, changing the DOM, or changing its rendered state.
 
 ### `CollectionView` Rendering
 
-For [`CollectionView`](./marionette.collectionview.md), rendering signifies that the view's
-[`children`](./marionette.collectionview.md#collectionviews-children) were created and attached to the
-view's `el`. So unlike `View` a `CollectionView` can be instantiated with content in its `el`, but until
-the `children` are "rendered" the entire view is not considered rendered.
+For [`CollectionView`](./marionette.collectionview.md), every live `render()` is
+bracketed by `before:render` and `render`. After it completes, collection-backed
+children have been rebuilt, the optional template and visible children have
+been rendered, and the CollectionView is rendered. Any children the
+CollectionView owned before that render have been destroyed.
 
-Notably if there are no `children` when rendering, the view will still be considered rendered. This is
-true whether or not an [`emptyView`](./marionette.collectionview.md#collectionviews-emptyview) is rendered.
-So it is possible for a `CollectionView` to be "rendered" but the `el` to only be an empty tag.
-Also note that just like `View` a `CollectionView` may have a `template` which is rendered and attached to
-the `el` during the `render`, but the template rendering itself has no bearing on the status of the `CollectionView`.
+Inserting a child element into the CollectionView is not itself an attachment
+transition. When the CollectionView is monitored as attached, rendering marks
+and notifies the inserted children as attached; when the parent is detached or
+child lifecycle monitoring is disabled, their monitored attachment state remains
+detached even though their elements are inside the parent element.
+
+A CollectionView with no children is still rendered, with or without an
+[`emptyView`](./marionette.collectionview.md#collectionviews-emptyview). Its own
+template controls the container markup but does not determine rendered state.
 
 ## Rendering Children
 
-Rendering child views is often best accomplish after the view render as typically the first render happens prior to
-the view entering the DOM. This helps to prevent unnecessary repaints and reflows by making the DOM insert at the
-highest possible view in the view tree.
+Rendering child views is often best accomplished after the View renders, as the first render typically happens before
+the View enters the DOM. This helps to prevent unnecessary repaints and reflows by making the DOM insertion at the
+highest practical View in the view tree.
 
-The exception is views with [prerendered content](./dom.prerendered.md). In the case that the view is instantiated
-rendered, child views are best managed in the view's [`initialize`](./common.md#initialize).
+The exception is Views with [pre-rendered content](./dom.prerendered.md). When a View is instantiated
+rendered, child Views are best managed in the View's [`initialize`](./common.md#initialize).
 
 ### `View` Children
 
 In general the best method for adding a child view to a `View` is to use [`showChildView`](./marionette.view.md#showing-a-view)
 in the [`render` event](./events.class.md#render-and-beforerender-events).
 
-View regions will be emptied on each render so views shown outside of the `render` event will still need be reshown
+View Regions are emptied on each render, so Views shown outside of the `render` event still need to be shown again
 on subsequent renders.
 
 ### `CollectionView` Children
 
-The primary use case for a `CollectionView` is maintaining child views to match the state of a Backbone Collection.
-By default children will be added or removed to match the models within the collection.
-However a `CollectionView` can have children in addition to, or instead of, views matching the `collection`.
+The primary use case for a `CollectionView` is maintaining collection-backed
+child Views. Marionette creates and removes those children as the collection
+changes.
 
-#### Adding managed children
+`addChildView()` can also add a child that is independent of the collection,
+but that child is not unmanaged. The CollectionView owns it, includes it in its
+child containers, and may sort or filter it. Rendering, collection reset, or
+CollectionView destruction destroys every child that is still owned, including
+manually added children. `detachChildView()` is the explicit operation that
+removes a child from ownership without destroying it and transfers cleanup
+responsibility to the caller.
 
-If you add a view to a `CollectionView`s children by default it will treat it as any other view added from the `collection`.
-This means it is subject to the [`viewComparator`](./marionette.collectionview.md#defining-the-viewcomparator) and
-[`viewFilter`](./marionette.collectionview.md#defining-the-viewfilter).
-
-So if you are accounting for added views in your `viewFilter` and `viewComparator` the best place to add these children is
-likely in the [`render` event](./events.class.md#render-and-beforerender-events) as the views will only be added once
-(or re-added if the children are rebuilt in a subsequent `render`) and managed in the sort or filter as the `collection` is updated.
-
-#### Adding unmanaged children
-
-Unlike managed children there may be cases where you want to insert views to the results of the `CollectionView` after the
-`collection` changes, or after sorting and/or filtering. In these cases the solution might depend slightly on the features
-used on the `CollectionView`.
-
-The goal will be to add the unmanaged views after other views are added and to remove any unmanaged views prior to any
-managed `children` changes. To do so you must understand which [`CollectionView` event](./events.class.md#collectionview-events)
-will occur prior to changes to the `children` for your particular use case. By default a `CollectionView` sorts according
-to the `collection` sort, so unless `viewComparator` is disabled, the best event for removing unmanaged views is the
-[`before:sort` event](./events.class.md#sort-and-beforesort-events), but if `viewComparator` is false the next event
-to consider is the [`before:filter` event](./events.class.md#filter-and-beforefilter-events) if your `CollectionView` has
-a `viewFilter`, otherwise the [`before:render:children` event](./events.class.md#renderchildren-and-beforerenderchildren-events)
-is ideal.
-
-Once you have determined the best strategy for removing your unmanaged child views, adding them is best handled in the
-[`render:children` event](./events.class.md#renderchildren-and-beforerenderchildren-events). Additionally adding a child
-with `addChildView` will itself cause these events to occur, so to prevent stack overflows, it is best to use a flag to guard
-the adds and to insert a new view at a specified index.
-
-The following simplistic example will add an unmanaged view at the 5th index and remove it prior to any changes to the `children`.
-In a real world scenario it will likely be more complicated to keep track of which view to remove in the `onBeforeSort`.
-
-```javascript
-import { CollectionView } from 'backbone.marionette';
-
-const MyCollectionView = CollectionView.extend({
-  childView: MyChildView,
-  onBeforeSort() {
-    this.removeChildView(this.children.findByIndex(5));
-  },
-  onRenderChildren() {
-    this.addFooView();
-  },
-  addFooView() {
-    if (this.addingFooView) {
-      return;
-    }
-
-    this.addingFooView = true;
-    this.addChildView(new FooView(), 5);
-    this.addingFooView = false;
-  }
-});
-```
+See [Self-Managed `children`](./marionette.collectionview.md#self-managed-children)
+for the supported add, remove, detach, sorting, and filtering contracts.
 
 ## Attaching a View
 
-In Marionette a view is attached if the view's `el` can be found in the DOM.
-The best time to add listeners to the view's `el` is likely in the [`attach` event](./events.class.md#attach-and-beforeattach-events).
+`isAttached()` is Marionette's monitored lifecycle state, not a live query of
+the physical DOM on every call. Construction and `setElement()` initialize it
+from the current root element, and Marionette-managed Region and CollectionView
+operations update it while attachment monitoring is enabled.
+The [`attach` event](./events.class.md#attach-and-beforeattach-events) is the
+appropriate place to add listeners to the root `el`. Render can replace the
+contents while that root remains attached; use
+[`dom:refresh`](./events.class.md#domrefresh-event) for listeners tied to those
+rendered descendants.
 
-While the `el` of the view can be attached the contents of the view can be removed and added to
-during the lifetime of the view. If you are adding listeners to the contents of the view rather than
-`attach` the [`dom:refresh` event](./events.class.md#domrefresh-event) would be best.
-
-The attached state is maintained when attaching a view with a `Region` or as a child of a `CollectionView`
-or during [view instantiation](#instantiating-a-view).
-If a view is attached by other means like `$.append` [`isAttached`] may not reflect the actual state of attachment.
+Moving `view.el` directly with native DOM APIs, such as
+`document.body.append(view.el)`, changes its physical location without running
+Marionette attachment lifecycles or updating `isAttached()`. The same caveat
+applies when application code directly removes or moves an attached root.
+Prefer a Region or CollectionView for managed transitions; if application code
+moves the element directly, it owns the resulting lifecycle mismatch.
 
 A child shown in a rendered but detached parent View's Region is rendered and remains
 detached. When the parent is later shown in an attached Region, attachment propagates
@@ -236,12 +221,13 @@ attachment lifecycles.
 
 ## Detaching a View
 
-A view is detached when its `el` is removed from the DOM.
-The best time to clean up any listeners added to the `el` is in the [`before:detach` event](./events.class.md#detach-and-beforedetach-events).
-
-While the `el` of the view may remain attached, its contents will be removed on render.
-If you have added listeners to the contents of the view rather than `before:detach` the
-[`dom:remove` event](./events.class.md#domremove-event) would be best.
+A managed View becomes detached when Marionette removes its `el` from the DOM
+and updates its monitored attachment state.
+Use the [`before:detach` event](./events.class.md#detach-and-beforedetach-events)
+to clean up listeners added to the root `el`. Render can replace descendants
+while the root remains attached; use
+[`dom:remove`](./events.class.md#domremove-event) to clean up listeners tied to
+those rendered descendants.
 
 Detaching a parent View propagates detachment to its managed Region children while
 preserving their rendered state and ownership. Re-showing that parent attaches the same
@@ -250,26 +236,48 @@ and its still-managed children once.
 
 ## Destroying a View
 
-Destroying a view (ie: `myView.destroy()`) cleans up anything constucted within Marionette so that if
-a view's instance is no longer referenced the view can be cleaned up by the browser's garbage collector.
+Destroying a View (for example, `myView.destroy()`) removes Marionette-owned
+resources: delegated View and Behavior DOM handlers, bound UI, outgoing
+`listenTo()` subscriptions, entity-event bookkeeping, Behaviors, Regions and
+their current Views, and CollectionView children that remain owned. It detaches
+the root element and leaves the View rendered `false`, attached `false`, and
+destroyed `true` after successful teardown.
+
+Destroy does not remove callbacks registered directly on the View with `on()`,
+destroy its model, collection, or arbitrary option collaborators, or clean up
+application resources Marionette does not own. Release those resources in the
+appropriate lifecycle callback.
 
 The [`before:destroy` event](./events.class.md#destroy-and-beforedestroy-events) is the best place to clean
 up any added listeners not related to the view's DOM.
 
 Once destruction begins, reentrant `destroy()` calls from `before:destroy` or
 `destroy`, and later repeated calls, return the same View without restarting
-teardown. An attached parent, its managed children, and its owning Region therefore
-complete their detach, destroy, and empty lifecycles once.
-If a View's `before:destroy` handler throws, the error propagates and the View
-remains live with its managed children intact. A later `destroy()` call retries
-`before:destroy` before completing detach and child cleanup once. Errors after
-`before:destroy` completes do not restart teardown.
+teardown. During a normal successful teardown, an attached parent and its owned
+children complete their detach and destroy lifecycles once.
 
-The state of the view after the destroy is not attached and not rendered although the `el` is not emptied.
+Marionette establishes a retry boundary only around `before:destroy`. If that
+callback throws, the error propagates, the destruction guard is cleared, and a
+later `destroy()` call runs `before:destroy` again before framework cleanup.
+Marionette does not roll back changes made by the throwing callback. If a later
+detach, child, Behavior, or `destroy` callback throws, the error also propagates,
+but teardown may already be partial and another `destroy()` call does not resume
+it. Do not rely on a stable intermediate state after such an error.
+
+Successful destruction retains the root `el` object but detaches it. Do not
+infer that all of its contents are retained: owned child Views are removed as
+they are destroyed, and Region or CollectionView cleanup can detach contents
+from managed containers. Marionette makes no general cleanup promise for
+unowned DOM outside those managed boundaries.
 
 ## Destroying Children
 
-Children added to a `View`'s region or through a `CollectionView` will be automatically destroyed if the
-view is re-rendered, if the view is destroyed, or for `CollectionView` if the `collection` is reset.
+Children still owned by a View's Region or a CollectionView are automatically
+destroyed when their owner completes a re-render or is destroyed. A CollectionView also
+destroys its currently owned children when its collection is reset before
+building the replacement collection-backed children. A child returned by
+`detachView()` or `detachChildView()` is no longer owned and is not included in
+later owner cleanup.
 
-**Note** Children are removed after the DOM detach of the parent to prevent multiple reflows or repaints.
+During owner destruction, children are removed after the parent root is detached
+to avoid repeated reflows or repaints.

--- a/test/unit/collection-view/collection-view-lifecycle.spec.js
+++ b/test/unit/collection-view/collection-view-lifecycle.spec.js
@@ -251,6 +251,32 @@ describe('CollectionView lifecycle contract', function() {
     region.destroy();
   });
 
+  it('destroys manually added children on rerender and collection reset', function() {
+    const collection = new Backbone.Collection([{ id: 1 }]);
+    const collectionView = new CollectionView({ collection, childView: ChildView });
+    const rerenderChild = new ChildView();
+    const resetChild = new ChildView();
+    const destroyChild = new ChildView();
+
+    collectionView.render();
+    collectionView.addChildView(rerenderChild);
+    collectionView.render();
+
+    expect(rerenderChild.isDestroyed()).to.be.true;
+    expect(collectionView.children.hasView(rerenderChild)).to.be.false;
+
+    collectionView.addChildView(resetChild);
+    collection.reset([{ id: 2 }]);
+
+    expect(resetChild.isDestroyed()).to.be.true;
+    expect(collectionView.children.hasView(resetChild)).to.be.false;
+
+    collectionView.addChildView(destroyChild);
+    collectionView.destroy();
+
+    expect(destroyChild.isDestroyed()).to.be.true;
+  });
+
   it('leaves child attachment state unmonitored when parent monitoring is disabled', function() {
     this.setFixtures('<div id="unmonitored-region"></div>');
     const collectionView = new CollectionView();

--- a/test/unit/collection-view/collection-view-lifecycle.spec.js
+++ b/test/unit/collection-view/collection-view-lifecycle.spec.js
@@ -251,7 +251,7 @@ describe('CollectionView lifecycle contract', function() {
     region.destroy();
   });
 
-  it('destroys manually added children on rerender and collection reset', function() {
+  it('destroys manually added children on rerender, reset, and owner destruction', function() {
     const collection = new Backbone.Collection([{ id: 1 }]);
     const collectionView = new CollectionView({ collection, childView: ChildView });
     const rerenderChild = new ChildView();


### PR DESCRIPTION
Related #147

## What

- Replace stale Backbone.View and implicit jQuery lifecycle guidance with the native v5 View and CollectionView contract.
- Document terminal lifecycle no-ops, ownership transfer, monitored attachment, and the distinct View/CollectionView setElement behavior.
- Add regression coverage proving manually added CollectionView children are destroyed on rerender, collection reset, and owner destruction.

## Why

The lifecycle page still described v4-era inheritance and an unmanaged-child pattern that does not match the v5 ownership model. The revised contract is grounded in current source, historical v3/v4 behavior, existing lifecycle tests, and consumer audits of app-frontend and marionette.toolkit.

## Scope

Impacts lifecycle documentation and one CollectionView lifecycle regression spec. It does not change runtime behavior, add compatibility aliases, publish artifacts, or change repository policy.

## Deployment Impact

No deployment or redeploy is required. This changes source documentation and tests only.

## Testing

- `npx vitest run test/unit/collection-view/collection-view-lifecycle.spec.js test/unit/view-lifecycle.spec.js test/unit/view-dom-delegation.spec.js test/unit/destroyed-add-child-view.spec.js test/unit/view-el.spec.js test/unit/jquery-dom-api.spec.js` (6 files, 60 tests)
- `npm run docs:check` (10 executable examples, 41 pages, 386 internal links)
- `npm run lint:ci`
- `git diff --check`
- `npm run test:fixtures` and the broader five-file lifecycle suite also passed before the final docs-only wording refinement.

Existing evidence for reviewer verification:

- `test/unit/collection-view/collection-view-lifecycle.spec.js` pins CollectionView setElement state preservation, monitored attachment, detach/remove ownership, and manual-child cleanup.
- `test/unit/view-lifecycle.spec.js` pins View setElement state recomputation.
- `test/unit/destroyed-add-child-view.spec.js` and `test/unit/view-dom-delegation.spec.js` pin the documented terminal no-ops.
- `test/unit/view-el.spec.js` and `test/unit/jquery-dom-api.spec.js` pin native element validation and jQuery-wrapper migration diagnostics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the lifecycle documentation with the v5 View and CollectionView ownership model, replacing stale v4-era guidance. Adds regression coverage proving manually added CollectionView children are destroyed on rerender, collection reset, and owner destruction, addressing #147. This changes docs and tests only, with no runtime behavior impact.

<sup>Written for commit b053fc29df4ee167aee8780ba048014b5d94a0b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

