### PR TITLE
docs(basics): align v5 configuration contracts

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,55 +1,43 @@
 # Common Marionette Concepts
 
-This document covers the basic usage patterns and concepts across Marionette.
-This includes things like calling conventions, setting attributes, common option
-patterns etc.
+This document covers the shared configuration patterns used by Marionette's
+classes. Class-specific pages remain the authority for when a particular value
+is read and whether it is read again.
 
 ## Documentation Index
 
-* [Using ES6 Modules](#using-es6-modules)
+* [Importing Marionette](#importing-marionette)
 * [Class-based Inheritance](#class-based-inheritance)
   * [Value Attributes](#value-attributes)
   * [Functions Returning Values](#functions-returning-values)
   * [Binding Attributes on Instantiation](#binding-attributes-on-instantiation)
 * [Common Marionette Functionality](./common.md)
 
-## Using ES6 Modules
+## Importing Marionette
 
-Marionette still supports using the library via an inline script.
-The UMD build supports `noConflict()`.
-
-```html
-<script src="./backbone.marionette.js"></script>
-<script>const MyMarionette = Marionette.noConflict();</script>
-<script>new MyMarionette.View({ el: 'body' });</script>
-```
-
-The recommended solution is to choose a solution like a [package manager](./installation.md)
-to allow for ES6 module importing of the library. The best way to import is using name imports.
+Install the v5 `marionette` package and use named imports:
 
 ```javascript
-import { View } from 'backbone.marionette';
-import * as Mn from 'backbone.marionette';
+import { Application, View } from 'marionette';
 
-new View({ el: 'body' });
-new Mn.Application();
+const view = new View();
+const app = new Application();
 ```
 
-However to support backwards compatibility Marionette exports all of its classes and
-functions on a default object. This default export may be removed in a future version of
-Marionette and it is recommend to migrate to a named imports.
+V5 has no default namespace export. The package also exposes explicit optional
+integration subpaths; see [Installing Marionette](./installation.md) for the
+current entrypoints and peer-dependency boundaries.
 
-```javascript
-import Marionette from 'backbone.marionette';
-
-new Marionette.Application();
-```
+Existing no-bundler applications may serve the published
+`dist/marionette.umd.js` artifact. It exposes the named API on the global
+`Marionette` object and supports `Marionette.noConflict()`. Package-based named
+imports are the canonical path for new applications.
 
 ## Class-based Inheritance
 
 Like [Backbone](http://backbonejs.org/#Model-extend), Marionette provides a
 pseudo-class `extend` method. [All built-in classes](./classes.md), such as
-`Marionette.View` and `Marionette.MnObject`, provide this method.
+`View` and `MnObject`, provide this method.
 
 The `protoProps` and `staticProps` hashes passed to `extend` contribute their own
 enumerable string keys only. Symbols, non-enumerable properties, and inherited
@@ -59,7 +47,7 @@ constructor remain available on the child constructor.
 In the example below, we create a new pseudo-class called `MyView`:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({});
 ```
@@ -76,12 +64,12 @@ When we extend classes, we can provide class attributes with specific values by
 defining them in the object we pass as the `extend` parameter:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   className: 'bg-success',
 
-  template: '#template-identifier',
+  template: () => '<div class="my-region"></div>',
 
   regions: {
     myRegion: '.my-region'
@@ -92,80 +80,108 @@ const MyView = View.extend({
   },
 
   removeBackground() {
-    this.$el.removeClass('bg-success');
+    this.el.classList.remove('bg-success');
   }
 });
 ```
 
-[Live example](https://jsfiddle.net/marionettejs/k93pejyb/)
-
-When we instantiate `MyView`, each instance will be given a `.bg-success` class
-with a `myRegion` region created on the `.my-region` element.
+When `MyView` creates its element, the element receives the `bg-success` class.
+When the View renders, the `myRegion` Region targets `.my-region` within that
+element. Entity-event behavior is documented separately because it depends on
+an attached entity.
 
 ### Functions Returning Values
 
-In almost every instance where we can set a value, we can also assign a function
-to figure out the value at runtime. In this case, Marionette will run the
-function on instantiation and use the returned value:
+Many configuration attributes accept either a value or a function returning
+that value. The consuming feature calls the function with the Marionette
+instance as `this`. Resolution timing is part of each attribute's contract; do
+not assume every function runs during construction or that every result is
+cached for the object's lifetime.
 
+<!-- executable-example: basics-class-configuration -->
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
+
+let cancelCalls = 0;
+let defaultCalls = 0;
+let overrideCalls = 0;
 
 const MyView = View.extend({
+  options() {
+    this.optionsResolutionCount = (this.optionsResolutionCount || 0) + 1;
+    return {
+      count: 1,
+      enabled: true,
+      label: 'default',
+      tone: 'quiet'
+    };
+  },
+
   className() {
-    return this.model.successful() ? 'bg-success' : 'bg-error';
+    this.classNameResolutionCount = (this.classNameResolutionCount || 0) + 1;
+    return `notice-${this.getOption('tone')}`;
   },
 
-  template: '#template-identifier',
+  template: () => '<button class="save">Save</button><button class="cancel">Cancel</button>',
 
-  regions() {
-    return {
-      myRegion: '.my-region'
-    };
+  triggers: {
+    'click .cancel': 'cancel:default',
+    'click .save': 'save:default'
   },
-
-  modelEvents() {
-    const wasSuccessful = this.model.successful();
-    return {
-      change: wasSuccessful ? 'removeBackground' : 'alert'
-    };
-  },
-
-  removeBackground() {
-    this.$el.removeClass('bg-success');
-  },
-
-  alert() {
-    console.log('model changed');
-  }
 });
+
+const view = new MyView({
+  count: 0,
+  enabled: false,
+  label: null,
+  tone: 'urgent',
+  triggers: {
+    'click .save': 'save:override'
+  },
+});
+
+const classNameBeforeRender = view.el.className;
+
+view.on('cancel:default', () => {
+  cancelCalls += 1;
+});
+
+view.on('save:default', () => {
+  defaultCalls += 1;
+});
+
+view.on('save:override', () => {
+  overrideCalls += 1;
+});
+
+view.render();
+view.el.querySelector('.save').click();
+view.el.querySelector('.cancel').click();
+
+export { cancelCalls, classNameBeforeRender, defaultCalls, overrideCalls, view };
 ```
 
-[Live example](https://jsfiddle.net/marionettejs/nn1754fc/)
-
-As we can see, almost all of the attributes here can be worked out dynamically.
-In most cases, Marionette will call the function once at instantiation, or first
-render, and preserve the value throughout the lifetime of the View. There are
-some exceptions to this rule - these will be referred to with their respective
-documentation.
+Here `options()` supplies class defaults, the constructor's `tone` wins, and
+`className()` resolves while the View creates its element. The constructor's
+`triggers` map replaces the class map rather than merging with it.
 
 ### Function Context
 
-When using functions to set attributes, Marionette will assign the instance of
-your new class as `this`. You can use this feature to ensure you're able to
-access your object in cases where `this` isn't what you might expect it to be.
+Use a normal method when a configuration callback needs the instance context.
+An arrow function retains its surrounding lexical `this`, so it is appropriate
+only when the callback does not need the Marionette instance.
 
 ### Binding Attributes on Instantiation
 
-In Marionette, most attributes can be bound on class instantiation in addition
-to being set when the [class is defined](#class-based-inheritance). You can use
-this to bind events, triggers, models, and collections at runtime:
+The documented constructor options for each class can replace matching values
+defined on its prototype. This supports runtime configuration such as a View's
+events, triggers, model, collection, and Region definitions:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
-  template: '#template-identifier'
+  template: () => '<a href="#details">Details</a>'
 });
 
 const myView = new MyView({
@@ -178,13 +194,14 @@ const myView = new MyView({
 This will set a trigger called `show:link` that will be fired whenever the user
 clicks an `<a>` inside the view.
 
-Options set here will override options set on class definition. So, for example:
+Constructor values replace matching class values; map options are not
+implicitly deep-merged. For example:
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
-  template: '#template-identifier',
+  template: () => '<button class="save">Save</button><a href="#details">Details</a>',
 
   triggers: {
     'click @ui.save': 'save:form'
@@ -198,15 +215,15 @@ const myView = new MyView({
 });
 ```
 
-In this example, the trigger for `save:form` will no longer be fired, as the
-trigger for `show:link` completely overrides it.
+In this example, `show:link` is the only configured trigger. The constructor's
+`triggers` object completely replaces the class-defined object.
 
 ## Setting Options
 
-Marionette can set options when you instantiate a class. This lets you override
-many class-based attributes when you need to. You can also pass new information
-specific to the object in question that it can access through special helper
-methods.
+Every Marionette class stores its merged class defaults and constructor values
+on `this.options`. `getOption(name)` reads a defined value from `this.options`
+before falling back to the instance. A constructor value of `false`, `null`, or
+`0` therefore remains an intentional override; only `undefined` falls through.
 
 Resolved class defaults and constructor option hashes contribute their own
 enumerable string properties when Marionette builds `options`. Inherited,
@@ -214,7 +231,7 @@ symbol, and non-enumerable properties are ignored. `mergeOptions` applies the
 same rule to the named options copied onto an instance.
 
 ```javascript
-import { View } from 'backbone.marionette';
+import { View } from 'marionette';
 
 const MyView = View.extend({
   checkOption() {
@@ -229,7 +246,9 @@ const view = new MyView({
 view.checkOption();  // prints 'some text'
 ```
 
-[Live example](https://jsfiddle.net/marionettejs/6n02ex1m/)
+Constructor/default option merges use own enumerable string properties. See
+[`getOption` and `mergeOptions`](./common.md#getoption) for the exact lookup and
+copying boundaries.
 
 ## Common Marionette Functionality
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -93,10 +93,12 @@ an attached entity.
 ### Functions Returning Values
 
 Many configuration attributes accept either a value or a function returning
-that value. The consuming feature calls the function with the Marionette
-instance as `this`. Resolution timing is part of each attribute's contract; do
-not assume every function runs during construction or that every result is
-cached for the object's lifetime.
+that value. Attributes documented as value callbacks call the function with
+the Marionette instance as `this`. A `template` function is the renderer itself
+and instead receives serialized data as its argument; it does not receive the
+View as `this`. Resolution timing is part of each attribute's contract; do not
+assume every function runs during construction or that every result is cached
+for the object's lifetime.
 
 <!-- executable-example: basics-class-configuration -->
 ```javascript
@@ -105,6 +107,8 @@ import { View } from 'marionette';
 let cancelCalls = 0;
 let defaultCalls = 0;
 let overrideCalls = 0;
+let templateContext;
+let templateData;
 
 const MyView = View.extend({
   options() {
@@ -122,7 +126,11 @@ const MyView = View.extend({
     return `notice-${this.getOption('tone')}`;
   },
 
-  template: () => '<button class="save">Save</button><button class="cancel">Cancel</button>',
+  template(data) {
+    templateContext = this;
+    templateData = data;
+    return '<button class="save">Save</button><button class="cancel">Cancel</button>';
+  },
 
   triggers: {
     'click .cancel': 'cancel:default',
@@ -158,7 +166,15 @@ view.render();
 view.el.querySelector('.save').click();
 view.el.querySelector('.cancel').click();
 
-export { cancelCalls, classNameBeforeRender, defaultCalls, overrideCalls, view };
+export {
+  cancelCalls,
+  classNameBeforeRender,
+  defaultCalls,
+  overrideCalls,
+  templateContext,
+  templateData,
+  view
+};
 ```
 
 Here `options()` supplies class defaults, the constructor's `tone` wins, and

--- a/test/fixtures/docs-basics-contract/.gitignore
+++ b/test/fixtures/docs-basics-contract/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+package-lock.json

--- a/test/fixtures/docs-basics-contract/package.json
+++ b/test/fixtures/docs-basics-contract/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "jsdom": "30.0.1"
+  }
+}

--- a/test/fixtures/docs-basics-contract/validate.mjs
+++ b/test/fixtures/docs-basics-contract/validate.mjs
@@ -30,6 +30,8 @@ try {
     classNameBeforeRender,
     defaultCalls,
     overrideCalls,
+    templateContext,
+    templateData,
     view,
   } = await import(pathToFileURL(examplePath));
 
@@ -40,6 +42,8 @@ try {
   assert.equal(view.getOption('enabled'), false, 'false must remain an intentional constructor override');
   assert.equal(view.getOption('count'), 0, 'zero must remain an intentional constructor override');
   assert.equal(view.getOption('label'), null, 'null must remain an intentional constructor override');
+  assert.equal(templateContext, undefined, 'template must not receive the view as its context');
+  assert.deepEqual(templateData, {}, 'template must receive serialized data');
   assert.equal(overrideCalls, 1, 'the constructor trigger map must replace the class trigger map');
   assert.equal(defaultCalls, 0, 'the replaced class trigger must not remain active');
   assert.equal(cancelCalls, 0, 'a class-only trigger must not be merged into the constructor map');
@@ -50,6 +54,7 @@ try {
   );
 
   view.destroy();
+  assert.equal(view.isDestroyed(), true, 'destroy must cleanly release the view');
 } finally {
   dom.window.close();
   delete globalThis.document;

--- a/test/fixtures/docs-basics-contract/validate.mjs
+++ b/test/fixtures/docs-basics-contract/validate.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const docsPath = resolve(__dirname, '../../../docs/basics.md');
+const markdown = await readFile(docsPath, 'utf8');
+const distDir = resolve(__dirname, 'dist');
+const examplePath = resolve(distDir, 'class-configuration.mjs');
+const marker = '<!-- executable-example: basics-class-configuration -->';
+
+assert.equal(markdown.split(marker).length - 1, 1, 'expected one basics configuration marker');
+
+const markedContent = markdown.slice(markdown.indexOf(marker) + marker.length);
+const codeFence = markedContent.match(/^\s*```javascript\n([\s\S]*?)\n```/);
+assert.ok(codeFence, 'expected a JavaScript fence immediately after the basics marker');
+
+await mkdir(distDir, { recursive: true });
+await writeFile(examplePath, codeFence[1], 'utf8');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+
+try {
+  const {
+    cancelCalls,
+    classNameBeforeRender,
+    defaultCalls,
+    overrideCalls,
+    view,
+  } = await import(pathToFileURL(examplePath));
+
+  assert.equal(view.optionsResolutionCount, 1, 'class options must resolve once during construction');
+  assert.equal(view.classNameResolutionCount, 1, 'className must resolve while creating the element');
+  assert.equal(view.getOption('tone'), 'urgent', 'constructor options must override class defaults');
+  assert.equal(classNameBeforeRender, 'notice-urgent', 'className must resolve before the first render');
+  assert.equal(view.getOption('enabled'), false, 'false must remain an intentional constructor override');
+  assert.equal(view.getOption('count'), 0, 'zero must remain an intentional constructor override');
+  assert.equal(view.getOption('label'), null, 'null must remain an intentional constructor override');
+  assert.equal(overrideCalls, 1, 'the constructor trigger map must replace the class trigger map');
+  assert.equal(defaultCalls, 0, 'the replaced class trigger must not remain active');
+  assert.equal(cancelCalls, 0, 'a class-only trigger must not be merged into the constructor map');
+  assert.deepEqual(
+    Object.keys(view.getOption('triggers')),
+    ['click .save'],
+    'the active trigger map must come from the constructor',
+  );
+
+  view.destroy();
+} finally {
+  dom.window.close();
+  delete globalThis.document;
+  delete globalThis.window;
+}


### PR DESCRIPTION
Related #41

## Linked issue

- Related #41

## What

- Replace stale v4 basics guidance with the canonical v5 `marionette` package, named imports, native DOM usage, template functions, and accurate option-resolution boundaries.
- Keep the published UMD artifact as an explicitly secondary no-bundler path while removing the obsolete package name, default export, selector-string View element, string-template, and native-core `$el` examples.
- Add a packed-package executable example for `extend`, class defaults, constructor overrides, callable configuration context/timing, and whole-map trigger replacement.

## Why

`docs/basics.md` was still a high-traffic source of v4 patterns that conflict with v5's shipped entrypoint and native-core contracts. Coding agents following it could generate imports that fail, rely on removed default exports, pass unsupported selector strings to Views, or assume every callable configuration is resolved and cached the same way.

## Agent-development failure addressed

- The basic entry page now teaches one canonical package/import path and scopes resolution timing to the consuming attribute.
- The executable example distinguishes shallow class-default option merging from constructor replacement of a configured map.
- Important claims run against the packed artifact without private consumer context.

## Public behavior contract

- Canonical behavior after this PR: use named imports from `marionette`; configuration functions receive the instance as `this`, with attribute-specific timing; documented constructor values override matching class configuration; `triggers` maps replace rather than deep-merge.
- Superseded behavior removed, if any: v4 `backbone.marionette` and default-namespace guidance, selector-string View `el`, string templates, native-core `$el`, and vague lifetime-wide resolver caching.
- Compatibility exception and removal condition, if any: the already-published UMD artifact remains documented as a secondary existing-app path; no alias, fallback, or new runtime path is added.

## Scope

- Documentation and one isolated packed-package fixture only.
- No runtime source, public export, declaration, generated distribution artifact, or consumer behavior changes.
- `app-frontend` already uses the v5 package's named imports; `marionette.toolkit` remains a v4 `backbone.marionette` consumer and does not require a v5 compatibility alias.

## Runtime cost

- [ ] Static or documentation only
- [x] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: no production artifact change.
- Startup/hot path: no runtime change.
- Allocations/retention: fixture-only jsdom allocation during validation.

## Deployment Impact

- No website, package, tag, release, or consumer deployment is performed or required by this PR.
- The updated docs ship with the next normal package/repository documentation update.
- No repository or organization settings change is required.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npx vitest run test/unit/utils/extend.spec.js test/unit/mixins/common.spec.js test/unit/view-constructor-options.spec.js --reporter=dot
npm run docs:check
npm run test:fixtures
npm run lint:ci
npm run check:dist
git diff --check
```

Results: 17 focused tests passed; docs validation passed 41 pages, 386 links, 16 executable examples, and 11 fixture validators; all packed fixtures, lint, distribution, and whitespace checks passed.

## Testing

- The packed example imports the built package by its public name and executes in jsdom.
- It proves constructor overrides for ordinary and falsy values, pre-render `className` resolution, instance callback context, native element output, and removal of class-only trigger keys when the constructor supplies a replacement map.
- Existing distribution validation independently verifies the UMD global and `noConflict()` behavior cited by the page.

## Package and browser impact

- Entry points or install fixtures affected: no entrypoint change; adds `docs-basics-contract` to packed-package validation.
- Browser contracts affected: documentation now matches native-core View elements and the existing UMD artifact.
- Production/dev/test module-graph impact: no production graph change; jsdom remains isolated to the fixture.

## Rollback or deprecation

- Revert this documentation/fixture commit if a stated contract conflicts with the final v5 API; do not restore stale v4 imports or compatibility aliases.

## Review notes

- Historical v4 commit `0c9d390e` added the default namespace specifically for backward compatibility; v5 intentionally removed it and already enforces that removal with a packed fixture.
- Claude initially found that the trigger replacement example could not distinguish replacement from merging. Exact head `f4362586f263ac8522637d801b58aa7946ceff48` adds a class-only key, exercises both elements, and asserts the replaced handlers never run. Claude then reported no hard blocker on that exact head.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `docs/basics.md` with v5's shipped configuration contracts by replacing stale v4 guidance (`backbone.marionette` imports, default exports, selector-string elements, string templates) with named imports from `marionette`, native DOM usage, and an executable fixture that validates option-resolution semantics. Related to #41.

**Behavior changes**
- Constructor options override class defaults; only `undefined` falls through, so `false`, `null`, and `0` remain intentional overrides.
- Constructor `triggers` replace class trigger maps instead of deep-merging.
- Configuration functions receive the instance as `this`, except `template`, which receives serialized data; resolution timing is scoped to each consuming attribute.
- The published UMD artifact remains documented as a secondary path for no-bundler apps.

<sup>Written for commit e60f69edb3918411ef2492a80537ab90baddbe4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the basics guide for Marionette v5 usage and package imports.
  * Added current UMD and `noConflict()` guidance.
  * Modernized template and configuration examples with updated behavior notes.
  * Replaced outdated live examples with links to shared documentation.

* **Tests**
  * Added executable documentation validation covering configuration, rendering, option overrides, and event trigger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->