### PR TITLE
feat(performance): measure consumer bundle scenarios

### DIFF
--- a/benchmarks/consumer-bundles/contract.json
+++ b/benchmarks/consumer-bundles/contract.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "status": "reporting",
+  "fixture": {
+    "version": "v1",
+    "path": "benchmarks/consumer-bundles/v1/manifest.json",
+    "sha256": "4f02c53b7a01054fb4126340d04c6ad5eff319d3c76daad3b790ab8da41a9243"
+  },
+  "toolchain": {
+    "rollup": "4.63.0",
+    "rollupPluginTerser": "1.0.0",
+    "terser": "5.48.0"
+  },
+  "peerExternalImports": [
+    "backbone",
+    "jquery"
+  ]
+}

--- a/benchmarks/consumer-bundles/contract.json
+++ b/benchmarks/consumer-bundles/contract.json
@@ -4,7 +4,7 @@
   "fixture": {
     "version": "v1",
     "path": "benchmarks/consumer-bundles/v1/manifest.json",
-    "sha256": "4f02c53b7a01054fb4126340d04c6ad5eff319d3c76daad3b790ab8da41a9243"
+    "sha256": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134"
   },
   "toolchain": {
     "rollup": "4.63.0",

--- a/benchmarks/consumer-bundles/v1/backbone-only.js
+++ b/benchmarks/consumer-bundles/v1/backbone-only.js
@@ -1,0 +1,1 @@
+export { default as Backbone } from 'marionette/backbone';

--- a/benchmarks/consumer-bundles/v1/jquery-dom-api-only.js
+++ b/benchmarks/consumer-bundles/v1/jquery-dom-api-only.js
@@ -1,0 +1,1 @@
+export { default as jQueryDomApi } from 'marionette/jquery-dom-api';

--- a/benchmarks/consumer-bundles/v1/manifest.json
+++ b/benchmarks/consumer-bundles/v1/manifest.json
@@ -45,7 +45,10 @@
     "root-plus-backbone:umd",
     "root-plus-jquery:esm",
     "root-plus-jquery:cjs",
-    "root-plus-jquery:umd"
+    "root-plus-jquery:umd",
+    "root-plus-backbone-jquery:esm",
+    "root-plus-backbone-jquery:cjs",
+    "root-plus-backbone-jquery:umd"
   ],
   "scenarios": [
     {
@@ -140,6 +143,31 @@
         "dist/marionette.js"
       ],
       "expectedExternalImports": [
+        "jquery"
+      ]
+    },
+    {
+      "id": "root-plus-backbone-jquery",
+      "entry": "root-plus-backbone-jquery.js",
+      "entrySha256": "11e8b600de783fa5958e4b5d5abb006df1eb82f8c662d023e4fe6d094b34a8a3",
+      "publicImports": [
+        "marionette",
+        "marionette/backbone",
+        "marionette/jquery-dom-api"
+      ],
+      "exercisedExports": [
+        "*",
+        "default",
+        "default"
+      ],
+      "expectedModules": [
+        "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+        "dist/backbone.js",
+        "dist/jquery-dom-api.js",
+        "dist/marionette.js"
+      ],
+      "expectedExternalImports": [
+        "backbone",
         "jquery"
       ]
     }

--- a/benchmarks/consumer-bundles/v1/manifest.json
+++ b/benchmarks/consumer-bundles/v1/manifest.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": 1,
+  "fixtureVersion": "v1",
+  "packageName": "marionette",
+  "compression": {
+    "algorithm": "brotli",
+    "quality": 11
+  },
+  "treeshake": true,
+  "minify": {
+    "compress": {
+      "passes": 2
+    },
+    "format": {
+      "comments": false
+    },
+    "mangle": true
+  },
+  "formats": [
+    {
+      "id": "esm",
+      "rollupFormat": "es"
+    },
+    {
+      "id": "cjs",
+      "rollupFormat": "cjs"
+    },
+    {
+      "id": "umd",
+      "rollupFormat": "umd"
+    }
+  ],
+  "expectedArtifacts": [
+    "root-only:esm",
+    "root-only:cjs",
+    "root-only:umd",
+    "backbone-only:esm",
+    "backbone-only:cjs",
+    "backbone-only:umd",
+    "jquery-dom-api-only:esm",
+    "jquery-dom-api-only:cjs",
+    "jquery-dom-api-only:umd",
+    "root-plus-backbone:esm",
+    "root-plus-backbone:cjs",
+    "root-plus-backbone:umd",
+    "root-plus-jquery:esm",
+    "root-plus-jquery:cjs",
+    "root-plus-jquery:umd"
+  ],
+  "scenarios": [
+    {
+      "id": "root-only",
+      "entry": "root-only.js",
+      "entrySha256": "9d25eabb86b385791b36e8aa56d845ff459c7adb07d62dacb504bc2189ef1510",
+      "publicImports": [
+        "marionette"
+      ],
+      "exercisedExports": [
+        "*"
+      ],
+      "expectedModules": [
+        "benchmarks/consumer-bundles/v1/root-only.js",
+        "dist/marionette.js"
+      ],
+      "expectedExternalImports": []
+    },
+    {
+      "id": "backbone-only",
+      "entry": "backbone-only.js",
+      "entrySha256": "c54a66300a9438aa88f131fdb8bb03e7e7ff714f2f153136a9d978d484e8c97b",
+      "publicImports": [
+        "marionette/backbone"
+      ],
+      "exercisedExports": [
+        "default"
+      ],
+      "expectedModules": [
+        "benchmarks/consumer-bundles/v1/backbone-only.js",
+        "dist/backbone.js",
+        "dist/marionette.js"
+      ],
+      "expectedExternalImports": [
+        "backbone"
+      ]
+    },
+    {
+      "id": "jquery-dom-api-only",
+      "entry": "jquery-dom-api-only.js",
+      "entrySha256": "26d25e2857d9fadedc404ab61b0e38a585234359494106b9c1477630f3d6f3c4",
+      "publicImports": [
+        "marionette/jquery-dom-api"
+      ],
+      "exercisedExports": [
+        "default"
+      ],
+      "expectedModules": [
+        "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+        "dist/jquery-dom-api.js"
+      ],
+      "expectedExternalImports": [
+        "jquery"
+      ]
+    },
+    {
+      "id": "root-plus-backbone",
+      "entry": "root-plus-backbone.js",
+      "entrySha256": "ee0441e600e3f94b263ac9d3ce0e679a7a9400c4d1a1c83ac9896b2e68a9cf32",
+      "publicImports": [
+        "marionette",
+        "marionette/backbone"
+      ],
+      "exercisedExports": [
+        "*",
+        "default"
+      ],
+      "expectedModules": [
+        "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+        "dist/backbone.js",
+        "dist/marionette.js"
+      ],
+      "expectedExternalImports": [
+        "backbone"
+      ]
+    },
+    {
+      "id": "root-plus-jquery",
+      "entry": "root-plus-jquery.js",
+      "entrySha256": "22057944e3223539a75566892e2ebd8267f43979495d6ce0370d8884d4f201a1",
+      "publicImports": [
+        "marionette",
+        "marionette/jquery-dom-api"
+      ],
+      "exercisedExports": [
+        "*",
+        "default"
+      ],
+      "expectedModules": [
+        "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+        "dist/jquery-dom-api.js",
+        "dist/marionette.js"
+      ],
+      "expectedExternalImports": [
+        "jquery"
+      ]
+    }
+  ]
+}

--- a/benchmarks/consumer-bundles/v1/root-only.js
+++ b/benchmarks/consumer-bundles/v1/root-only.js
@@ -1,0 +1,3 @@
+import * as Marionette from 'marionette';
+
+export { Marionette };

--- a/benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js
+++ b/benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js
@@ -1,0 +1,5 @@
+import * as Marionette from 'marionette';
+
+export { default as Backbone } from 'marionette/backbone';
+export { default as jQueryDomApi } from 'marionette/jquery-dom-api';
+export { Marionette };

--- a/benchmarks/consumer-bundles/v1/root-plus-backbone.js
+++ b/benchmarks/consumer-bundles/v1/root-plus-backbone.js
@@ -1,0 +1,4 @@
+import * as Marionette from 'marionette';
+
+export { default as Backbone } from 'marionette/backbone';
+export { Marionette };

--- a/benchmarks/consumer-bundles/v1/root-plus-jquery.js
+++ b/benchmarks/consumer-bundles/v1/root-plus-jquery.js
@@ -1,0 +1,4 @@
+import * as Marionette from 'marionette';
+
+export { default as jQueryDomApi } from 'marionette/jquery-dom-api';
+export { Marionette };

--- a/config/performance.json
+++ b/config/performance.json
@@ -21,12 +21,9 @@
       }
     },
     "lockedDependencies": {
-      "@rollup/plugin-terser": "1.0.0",
       "backbone": "1.4.0",
-      "jquery": "4.0.0",
       "jsdom": "30.0.1",
-      "rollup": "4.63.0",
-      "terser": "5.48.0"
+      "rollup": "4.63.0"
     },
     "commands": {
       "deterministic": [
@@ -194,24 +191,6 @@
     "config/release-profile.json",
     "config/release-promotion.json"
   ],
-  "consumerBundles": {
-    "schemaVersion": 1,
-    "status": "reporting",
-    "fixture": {
-      "version": "v1",
-      "path": "benchmarks/consumer-bundles/v1/manifest.json",
-      "sha256": "4f02c53b7a01054fb4126340d04c6ad5eff319d3c76daad3b790ab8da41a9243"
-    },
-    "toolchain": {
-      "rollup": "4.63.0",
-      "rollupPluginTerser": "1.0.0",
-      "terser": "5.48.0"
-    },
-    "peerExternalImports": [
-      "backbone",
-      "jquery"
-    ]
-  },
   "deterministicResources": {
     "attachDetachCycles": 100,
     "mountDestroyCycles": 1000,

--- a/config/performance.json
+++ b/config/performance.json
@@ -21,9 +21,12 @@
       }
     },
     "lockedDependencies": {
+      "@rollup/plugin-terser": "1.0.0",
       "backbone": "1.4.0",
+      "jquery": "4.0.0",
       "jsdom": "30.0.1",
-      "rollup": "4.63.0"
+      "rollup": "4.63.0",
+      "terser": "5.48.0"
     },
     "commands": {
       "deterministic": [
@@ -191,6 +194,24 @@
     "config/release-profile.json",
     "config/release-promotion.json"
   ],
+  "consumerBundles": {
+    "schemaVersion": 1,
+    "status": "reporting",
+    "fixture": {
+      "version": "v1",
+      "path": "benchmarks/consumer-bundles/v1/manifest.json",
+      "sha256": "4f02c53b7a01054fb4126340d04c6ad5eff319d3c76daad3b790ab8da41a9243"
+    },
+    "toolchain": {
+      "rollup": "4.63.0",
+      "rollupPluginTerser": "1.0.0",
+      "terser": "5.48.0"
+    },
+    "peerExternalImports": [
+      "backbone",
+      "jquery"
+    ]
+  },
   "deterministicResources": {
     "attachDetachCycles": 100,
     "mountDestroyCycles": 1000,

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -29,15 +29,30 @@ every JavaScript file shipped from `dist/` must be classified by the contract, s
 new artifact cannot silently avoid the aggregate budget.
 
 The roadmap also requires versioned root-only, opt-in-subpath-only, and
-root-plus-subpath consumer scenarios. Each scenario must record its own Brotli-11
-baseline and ceiling before adoption; those scenario limits and the aggregate package
-backstop are independent hard gates. These fixtures are not implemented yet and remain
-tracked by issue #127, so the current command enforces only the aggregate package
-backstop and per-artifact comparison described below.
+root-plus-subpath consumer scenarios. The public `v1` fixture under
+`benchmarks/consumer-bundles/` now measures root-only, `backbone`-only,
+`jquery-dom-api`-only, root-plus-`backbone`, and root-plus-`jquery-dom-api` imports.
+Each entry pins its source digest, public imports, exercised exports, expected module
+graph, and external imports. The fixture also pins Brotli quality 11 against the global
+performance contract. Rollup tree-shakes each entry and the pinned Terser toolchain
+minifies equivalent ESM, CommonJS, and UMD outputs before all 15 results are compressed.
+Declared runtime peers remain external. The root-only graph must remain isolated from
+both opt-in adapters and their peers.
+The current optional Backbone and jQuery peer set is part of fixture `v1`; changing
+that set requires an explicit fixture and contract revision rather than retaining
+obsolete peers.
+
+This first slice is reporting-only. It records exact-base deltas but deliberately has
+no consumer-scenario baseline or ceiling, so it cannot approve growth or compensate
+for the aggregate package backstop. A later governance change must adopt an explicit
+baseline and ceiling for each scenario and format before these measurements become a
+hard gate. Removing the fixture, changing its versioned metadata, omitting an output,
+bundling a peer, or changing the root-only graph fails closed independently of size.
 
 The Phase 0 baseline never changes. Aggregate package ceiling changes use the
 versioned, two-stage amendment protocol described below. Consumer-scenario targets
-remain unsupported until issue #127 establishes their canonical fixtures.
+remain unsupported until issue #127 separately adopts their initial baselines and
+ceilings.
 
 The same command asks Rollup for the actual internal modules and external imports of
 `.`, `./backbone`, and `./jquery-dom-api`. It records graph changes and fails if test,
@@ -205,9 +220,18 @@ protected base.
 The current contract is also validated independently so intentional contract and
 toolchain edits remain internally coherent. Its pinned release profile records Node
 24.19.0, npm 11.17.0, lockfile v3, Ubuntu 24.04 linux-x64, Rollup 4.63.0, jsdom
-30.0.1, Backbone 1.4.0, and the commands that reproduce deterministic and hosted
-checks. CI posts artifact, cumulative-size, and production-graph changes through
+30.0.1, Backbone 1.4.0, jQuery 4.0.0, `@rollup/plugin-terser` 1.0.0, Terser 5.48.0,
+and the commands that reproduce deterministic and hosted checks. CI posts artifact,
+cumulative-size, production-graph, and reporting-only consumer-bundle changes through
 the repository's read-only workflow plus the separate comment workflow.
+
+Marionette 3.5.1 and 4.1.3 declared Backbone and Underscore as peers; the 4.1.3
+Rollup build also externalized Backbone, Underscore, and Backbone.Radio. That history
+supports measuring framework cost separately from consumer-owned peers, but does not
+dictate the current dependency set. The `v1` fixture externalizes only the package's
+current runtime peers, Backbone and jQuery. It resolves Marionette's own public root
+and adapter imports to the shipped ESM files so the adapter scenarios still include
+their actual package-owned code.
 
 The roadmap also requires explicit issue approval and evidence for growth above one
 percent versus the pull request base and for every new production subpath. Existing

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -31,7 +31,8 @@ new artifact cannot silently avoid the aggregate budget.
 The roadmap also requires versioned root-only, opt-in-subpath-only, and
 root-plus-subpath consumer scenarios. The public `v1` fixture under
 `benchmarks/consumer-bundles/` now measures root-only, `backbone`-only,
-`jquery-dom-api`-only, root-plus-`backbone`, and root-plus-`jquery-dom-api` imports.
+`jquery-dom-api`-only, root-plus-`backbone`, root-plus-`jquery-dom-api`, and the
+representative root-plus-both-adapters import used by full Backbone/jQuery consumers.
 Each entry pins its source digest, public imports, exercised exports, expected module
 graph, and external imports. The adjacent reporting contract pins the fixture digest,
 current peer set, toolchain, and Brotli quality 11 against the global performance
@@ -222,8 +223,9 @@ The current contract is also validated independently so intentional contract and
 toolchain edits remain internally coherent. Its pinned release profile records Node
 24.19.0, npm 11.17.0, lockfile v3, Ubuntu 24.04 linux-x64, Rollup 4.63.0, jsdom
 30.0.1, Backbone 1.4.0, and the commands that reproduce deterministic and hosted
-checks. The separate consumer-bundle reporting contract pins jQuery 4.0.0,
-`@rollup/plugin-terser` 1.0.0, and Terser 5.48.0 through the package manifest. CI posts artifact,
+checks. The separate consumer-bundle reporting contract pins `@rollup/plugin-terser`
+1.0.0 and Terser 5.48.0. It names jQuery as an externalized runtime peer whose
+4.0.0 version is pinned by the package manifest and lockfile. CI posts artifact,
 cumulative-size, production-graph, and reporting-only consumer-bundle changes through
 the repository's read-only workflow plus the separate comment workflow.
 

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -37,7 +37,7 @@ Each entry pins its source digest, public imports, exercised exports, expected m
 graph, and external imports. The adjacent reporting contract pins the fixture digest,
 current peer set, toolchain, and Brotli quality 11 against the global performance
 contract. Rollup tree-shakes each entry and the pinned Terser toolchain
-minifies equivalent ESM, CommonJS, and UMD outputs before all 15 results are compressed.
+minifies equivalent ESM, CommonJS, and UMD outputs before all 18 results are compressed.
 Declared runtime peers remain external. The root-only graph must remain isolated from
 both opt-in adapters and their peers.
 The current optional Backbone and jQuery peer set is part of fixture `v1`; changing

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -33,8 +33,9 @@ root-plus-subpath consumer scenarios. The public `v1` fixture under
 `benchmarks/consumer-bundles/` now measures root-only, `backbone`-only,
 `jquery-dom-api`-only, root-plus-`backbone`, and root-plus-`jquery-dom-api` imports.
 Each entry pins its source digest, public imports, exercised exports, expected module
-graph, and external imports. The fixture also pins Brotli quality 11 against the global
-performance contract. Rollup tree-shakes each entry and the pinned Terser toolchain
+graph, and external imports. The adjacent reporting contract pins the fixture digest,
+current peer set, toolchain, and Brotli quality 11 against the global performance
+contract. Rollup tree-shakes each entry and the pinned Terser toolchain
 minifies equivalent ESM, CommonJS, and UMD outputs before all 15 results are compressed.
 Declared runtime peers remain external. The root-only graph must remain isolated from
 both opt-in adapters and their peers.
@@ -220,8 +221,9 @@ protected base.
 The current contract is also validated independently so intentional contract and
 toolchain edits remain internally coherent. Its pinned release profile records Node
 24.19.0, npm 11.17.0, lockfile v3, Ubuntu 24.04 linux-x64, Rollup 4.63.0, jsdom
-30.0.1, Backbone 1.4.0, jQuery 4.0.0, `@rollup/plugin-terser` 1.0.0, Terser 5.48.0,
-and the commands that reproduce deterministic and hosted checks. CI posts artifact,
+30.0.1, Backbone 1.4.0, and the commands that reproduce deterministic and hosted
+checks. The separate consumer-bundle reporting contract pins jQuery 4.0.0,
+`@rollup/plugin-terser` 1.0.0, and Terser 5.48.0 through the package manifest. CI posts artifact,
 cumulative-size, production-graph, and reporting-only consumer-bundle changes through
 the repository's read-only workflow plus the separate comment workflow.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "rollup": "4.63.0",
         "sinon": "^22.1.0",
         "sinon-chai": "^4.0.0",
+        "terser": "5.48.0",
         "underscore": "^1.13.0",
         "vitest": "^4.1.11"
       },
@@ -5491,6 +5492,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "rollup": "4.63.0",
     "sinon": "^22.1.0",
     "sinon-chai": "^4.0.0",
+    "terser": "5.48.0",
     "underscore": "^1.13.0",
     "vitest": "^4.1.11"
   },

--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -5,6 +5,7 @@ import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { isDeepStrictEqual, promisify } from 'node:util';
 import { brotliCompress, constants } from 'node:zlib';
+import terser from '@rollup/plugin-terser';
 import { rollup } from 'rollup';
 import {
   canonicalForbiddenExternalImports,
@@ -23,6 +24,21 @@ import {
 } from './budget-amendments.mjs';
 
 const compress = promisify(brotliCompress);
+const consumerScenarioIds = [
+  'root-only',
+  'backbone-only',
+  'jquery-dom-api-only',
+  'root-plus-backbone',
+  'root-plus-jquery',
+];
+const consumerFormatIds = ['esm', 'cjs', 'umd'];
+const consumerCompression = { algorithm: 'brotli', quality: 11 };
+const consumerPeerExternalImports = ['backbone', 'jquery'];
+const consumerToolchain = {
+  rollup: '4.63.0',
+  rollupPluginTerser: '1.0.0',
+  terser: '5.48.0',
+};
 
 function getArgument(args, name, fallback) {
   const index = args.indexOf(name);
@@ -225,6 +241,294 @@ export function findForbiddenExternalImports(externalImports, contract) {
 
 async function sha256(file) {
   return createHash('sha256').update(await readFile(file)).digest('hex');
+}
+
+function sha256Text(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function canonicalJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function sameStringInventory(actual, expected) {
+  return Array.isArray(actual) && isDeepStrictEqual(actual, expected);
+}
+
+export function validateConsumerBundleContract(contract, fixture, packageJson, brotliQuality) {
+  const violations = [];
+  if (!contract || contract.schemaVersion !== 1) {
+    return ['consumerBundles must use schemaVersion 1'];
+  }
+  if (contract.status !== 'reporting') {
+    violations.push('consumerBundles status must remain reporting until baselines and ceilings are adopted');
+  }
+  if (fixture?.schemaVersion !== 1 || fixture?.fixtureVersion !== contract.fixture?.version) {
+    violations.push('Consumer bundle fixture metadata does not match the performance contract');
+  }
+  const expectedCompression = { algorithm: 'brotli', quality: brotliQuality };
+  if (!isDeepStrictEqual(fixture?.compression, expectedCompression)) {
+    violations.push(`Consumer bundle compression must be Brotli quality ${brotliQuality}`);
+  }
+  const fixtureRevision = fixture ? sha256Text(canonicalJson(fixture)) : null;
+  if (fixtureRevision !== contract.fixture?.sha256) {
+    violations.push(`Consumer bundle fixture SHA-256 ${fixtureRevision || 'missing'} does not match ${contract.fixture?.sha256 || 'missing'}`);
+  }
+
+  const scenarioIds = fixture?.scenarios?.map(({ id }) => id);
+  if (!sameStringInventory(scenarioIds, consumerScenarioIds)) {
+    violations.push(`Consumer bundle scenario inventory must be ${consumerScenarioIds.join(', ')}`);
+  }
+  const formatIds = fixture?.formats?.map(({ id }) => id);
+  if (!sameStringInventory(formatIds, consumerFormatIds)) {
+    violations.push(`Consumer bundle format inventory must be ${consumerFormatIds.join(', ')}`);
+  }
+  const expectedArtifacts = consumerScenarioIds.flatMap(scenario =>
+    consumerFormatIds.map(format => `${scenario}:${format}`));
+  if (!sameStringInventory(fixture?.expectedArtifacts, expectedArtifacts)) {
+    violations.push(`Consumer bundle expected artifact set must be ${expectedArtifacts.join(', ')}`);
+  }
+  if (fixture?.packageName !== packageJson.name) {
+    violations.push(`Consumer bundle fixture package ${fixture?.packageName || 'missing'} does not match ${packageJson.name}`);
+  }
+
+  const runtimePeers = Object.keys(packageJson.peerDependencies || {})
+    .filter(peer => !peer.startsWith('@types/'))
+    .sort();
+  if (!sameStringInventory(contract.peerExternalImports, runtimePeers)) {
+    violations.push(`Consumer bundle peer externals must be ${runtimePeers.join(', ')}`);
+  }
+  const pinnedTools = {
+    rollup: packageJson.devDependencies?.rollup,
+    rollupPluginTerser: packageJson.devDependencies?.['@rollup/plugin-terser'],
+    terser: packageJson.devDependencies?.terser,
+  };
+  for (const [tool, expectedVersion] of Object.entries(pinnedTools)) {
+    if (contract.toolchain?.[tool] !== expectedVersion) {
+      violations.push(`Locked ${tool} version ${contract.toolchain?.[tool] || 'missing'} does not match ${expectedVersion || 'missing'}`);
+    }
+  }
+
+  const exportedImports = new Set(Object.keys(packageJson.exports || {}).map(subpath => {
+    return subpath === '.' ? packageJson.name : `${packageJson.name}/${subpath.slice(2)}`;
+  }));
+  for (const scenario of fixture?.scenarios || []) {
+    if (!Array.isArray(scenario.publicImports) || !scenario.publicImports.length ||
+        scenario.publicImports.some(publicImport => !exportedImports.has(publicImport))) {
+      violations.push(`Consumer bundle scenario ${scenario.id || 'missing'} has invalid publicImports`);
+    }
+    if (!Array.isArray(scenario.exercisedExports) || !scenario.exercisedExports.length) {
+      violations.push(`Consumer bundle scenario ${scenario.id || 'missing'} must name exercisedExports`);
+    }
+    if (typeof scenario.entry !== 'string' ||
+        typeof scenario.entrySha256 !== 'string' ||
+        !/^[a-f\d]{64}$/.test(scenario.entrySha256)) {
+      violations.push(`Consumer bundle scenario ${scenario.id || 'missing'} has invalid entry metadata`);
+    }
+    if (!Array.isArray(scenario.expectedModules) || !Array.isArray(scenario.expectedExternalImports)) {
+      violations.push(`Consumer bundle scenario ${scenario.id || 'missing'} is missing expected graph metadata`);
+    }
+  }
+  const rootScenario = fixture?.scenarios?.find(({ id }) => id === 'root-only');
+  if (rootScenario && (!sameStringInventory(rootScenario.publicImports, [packageJson.name]) ||
+      !sameStringInventory(rootScenario.expectedModules, [
+        'benchmarks/consumer-bundles/v1/root-only.js',
+        'dist/marionette.js',
+      ]) ||
+      !sameStringInventory(rootScenario.expectedExternalImports, []))) {
+    violations.push('Consumer bundle root-only scenario must remain isolated from opt-in subpaths and peers');
+  }
+
+  return violations;
+}
+
+export function validateCandidateConsumerBundleContract(authority, candidate) {
+  const base = authority?.consumerBundles;
+  const current = candidate?.consumerBundles;
+  if (!base) {
+    if (!current) {
+      return [];
+    }
+    const validBootstrap = sameStringInventory(Object.keys(current).sort(), [
+      'fixture',
+      'peerExternalImports',
+      'schemaVersion',
+      'status',
+      'toolchain',
+    ]) && current.schemaVersion === 1 && current.status === 'reporting' &&
+      sameStringInventory(Object.keys(current.fixture || {}).sort(), [
+        'path',
+        'sha256',
+        'version',
+      ]) && current.fixture.version === 'v1' &&
+      current.fixture.path === 'benchmarks/consumer-bundles/v1/manifest.json' &&
+      typeof current.fixture.sha256 === 'string' &&
+      /^[a-f\d]{64}$/.test(current.fixture.sha256) &&
+      isDeepStrictEqual(current.toolchain, consumerToolchain) &&
+      isDeepStrictEqual(current.peerExternalImports, consumerPeerExternalImports);
+    return validBootstrap ? [] : [
+      'The consumerBundles bootstrap contract is malformed',
+    ];
+  }
+  if (!current) {
+    return ['Candidate performance contract is missing consumerBundles'];
+  }
+  return isDeepStrictEqual(base, current) ? [] : [
+    'Candidate consumerBundles differs from exact-base reporting contract',
+  ];
+}
+
+function consumerPackageResolver(root, packageJson, peerExternalImports) {
+  const packageName = packageJson.name;
+  const importPaths = new Map(Object.entries(packageJson.exports || {}).map(([subpath, value]) => {
+    const publicImport = subpath === '.' ? packageName : `${packageName}/${subpath.slice(2)}`;
+    const paths = collectRuntimePaths(value);
+    const esmPath = [...paths].find(path => path.endsWith('.js') && !path.endsWith('.umd.js'));
+    return [publicImport, esmPath ? resolve(root, esmPath) : null];
+  }));
+
+  return {
+    name: 'consumer-package-resolver',
+    resolveId(source) {
+      if (peerExternalImports.some(peer => source === peer || source.startsWith(`${peer}/`))) {
+        return { id: source, external: true };
+      }
+      if (importPaths.has(source)) {
+        const resolved = importPaths.get(source);
+        if (!resolved) {
+          throw new Error(`No ES module runtime path exists for ${source}`);
+        }
+        return resolved;
+      }
+      return null;
+    },
+  };
+}
+
+function consumerGraphViolations(scenario, modules, externalImports, peerExternalImports) {
+  const violations = [];
+  if (!sameStringInventory(modules, scenario.expectedModules)) {
+    violations.push(`${scenario.id} modules differ from fixture metadata; expected ${scenario.expectedModules.join(', ') || 'none'}; measured ${modules.join(', ') || 'none'}`);
+  }
+  if (!sameStringInventory(externalImports, scenario.expectedExternalImports)) {
+    violations.push(`${scenario.id} external imports differ from fixture metadata; expected ${scenario.expectedExternalImports.join(', ') || 'none'}; measured ${externalImports.join(', ') || 'none'}`);
+  }
+  const undeclaredExternals = externalImports.filter(externalImport =>
+    !peerExternalImports.some(peer => externalImport === peer || externalImport.startsWith(`${peer}/`)));
+  if (undeclaredExternals.length) {
+    violations.push(`${scenario.id} contains non-peer external imports: ${undeclaredExternals.join(', ')}`);
+  }
+  if (scenario.id === 'root-only' && (externalImports.length !== 0 ||
+      modules.some(module => module === 'dist/backbone.js' || module === 'dist/jquery-dom-api.js'))) {
+    violations.push('root-only consumer bundle is not isolated from opt-in subpaths and peers');
+  }
+  return violations;
+}
+
+export async function measureConsumerBundles({ root = '.', contract, brotliQuality } = {}) {
+  const resolvedRoot = resolve(root);
+  const fixturePath = resolve(resolvedRoot, contract.fixture.path);
+  const [fixtureText, packageJson] = await Promise.all([
+    readFile(fixturePath, 'utf8'),
+    readJson(resolve(resolvedRoot, 'package.json')),
+  ]);
+  const fixture = JSON.parse(fixtureText);
+  const violations = validateConsumerBundleContract(
+    contract,
+    fixture,
+    packageJson,
+    brotliQuality
+  );
+  const actualFixtureRevision = sha256Text(fixtureText);
+  if (actualFixtureRevision !== contract.fixture.sha256 &&
+      !violations.some(violation => violation.startsWith('Consumer bundle fixture SHA-256'))) {
+    violations.push(`Consumer bundle fixture SHA-256 ${actualFixtureRevision} does not match ${contract.fixture.sha256}`);
+  }
+  const fixtureRoot = dirname(fixturePath);
+  const artifacts = [];
+
+  for (const scenario of fixture.scenarios || []) {
+    let bundle;
+    try {
+      const entryPath = resolve(fixtureRoot, scenario.entry);
+      const entryRevision = await sha256(entryPath);
+      if (entryRevision !== scenario.entrySha256) {
+        violations.push(`${scenario.id} entry SHA-256 ${entryRevision} does not match ${scenario.entrySha256}`);
+        continue;
+      }
+      bundle = await rollup({
+        input: entryPath,
+        plugins: [
+          consumerPackageResolver(resolvedRoot, packageJson, contract.peerExternalImports),
+          terser(fixture.minify),
+        ],
+        treeshake: fixture.treeshake,
+      });
+      for (const format of fixture.formats || []) {
+        const generated = await bundle.generate({
+          format: format.rollupFormat,
+          exports: 'named',
+          name: format.rollupFormat === 'umd' ? 'MarionetteConsumerBundle' : undefined,
+          globals: {
+            backbone: 'Backbone',
+            jquery: 'jQuery',
+          },
+        });
+        const chunks = generated.output.filter(item => item.type === 'chunk');
+        const code = chunks.map(chunk => chunk.code).join('\n');
+        const modules = [...new Set(chunks.flatMap(chunk => Object.keys(chunk.modules)))]
+          .map(moduleId => normalizePath(relative(resolvedRoot, moduleId)))
+          .sort();
+        const externalImports = [...new Set(chunks.flatMap(chunk => [
+          ...chunk.imports,
+          ...chunk.dynamicImports,
+        ]))].sort();
+        const compressed = await compress(code, {
+          params: { [constants.BROTLI_PARAM_QUALITY]: fixture.compression.quality },
+        });
+        artifacts.push({
+          id: `${scenario.id}:${format.id}`,
+          scenario: scenario.id,
+          format: format.id,
+          status: 'measured',
+          size: compressed.length,
+          modules,
+          externalImports,
+        });
+        violations.push(...consumerGraphViolations(
+          scenario,
+          modules,
+          externalImports,
+          contract.peerExternalImports
+        ));
+      }
+    } catch (error) {
+      violations.push(`Unable to measure consumer bundle ${scenario.id}: ${error.message}`);
+    } finally {
+      await bundle?.close();
+    }
+  }
+
+  const expectedArtifactCount = consumerScenarioIds.length * consumerFormatIds.length;
+  if (artifacts.length !== expectedArtifactCount) {
+    violations.push(`Consumer bundle artifact inventory measured ${artifacts.length}; expected ${expectedArtifactCount}`);
+  }
+  const measuredArtifacts = artifacts.map(({ scenario, format }) => `${scenario}:${format}`);
+  if (!sameStringInventory(measuredArtifacts, fixture.expectedArtifacts)) {
+    violations.push('Consumer bundle measured artifact set differs from fixture metadata');
+  }
+
+  return {
+    schemaVersion: 1,
+    status: contract.status,
+    fixtureVersion: fixture.fixtureVersion,
+    fixtureRevision: actualFixtureRevision,
+    compression: fixture.compression,
+    toolchain: contract.toolchain,
+    peerExternalImports: contract.peerExternalImports,
+    artifacts,
+    violations: [...new Set(violations)],
+  };
 }
 
 export async function validateToolchain(contract, root) {
@@ -478,6 +782,20 @@ export async function measure({
     }
   }
 
+  let consumerBundles = null;
+  if (contract.consumerBundles) {
+    try {
+      consumerBundles = await measureConsumerBundles({
+        root: resolvedRoot,
+        contract: contract.consumerBundles,
+        brotliQuality: quality,
+      });
+      violations.push(...consumerBundles.violations);
+    } catch (error) {
+      violations.push(`Unable to measure consumer bundles: ${error.message}`);
+    }
+  }
+
   let resources = null;
   if (contract.deterministicResources) {
     try {
@@ -504,10 +822,133 @@ export async function measure({
       absoluteCeiling: contract.baseline.absoluteCeilingBytes,
     },
     graphs,
+    consumerBundles,
     resourcesRequired: Boolean(contract.deterministicResources),
     resources,
     violations,
   };
+}
+
+function consumerArtifactIds() {
+  return consumerScenarioIds.flatMap(scenario =>
+    consumerFormatIds.map(format => `${scenario}:${format}`));
+}
+
+function validateConsumerBundleReport(report, label) {
+  const violations = [];
+  if (!report || report.schemaVersion !== 1 || report.status !== 'reporting' ||
+      typeof report.fixtureVersion !== 'string' || !report.fixtureVersion ||
+      typeof report.fixtureRevision !== 'string' ||
+      !/^[a-f\d]{64}$/.test(report.fixtureRevision) ||
+      !Array.isArray(report.artifacts) || !Array.isArray(report.violations)) {
+    return [`${label} consumer bundle report is malformed`];
+  }
+  if (!isDeepStrictEqual(report.compression, consumerCompression) ||
+      !isDeepStrictEqual(report.toolchain, consumerToolchain) ||
+      !isDeepStrictEqual(report.peerExternalImports, consumerPeerExternalImports)) {
+    violations.push(`${label} consumer bundle metadata is not canonical`);
+  }
+
+  const expectedIds = consumerArtifactIds();
+  const actualIds = report.artifacts.map(artifact => artifact?.id);
+  if (!isDeepStrictEqual(actualIds, expectedIds)) {
+    violations.push(`${label} consumer bundle artifact inventory is not canonical`);
+  }
+  for (const artifact of report.artifacts) {
+    const expectedId = `${artifact?.scenario}:${artifact?.format}`;
+    if (artifact?.id !== expectedId || artifact?.status !== 'measured' ||
+        !Number.isSafeInteger(artifact?.size) || artifact.size <= 0) {
+      violations.push(`${label} consumer bundle artifact ${artifact?.id || 'missing'} is malformed`);
+    }
+  }
+  return violations;
+}
+
+export function compareConsumerBundleReports(base, current) {
+  if (!base && !current) {
+    return { bootstrap: false, rows: [], violations: [], unavailable: true };
+  }
+  if (!current) {
+    return {
+      bootstrap: false,
+      rows: [],
+      violations: ['Pull request consumer bundle measurement is missing'],
+    };
+  }
+  const currentReportViolations = validateConsumerBundleReport(current, 'Pull request');
+  if (currentReportViolations.some(violation => violation.endsWith('report is malformed'))) {
+    return {
+      bootstrap: !base,
+      rows: [],
+      violations: currentReportViolations,
+    };
+  }
+  if (!base) {
+    return {
+      bootstrap: true,
+      rows: current.artifacts.map(artifact => ({
+        scenario: artifact.scenario,
+        format: artifact.format,
+        id: artifact.id,
+        baseSize: null,
+        currentSize: artifact.size,
+        deltaBytes: null,
+      })),
+      violations: [...currentReportViolations, ...current.violations],
+    };
+  }
+  const baseReportViolations = validateConsumerBundleReport(base, 'Exact base');
+  if (baseReportViolations.some(violation => violation.endsWith('report is malformed'))) {
+    return {
+      bootstrap: false,
+      rows: [],
+      violations: baseReportViolations,
+    };
+  }
+  if (base.fixtureVersion !== current.fixtureVersion ||
+      base.fixtureRevision !== current.fixtureRevision ||
+      !isDeepStrictEqual(base.compression, current.compression) ||
+      !isDeepStrictEqual(base.toolchain, current.toolchain) ||
+      !isDeepStrictEqual(base.peerExternalImports, current.peerExternalImports)) {
+    return {
+      bootstrap: false,
+      rows: [],
+      violations: [
+        ...baseReportViolations,
+        ...currentReportViolations,
+        'Consumer bundle metadata differs from the exact base',
+      ],
+    };
+  }
+  const baseByKey = new Map(base.artifacts.map(artifact => [
+    artifact.id,
+    artifact,
+  ]));
+  const rows = current.artifacts.map(artifact => {
+    const baseArtifact = baseByKey.get(artifact.id);
+    return {
+      id: artifact.id,
+      scenario: artifact.scenario,
+      format: artifact.format,
+      baseSize: baseArtifact?.size ?? null,
+      currentSize: artifact.size,
+      deltaBytes: baseArtifact ? artifact.size - baseArtifact.size : null,
+    };
+  });
+  const currentKeys = new Set(current.artifacts.map(artifact => artifact.id));
+  const missing = base.artifacts.filter(artifact =>
+    !currentKeys.has(artifact.id));
+  const added = rows.filter(row => row.baseSize == null);
+  const violations = [
+    ...baseReportViolations,
+    ...currentReportViolations,
+    ...base.violations,
+    ...current.violations,
+  ];
+  if (missing.length || added.length) {
+    violations.push('Consumer bundle report inventory differs from the exact base');
+  }
+  return { bootstrap: false, rows, violations };
 }
 
 function graphChange(baseGraph, currentGraph) {
@@ -791,6 +1232,26 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
   const cumulativeGrowth = formatChange(base.cumulative.size, current.cumulative.size);
   const phase0Growth = formatChange(current.cumulative.baselineSize, current.cumulative.size);
   const resourceComparison = compareResourceReports(base, current);
+  const consumerComparison = compareConsumerBundleReports(
+    base.consumerBundles,
+    current.consumerBundles
+  );
+  const consumerSection = consumerComparison.unavailable ? [] : [
+    '',
+    '## Canonical consumer bundles',
+    '',
+    '| Scenario | Format | Base | PR | Change |',
+    '| --- | --- | ---: | ---: | ---: |',
+    ...consumerComparison.rows.map(row =>
+      `| ${row.scenario} | ${row.format} | ${formatBytes(row.baseSize)} | ${formatBytes(row.currentSize)} | ${row.deltaBytes == null ? 'Bootstrap' : formatChange(row.baseSize, row.currentSize)} |`),
+    '',
+    consumerComparison.bootstrap ?
+      'Reporting bootstrap only: no consumer-scenario baseline or ceiling is active.' :
+      'Reporting only: consumer-scenario deltas do not enforce a baseline or ceiling yet.',
+    ...(consumerComparison.violations.length ? [
+      `Consumer bundle violations: ${consumerComparison.violations.join('; ')}`,
+    ] : []),
+  ];
   const resourceSection = resourceComparison.unavailable ? [] : [
     '',
     '## Deterministic allocation and retention',
@@ -823,10 +1284,11 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
       `Contract violations: ${current.violations.join('; ')}` :
       'All deterministic size and production-graph checks passed against the base authority contract.',
     ...resourceSection,
+    ...consumerSection,
     ...approvalSection,
   ].join('\n');
 
-  return { growthApproval, markdown, resourceComparison };
+  return { consumerComparison, growthApproval, markdown, resourceComparison };
 }
 
 export async function createReport(baseFile, currentFile, growthApprovalFile) {
@@ -845,6 +1307,9 @@ function writeMeasurement(result, json) {
   console.log(`Cumulative: ${formatBytes(result.cumulative.size)} / ${formatBytes(result.cumulative.absoluteCeiling)}`);
   for (const graph of result.graphs) {
     console.log(`${graph.subpath}: ${graph.status === 'measured' ? `${graph.modules.length} internal modules, ${graph.externalImports.length} external imports` : graph.error}`);
+  }
+  if (result.consumerBundles) {
+    console.log(`Consumer bundles: ${result.consumerBundles.artifacts.length} reporting-only scenarios/formats measured from ${result.consumerBundles.fixtureVersion}`);
   }
   if (result.resources) {
     console.log(`Resources: ${Object.keys(result.resources.allocations).length} measured instance shapes; ${result.resources.workload.attachDetachCycles} detach cycles; ${result.resources.workload.mountDestroyCycles} mount/destroy cycles`);
@@ -868,7 +1333,10 @@ export async function main(args = process.argv.slice(2)) {
       readJson(paths[0]),
       readJson(paths[1]),
     ]);
-    const violations = validateCandidateResourceContract(authority, candidate);
+    const violations = [
+      ...validateCandidateResourceContract(authority, candidate),
+      ...validateCandidateConsumerBundleContract(authority, candidate),
+    ];
     for (const violation of violations) {
       console.error(`Performance contract violation: ${violation}`);
     }
@@ -885,6 +1353,7 @@ export async function main(args = process.argv.slice(2)) {
     const report = await buildReport(baseFile, currentFile, growthApprovalFile);
     console.log(report.markdown);
     if (report.resourceComparison.violations.length ||
+        report.consumerComparison.violations.length ||
         (growthApprovalFile && !report.growthApproval.accepted)) {
       process.exitCode = 1;
     }

--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -34,6 +34,7 @@ const consumerScenarioIds = [
 const consumerFormatIds = ['esm', 'cjs', 'umd'];
 const consumerCompression = { algorithm: 'brotli', quality: 11 };
 const consumerPeerExternalImports = ['backbone', 'jquery'];
+const consumerBundleContractPath = 'benchmarks/consumer-bundles/contract.json';
 const consumerToolchain = {
   rollup: '4.63.0',
   rollupPluginTerser: '1.0.0',
@@ -257,8 +258,24 @@ function sameStringInventory(actual, expected) {
 
 export function validateConsumerBundleContract(contract, fixture, packageJson, brotliQuality) {
   const violations = [];
-  if (!contract || contract.schemaVersion !== 1) {
+  if (!contract || !sameStringInventory(Object.keys(contract).sort(), [
+    'fixture',
+    'peerExternalImports',
+    'schemaVersion',
+    'status',
+    'toolchain',
+  ]) || contract.schemaVersion !== 1) {
     return ['consumerBundles must use schemaVersion 1'];
+  }
+  if (!sameStringInventory(Object.keys(contract.fixture || {}).sort(), [
+    'path',
+    'sha256',
+    'version',
+  ]) || contract.fixture.version !== 'v1' ||
+      contract.fixture.path !== 'benchmarks/consumer-bundles/v1/manifest.json' ||
+      typeof contract.fixture.sha256 !== 'string' ||
+      !/^[a-f\d]{64}$/.test(contract.fixture.sha256)) {
+    violations.push('consumerBundles fixture authority is malformed');
   }
   if (contract.status !== 'reporting') {
     violations.push('consumerBundles status must remain reporting until baselines and ceilings are adopted');
@@ -297,6 +314,9 @@ export function validateConsumerBundleContract(contract, fixture, packageJson, b
     .sort();
   if (!sameStringInventory(contract.peerExternalImports, runtimePeers)) {
     violations.push(`Consumer bundle peer externals must be ${runtimePeers.join(', ')}`);
+  }
+  if (!isDeepStrictEqual(contract.toolchain, consumerToolchain)) {
+    violations.push('Consumer bundle toolchain metadata is not canonical');
   }
   const pinnedTools = {
     rollup: packageJson.devDependencies?.rollup,
@@ -340,42 +360,6 @@ export function validateConsumerBundleContract(contract, fixture, packageJson, b
   }
 
   return violations;
-}
-
-export function validateCandidateConsumerBundleContract(authority, candidate) {
-  const base = authority?.consumerBundles;
-  const current = candidate?.consumerBundles;
-  if (!base) {
-    if (!current) {
-      return [];
-    }
-    const validBootstrap = sameStringInventory(Object.keys(current).sort(), [
-      'fixture',
-      'peerExternalImports',
-      'schemaVersion',
-      'status',
-      'toolchain',
-    ]) && current.schemaVersion === 1 && current.status === 'reporting' &&
-      sameStringInventory(Object.keys(current.fixture || {}).sort(), [
-        'path',
-        'sha256',
-        'version',
-      ]) && current.fixture.version === 'v1' &&
-      current.fixture.path === 'benchmarks/consumer-bundles/v1/manifest.json' &&
-      typeof current.fixture.sha256 === 'string' &&
-      /^[a-f\d]{64}$/.test(current.fixture.sha256) &&
-      isDeepStrictEqual(current.toolchain, consumerToolchain) &&
-      isDeepStrictEqual(current.peerExternalImports, consumerPeerExternalImports);
-    return validBootstrap ? [] : [
-      'The consumerBundles bootstrap contract is malformed',
-    ];
-  }
-  if (!current) {
-    return ['Candidate performance contract is missing consumerBundles'];
-  }
-  return isDeepStrictEqual(base, current) ? [] : [
-    'Candidate consumerBundles differs from exact-base reporting contract',
-  ];
 }
 
 function consumerPackageResolver(root, packageJson, peerExternalImports) {
@@ -783,17 +767,18 @@ export async function measure({
   }
 
   let consumerBundles = null;
-  if (contract.consumerBundles) {
-    try {
-      consumerBundles = await measureConsumerBundles({
-        root: resolvedRoot,
-        contract: contract.consumerBundles,
-        brotliQuality: quality,
-      });
-      violations.push(...consumerBundles.violations);
-    } catch (error) {
-      violations.push(`Unable to measure consumer bundles: ${error.message}`);
-    }
+  try {
+    const consumerBundleContract = await readJson(
+      resolve(resolvedRoot, consumerBundleContractPath)
+    );
+    consumerBundles = await measureConsumerBundles({
+      root: resolvedRoot,
+      contract: consumerBundleContract,
+      brotliQuality: quality,
+    });
+    violations.push(...consumerBundles.violations);
+  } catch (error) {
+    violations.push(`Unable to measure consumer bundles: ${error.message}`);
   }
 
   let resources = null;
@@ -1335,7 +1320,6 @@ export async function main(args = process.argv.slice(2)) {
     ]);
     const violations = [
       ...validateCandidateResourceContract(authority, candidate),
-      ...validateCandidateConsumerBundleContract(authority, candidate),
     ];
     for (const violation of violations) {
       console.error(`Performance contract violation: ${violation}`);

--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -30,6 +30,7 @@ const consumerScenarioIds = [
   'jquery-dom-api-only',
   'root-plus-backbone',
   'root-plus-jquery',
+  'root-plus-backbone-jquery',
 ];
 const consumerFormatIds = ['esm', 'cjs', 'umd'];
 const consumerCompression = { algorithm: 'brotli', quality: 11 };
@@ -252,7 +253,13 @@ function sameStringInventory(actual, expected) {
   return Array.isArray(actual) && isDeepStrictEqual(actual, expected);
 }
 
-export function validateConsumerBundleContract(contract, fixture, packageJson, brotliQuality) {
+export function validateConsumerBundleContract(
+  contract,
+  fixture,
+  packageJson,
+  brotliQuality,
+  fixtureRevision
+) {
   const violations = [];
   if (!contract || !sameStringInventory(Object.keys(contract).sort(), [
     'fixture',
@@ -278,6 +285,9 @@ export function validateConsumerBundleContract(contract, fixture, packageJson, b
   }
   if (fixture?.schemaVersion !== 1 || fixture?.fixtureVersion !== contract.fixture?.version) {
     violations.push('Consumer bundle fixture metadata does not match the performance contract');
+  }
+  if (fixtureRevision !== contract.fixture.sha256) {
+    violations.push(`Consumer bundle fixture SHA-256 ${fixtureRevision || 'missing'} does not match ${contract.fixture.sha256}`);
   }
   const expectedCompression = { algorithm: 'brotli', quality: brotliQuality };
   if (!isDeepStrictEqual(fixture?.compression, expectedCompression)) {
@@ -408,16 +418,14 @@ export async function measureConsumerBundles({ root = '.', contract, brotliQuali
     readJson(resolve(resolvedRoot, 'package.json')),
   ]);
   const fixture = JSON.parse(fixtureText);
+  const actualFixtureRevision = sha256Text(fixtureText);
   const violations = validateConsumerBundleContract(
     contract,
     fixture,
     packageJson,
-    brotliQuality
+    brotliQuality,
+    actualFixtureRevision
   );
-  const actualFixtureRevision = sha256Text(fixtureText);
-  if (actualFixtureRevision !== contract.fixture.sha256) {
-    violations.push(`Consumer bundle fixture SHA-256 ${actualFixtureRevision} does not match ${contract.fixture.sha256}`);
-  }
   const fixtureRoot = dirname(fixturePath);
   const artifacts = [];
 

--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -248,10 +248,6 @@ function sha256Text(value) {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function canonicalJson(value) {
-  return `${JSON.stringify(value, null, 2)}\n`;
-}
-
 function sameStringInventory(actual, expected) {
   return Array.isArray(actual) && isDeepStrictEqual(actual, expected);
 }
@@ -287,11 +283,6 @@ export function validateConsumerBundleContract(contract, fixture, packageJson, b
   if (!isDeepStrictEqual(fixture?.compression, expectedCompression)) {
     violations.push(`Consumer bundle compression must be Brotli quality ${brotliQuality}`);
   }
-  const fixtureRevision = fixture ? sha256Text(canonicalJson(fixture)) : null;
-  if (fixtureRevision !== contract.fixture?.sha256) {
-    violations.push(`Consumer bundle fixture SHA-256 ${fixtureRevision || 'missing'} does not match ${contract.fixture?.sha256 || 'missing'}`);
-  }
-
   const scenarioIds = fixture?.scenarios?.map(({ id }) => id);
   if (!sameStringInventory(scenarioIds, consumerScenarioIds)) {
     violations.push(`Consumer bundle scenario inventory must be ${consumerScenarioIds.join(', ')}`);
@@ -424,8 +415,7 @@ export async function measureConsumerBundles({ root = '.', contract, brotliQuali
     brotliQuality
   );
   const actualFixtureRevision = sha256Text(fixtureText);
-  if (actualFixtureRevision !== contract.fixture.sha256 &&
-      !violations.some(violation => violation.startsWith('Consumer bundle fixture SHA-256'))) {
+  if (actualFixtureRevision !== contract.fixture.sha256) {
     violations.push(`Consumer bundle fixture SHA-256 ${actualFixtureRevision} does not match ${contract.fixture.sha256}`);
   }
   const fixtureRoot = dirname(fixturePath);

--- a/test/performance/consumer-bundles.test.mjs
+++ b/test/performance/consumer-bundles.test.mjs
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import {
+  compareConsumerBundleReports,
+  measureConsumerBundles,
+  validateCandidateConsumerBundleContract,
+  validateConsumerBundleContract,
+} from '../../scripts/performance/bundle-size.mjs';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+const fixtureUrl = new URL('../../benchmarks/consumer-bundles/v1/manifest.json', import.meta.url);
+const contractUrl = new URL('../../config/performance.json', import.meta.url);
+const packageUrl = new URL('../../package.json', import.meta.url);
+
+async function canonicalInputs() {
+  const [performance, fixture, packageJson] = await Promise.all([
+    readFile(contractUrl, 'utf8').then(JSON.parse),
+    readFile(fixtureUrl, 'utf8').then(JSON.parse),
+    readFile(packageUrl, 'utf8').then(JSON.parse),
+  ]);
+  return {
+    brotliQuality: performance.baseline.brotliQuality,
+    contract: performance.consumerBundles,
+    fixture,
+    packageJson,
+  };
+}
+
+function consumerReport({ contract, fixture }, sizeOffset = 0) {
+  return {
+    schemaVersion: 1,
+    status: 'reporting',
+    fixtureVersion: fixture.fixtureVersion,
+    fixtureRevision: contract.fixture.sha256,
+    compression: fixture.compression,
+    toolchain: contract.toolchain,
+    peerExternalImports: contract.peerExternalImports,
+    artifacts: fixture.expectedArtifacts.map((id, index) => {
+      const [scenario, format] = id.split(':');
+      return {
+        id,
+        scenario,
+        format,
+        status: 'measured',
+        size: 100 + index + sizeOffset,
+      };
+    }),
+    violations: [],
+  };
+}
+
+function measurementOptions({ brotliQuality, contract }) {
+  return { brotliQuality, contract };
+}
+
+describe('consumer bundle measurements', () => {
+  test('measures the complete versioned ESM, CommonJS, and UMD inventory', async() => {
+    const result = await measureConsumerBundles({
+      root,
+      ...measurementOptions(await canonicalInputs()),
+    });
+
+    assert.equal(result.status, 'reporting');
+    assert.equal(result.fixtureVersion, 'v1');
+    assert.deepEqual(result.compression, { algorithm: 'brotli', quality: 11 });
+    assert.equal(result.artifacts.length, 15);
+    assert.deepEqual(
+      [...new Set(result.artifacts.map(({ format }) => format))],
+      ['esm', 'cjs', 'umd']
+    );
+    assert.ok(result.artifacts.every(({ size }) => Number.isSafeInteger(size) && size > 0));
+    assert.deepEqual(result.violations, []);
+  });
+
+  test('fails closed when scenario or format inventory is incomplete', async() => {
+    const { brotliQuality, contract, fixture, packageJson } = await canonicalInputs();
+    fixture.scenarios.pop();
+    fixture.formats.pop();
+
+    assert.match(
+      validateConsumerBundleContract(contract, fixture, packageJson, brotliQuality).join('\n'),
+      /scenario inventory.*root-plus-jquery.*format inventory.*umd/s
+    );
+  });
+
+  test('fails closed on fixture metadata or pinned toolchain drift', async() => {
+    const { brotliQuality, contract, fixture, packageJson } = await canonicalInputs();
+    const changed = structuredClone(contract);
+    changed.fixture.sha256 = '0'.repeat(64);
+    changed.toolchain.terser = '0.0.0';
+
+    assert.match(
+      validateConsumerBundleContract(changed, fixture, packageJson, brotliQuality).join('\n'),
+      /fixture SHA-256.*does not match.*Locked terser version/s
+    );
+  });
+
+  test('externalizes runtime peers and keeps the root scenario isolated', async() => {
+    const result = await measureConsumerBundles({
+      root,
+      ...measurementOptions(await canonicalInputs()),
+    });
+    const rootArtifacts = result.artifacts.filter(({ scenario }) => scenario === 'root-only');
+    const backboneArtifacts = result.artifacts.filter(({ scenario }) => scenario === 'backbone-only');
+    const jqueryArtifacts = result.artifacts.filter(({ scenario }) => scenario === 'jquery-dom-api-only');
+
+    assert.ok(rootArtifacts.every(({ externalImports }) => externalImports.length === 0));
+    assert.ok(rootArtifacts.every(({ modules }) =>
+      modules.includes('dist/marionette.js') &&
+      !modules.includes('dist/backbone.js') &&
+      !modules.includes('dist/jquery-dom-api.js')));
+    assert.ok(backboneArtifacts.every(({ externalImports }) =>
+      assert.deepEqual(externalImports, ['backbone']) === undefined));
+    assert.ok(jqueryArtifacts.every(({ externalImports }) =>
+      assert.deepEqual(externalImports, ['jquery']) === undefined));
+  });
+
+  test('reports deterministic exact-base deltas without enforcing a ceiling', async() => {
+    const inputs = await canonicalInputs();
+    const base = consumerReport(inputs);
+    const current = consumerReport(inputs, 4);
+    const comparison = compareConsumerBundleReports(base, current);
+
+    assert.equal(comparison.bootstrap, false);
+    assert.equal(comparison.rows.length, 15);
+    assert.deepEqual(comparison.rows[0], {
+      id: 'root-only:esm',
+      scenario: 'root-only',
+      format: 'esm',
+      baseSize: 100,
+      currentSize: 104,
+      deltaBytes: 4,
+    });
+    assert.deepEqual(comparison.violations, []);
+  });
+
+  test('permits only the reporting bootstrap transition and then fails closed', async() => {
+    const inputs = await canonicalInputs();
+    const { contract } = inputs;
+
+    assert.deepEqual(validateCandidateConsumerBundleContract({}, { consumerBundles: contract }), []);
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        {},
+        { consumerBundles: { status: 'reporting' } }
+      ).join('\n'),
+      /bootstrap contract is malformed/
+    );
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        {},
+        { consumerBundles: { ...contract, unknownAuthority: true } }
+      ).join('\n'),
+      /bootstrap contract is malformed/
+    );
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        {},
+        { consumerBundles: { ...contract, schemaVersion: 2 } }
+      ).join('\n'),
+      /bootstrap contract is malformed/
+    );
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        {},
+        {
+          consumerBundles: {
+            ...contract,
+            fixture: {
+              ...contract.fixture,
+              sha256: contract.fixture.sha256.toUpperCase(),
+            },
+          },
+        }
+      ).join('\n'),
+      /bootstrap contract is malformed/
+    );
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        {},
+        {
+          consumerBundles: {
+            ...contract,
+            fixture: { ...contract.fixture, unknownFixtureAuthority: true },
+          },
+        }
+      ).join('\n'),
+      /bootstrap contract is malformed/
+    );
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        { consumerBundles: contract },
+        {}
+      ).join('\n'),
+      /Candidate performance contract is missing consumerBundles/
+    );
+
+    const changed = structuredClone(contract);
+    changed.status = 'enforcing';
+    assert.match(
+      validateCandidateConsumerBundleContract(
+        { consumerBundles: contract },
+        { consumerBundles: changed }
+      ).join('\n'),
+      /consumerBundles differs from exact-base reporting contract/
+    );
+
+    const bootstrap = compareConsumerBundleReports(null, consumerReport(inputs));
+    assert.equal(bootstrap.bootstrap, true);
+    assert.deepEqual(bootstrap.violations, []);
+  });
+
+  test('rejects truncated, duplicate, and metadata-drifted reports', async() => {
+    const inputs = await canonicalInputs();
+    const complete = consumerReport(inputs);
+    const truncated = structuredClone(complete);
+    truncated.artifacts.pop();
+    const duplicate = structuredClone(complete);
+    duplicate.artifacts[14] = structuredClone(duplicate.artifacts[0]);
+    const metadataDrift = structuredClone(complete);
+    metadataDrift.compression.quality = 10;
+
+    assert.match(
+      compareConsumerBundleReports(null, truncated).violations.join('\n'),
+      /artifact inventory/
+    );
+    assert.match(
+      compareConsumerBundleReports(null, duplicate).violations.join('\n'),
+      /artifact inventory/
+    );
+    assert.match(
+      compareConsumerBundleReports(complete, metadataDrift).violations.join('\n'),
+      /metadata differs from the exact base/
+    );
+  });
+
+  test('fails closed when a versioned entry source digest drifts', async() => {
+    const inputs = await canonicalInputs();
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-consumer-entry-'));
+    try {
+      await Promise.all([
+        mkdir(join(fixtureRoot, 'benchmarks/consumer-bundles'), { recursive: true }),
+        cp(join(root, 'dist'), join(fixtureRoot, 'dist'), { recursive: true }),
+        writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(inputs.packageJson)),
+      ]);
+      await cp(
+        join(root, 'benchmarks/consumer-bundles/v1'),
+        join(fixtureRoot, 'benchmarks/consumer-bundles/v1'),
+        { recursive: true }
+      );
+      await writeFile(
+        join(fixtureRoot, 'benchmarks/consumer-bundles/v1/root-only.js'),
+        'export const drifted = true;\n'
+      );
+
+      const result = await measureConsumerBundles({
+        root: fixtureRoot,
+        contract: inputs.contract,
+        brotliQuality: inputs.brotliQuality,
+      });
+      assert.match(result.violations.join('\n'), /root-only entry SHA-256 .* does not match/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/performance/consumer-bundles.test.mjs
+++ b/test/performance/consumer-bundles.test.mjs
@@ -98,6 +98,16 @@ describe('consumer bundle measurements', () => {
       validateConsumerBundleContract(changed, fixture, packageJson, brotliQuality).join('\n'),
       /fixture SHA-256.*does not match.*Locked terser version/s
     );
+
+    const measured = await measureConsumerBundles({
+      root,
+      contract: changed,
+      brotliQuality,
+    });
+    assert.match(
+      measured.violations.join('\n'),
+      /fixture SHA-256.*does not match.*Locked terser version/s
+    );
   });
 
   test('externalizes runtime peers and keeps the root scenario isolated', async() => {
@@ -179,8 +189,12 @@ describe('consumer bundle measurements', () => {
     truncated.artifacts.pop();
     const duplicate = structuredClone(complete);
     duplicate.artifacts[14] = structuredClone(duplicate.artifacts[0]);
-    const metadataDrift = structuredClone(complete);
-    metadataDrift.compression.quality = 10;
+    const metadataDrifts = [
+      report => { report.fixtureRevision = '0'.repeat(64); },
+      report => { report.compression.quality = 10; },
+      report => { report.toolchain.terser = '0.0.0'; },
+      report => { report.peerExternalImports.pop(); },
+    ];
 
     assert.match(
       compareConsumerBundleReports(null, truncated).violations.join('\n'),
@@ -190,9 +204,17 @@ describe('consumer bundle measurements', () => {
       compareConsumerBundleReports(null, duplicate).violations.join('\n'),
       /artifact inventory/
     );
+    for (const mutate of metadataDrifts) {
+      const metadataDrift = structuredClone(complete);
+      mutate(metadataDrift);
+      assert.match(
+        compareConsumerBundleReports(complete, metadataDrift).violations.join('\n'),
+        /metadata differs from the exact base/
+      );
+    }
     assert.match(
-      compareConsumerBundleReports(complete, metadataDrift).violations.join('\n'),
-      /metadata differs from the exact base/
+      compareConsumerBundleReports(complete, null).violations.join('\n'),
+      /measurement is missing/
     );
   });
 

--- a/test/performance/consumer-bundles.test.mjs
+++ b/test/performance/consumer-bundles.test.mjs
@@ -96,7 +96,7 @@ describe('consumer bundle measurements', () => {
 
     assert.match(
       validateConsumerBundleContract(changed, fixture, packageJson, brotliQuality).join('\n'),
-      /fixture SHA-256.*does not match.*Locked terser version/s
+      /Locked terser version/
     );
 
     const measured = await measureConsumerBundles({
@@ -104,10 +104,8 @@ describe('consumer bundle measurements', () => {
       contract: changed,
       brotliQuality,
     });
-    assert.match(
-      measured.violations.join('\n'),
-      /fixture SHA-256.*does not match.*Locked terser version/s
-    );
+    assert.match(measured.violations.join('\n'), /fixture SHA-256.*does not match/);
+    assert.match(measured.violations.join('\n'), /Locked terser version/);
   });
 
   test('externalizes runtime peers and keeps the root scenario isolated', async() => {

--- a/test/performance/consumer-bundles.test.mjs
+++ b/test/performance/consumer-bundles.test.mjs
@@ -7,24 +7,25 @@ import { describe, test } from 'node:test';
 import {
   compareConsumerBundleReports,
   measureConsumerBundles,
-  validateCandidateConsumerBundleContract,
   validateConsumerBundleContract,
 } from '../../scripts/performance/bundle-size.mjs';
 
 const root = fileURLToPath(new URL('../..', import.meta.url));
 const fixtureUrl = new URL('../../benchmarks/consumer-bundles/v1/manifest.json', import.meta.url);
-const contractUrl = new URL('../../config/performance.json', import.meta.url);
+const contractUrl = new URL('../../benchmarks/consumer-bundles/contract.json', import.meta.url);
+const performanceUrl = new URL('../../config/performance.json', import.meta.url);
 const packageUrl = new URL('../../package.json', import.meta.url);
 
 async function canonicalInputs() {
-  const [performance, fixture, packageJson] = await Promise.all([
+  const [contract, performance, fixture, packageJson] = await Promise.all([
     readFile(contractUrl, 'utf8').then(JSON.parse),
+    readFile(performanceUrl, 'utf8').then(JSON.parse),
     readFile(fixtureUrl, 'utf8').then(JSON.parse),
     readFile(packageUrl, 'utf8').then(JSON.parse),
   ]);
   return {
     brotliQuality: performance.baseline.brotliQuality,
-    contract: performance.consumerBundles,
+    contract,
     fixture,
     packageJson,
   };
@@ -138,76 +139,33 @@ describe('consumer bundle measurements', () => {
     assert.deepEqual(comparison.violations, []);
   });
 
-  test('permits only the reporting bootstrap transition and then fails closed', async() => {
+  test('rejects malformed reporting authority metadata', async() => {
     const inputs = await canonicalInputs();
-    const { contract } = inputs;
-
-    assert.deepEqual(validateCandidateConsumerBundleContract({}, { consumerBundles: contract }), []);
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        {},
-        { consumerBundles: { status: 'reporting' } }
-      ).join('\n'),
-      /bootstrap contract is malformed/
-    );
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        {},
-        { consumerBundles: { ...contract, unknownAuthority: true } }
-      ).join('\n'),
-      /bootstrap contract is malformed/
-    );
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        {},
-        { consumerBundles: { ...contract, schemaVersion: 2 } }
-      ).join('\n'),
-      /bootstrap contract is malformed/
-    );
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        {},
-        {
-          consumerBundles: {
-            ...contract,
-            fixture: {
-              ...contract.fixture,
-              sha256: contract.fixture.sha256.toUpperCase(),
-            },
-          },
-        }
-      ).join('\n'),
-      /bootstrap contract is malformed/
-    );
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        {},
-        {
-          consumerBundles: {
-            ...contract,
-            fixture: { ...contract.fixture, unknownFixtureAuthority: true },
-          },
-        }
-      ).join('\n'),
-      /bootstrap contract is malformed/
-    );
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        { consumerBundles: contract },
-        {}
-      ).join('\n'),
-      /Candidate performance contract is missing consumerBundles/
-    );
-
-    const changed = structuredClone(contract);
-    changed.status = 'enforcing';
-    assert.match(
-      validateCandidateConsumerBundleContract(
-        { consumerBundles: contract },
-        { consumerBundles: changed }
-      ).join('\n'),
-      /consumerBundles differs from exact-base reporting contract/
-    );
+    const { brotliQuality, contract, fixture, packageJson } = inputs;
+    const malformed = [
+      { ...contract, unknownAuthority: true },
+      { ...contract, schemaVersion: 2 },
+      {
+        ...contract,
+        fixture: { ...contract.fixture, sha256: contract.fixture.sha256.toUpperCase() },
+      },
+      {
+        ...contract,
+        fixture: { ...contract.fixture, unknownFixtureAuthority: true },
+      },
+      {
+        ...contract,
+        toolchain: { ...contract.toolchain, unknownTool: '1.0.0' },
+      },
+    ];
+    for (const candidate of malformed) {
+      assert.ok(validateConsumerBundleContract(
+        candidate,
+        fixture,
+        packageJson,
+        brotliQuality
+      ).length > 0);
+    }
 
     const bootstrap = compareConsumerBundleReports(null, consumerReport(inputs));
     assert.equal(bootstrap.bootstrap, true);

--- a/test/performance/consumer-bundles.test.mjs
+++ b/test/performance/consumer-bundles.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -17,16 +18,17 @@ const performanceUrl = new URL('../../config/performance.json', import.meta.url)
 const packageUrl = new URL('../../package.json', import.meta.url);
 
 async function canonicalInputs() {
-  const [contract, performance, fixture, packageJson] = await Promise.all([
+  const [contract, performance, fixtureText, packageJson] = await Promise.all([
     readFile(contractUrl, 'utf8').then(JSON.parse),
     readFile(performanceUrl, 'utf8').then(JSON.parse),
-    readFile(fixtureUrl, 'utf8').then(JSON.parse),
+    readFile(fixtureUrl, 'utf8'),
     readFile(packageUrl, 'utf8').then(JSON.parse),
   ]);
   return {
     brotliQuality: performance.baseline.brotliQuality,
     contract,
-    fixture,
+    fixture: JSON.parse(fixtureText),
+    fixtureRevision: createHash('sha256').update(fixtureText).digest('hex'),
     packageJson,
   };
 }
@@ -68,7 +70,7 @@ describe('consumer bundle measurements', () => {
     assert.equal(result.status, 'reporting');
     assert.equal(result.fixtureVersion, 'v1');
     assert.deepEqual(result.compression, { algorithm: 'brotli', quality: 11 });
-    assert.equal(result.artifacts.length, 15);
+    assert.equal(result.artifacts.length, 18);
     assert.deepEqual(
       [...new Set(result.artifacts.map(({ format }) => format))],
       ['esm', 'cjs', 'umd']
@@ -78,24 +80,36 @@ describe('consumer bundle measurements', () => {
   });
 
   test('fails closed when scenario or format inventory is incomplete', async() => {
-    const { brotliQuality, contract, fixture, packageJson } = await canonicalInputs();
+    const { brotliQuality, contract, fixture, fixtureRevision, packageJson } = await canonicalInputs();
     fixture.scenarios.pop();
     fixture.formats.pop();
 
     assert.match(
-      validateConsumerBundleContract(contract, fixture, packageJson, brotliQuality).join('\n'),
-      /scenario inventory.*root-plus-jquery.*format inventory.*umd/s
+      validateConsumerBundleContract(
+        contract,
+        fixture,
+        packageJson,
+        brotliQuality,
+        fixtureRevision
+      ).join('\n'),
+      /scenario inventory.*root-plus-backbone-jquery.*format inventory.*umd/s
     );
   });
 
   test('fails closed on fixture metadata or pinned toolchain drift', async() => {
-    const { brotliQuality, contract, fixture, packageJson } = await canonicalInputs();
+    const { brotliQuality, contract, fixture, fixtureRevision, packageJson } = await canonicalInputs();
     const changed = structuredClone(contract);
     changed.fixture.sha256 = '0'.repeat(64);
     changed.toolchain.terser = '0.0.0';
 
     assert.match(
-      validateConsumerBundleContract(changed, fixture, packageJson, brotliQuality).join('\n'),
+      validateConsumerBundleContract(
+        changed,
+        fixture,
+        packageJson,
+        brotliQuality,
+        fixtureRevision
+      ).join('\n'),
       /Locked terser version/
     );
 
@@ -116,16 +130,31 @@ describe('consumer bundle measurements', () => {
     const rootArtifacts = result.artifacts.filter(({ scenario }) => scenario === 'root-only');
     const backboneArtifacts = result.artifacts.filter(({ scenario }) => scenario === 'backbone-only');
     const jqueryArtifacts = result.artifacts.filter(({ scenario }) => scenario === 'jquery-dom-api-only');
+    const combinedArtifacts = result.artifacts.filter(
+      ({ scenario }) => scenario === 'root-plus-backbone-jquery'
+    );
 
+    assert.equal(rootArtifacts.length, 3);
+    assert.equal(backboneArtifacts.length, 3);
+    assert.equal(jqueryArtifacts.length, 3);
+    assert.equal(combinedArtifacts.length, 3);
     assert.ok(rootArtifacts.every(({ externalImports }) => externalImports.length === 0));
     assert.ok(rootArtifacts.every(({ modules }) =>
       modules.includes('dist/marionette.js') &&
       !modules.includes('dist/backbone.js') &&
       !modules.includes('dist/jquery-dom-api.js')));
-    assert.ok(backboneArtifacts.every(({ externalImports }) =>
-      assert.deepEqual(externalImports, ['backbone']) === undefined));
-    assert.ok(jqueryArtifacts.every(({ externalImports }) =>
-      assert.deepEqual(externalImports, ['jquery']) === undefined));
+    for (const { externalImports } of backboneArtifacts) {
+      assert.deepEqual(externalImports, ['backbone']);
+    }
+    for (const { externalImports } of jqueryArtifacts) {
+      assert.deepEqual(externalImports, ['jquery']);
+    }
+    for (const { externalImports, modules } of combinedArtifacts) {
+      assert.deepEqual(externalImports, ['backbone', 'jquery']);
+      assert.ok(modules.includes('dist/backbone.js'));
+      assert.ok(modules.includes('dist/jquery-dom-api.js'));
+      assert.ok(modules.includes('dist/marionette.js'));
+    }
   });
 
   test('reports deterministic exact-base deltas without enforcing a ceiling', async() => {
@@ -135,7 +164,7 @@ describe('consumer bundle measurements', () => {
     const comparison = compareConsumerBundleReports(base, current);
 
     assert.equal(comparison.bootstrap, false);
-    assert.equal(comparison.rows.length, 15);
+    assert.equal(comparison.rows.length, 18);
     assert.deepEqual(comparison.rows[0], {
       id: 'root-only:esm',
       scenario: 'root-only',
@@ -149,7 +178,7 @@ describe('consumer bundle measurements', () => {
 
   test('rejects malformed reporting authority metadata', async() => {
     const inputs = await canonicalInputs();
-    const { brotliQuality, contract, fixture, packageJson } = inputs;
+    const { brotliQuality, contract, fixture, fixtureRevision, packageJson } = inputs;
     const malformed = [
       { ...contract, unknownAuthority: true },
       { ...contract, schemaVersion: 2 },
@@ -171,7 +200,8 @@ describe('consumer bundle measurements', () => {
         candidate,
         fixture,
         packageJson,
-        brotliQuality
+        brotliQuality,
+        fixtureRevision
       ).length > 0);
     }
 


### PR DESCRIPTION
Related #127

## What

- Add a versioned v1 consumer-bundle fixture covering six public import scenarios across ESM, CJS, and UMD output.
- Add deterministic Terser and Brotli-11 measurement/reporting with strict one-time baseline-bootstrap validation.
- Document the reporting contract and its intentionally inactive baseline/ceiling state.

## Why

Issue #127 requires evidence about the bundles real consumers receive, rather than only the repository's aggregate distribution files. This establishes the canonical, reproducible reporting layer without prematurely freezing size ceilings or changing runtime behavior.

The matrix uses v3/v4 externalization history as evidence while reflecting v5's current optional Backbone and jQuery peer contracts. It does not retain obsolete Underscore or Backbone.Radio paths. app-frontend and marionette.toolkit were assessed as consumer evidence, not treated as private normative APIs.

## Scope

- Performance tooling, fixture metadata, tests, package metadata, and performance documentation only.
- Covers root-only, Backbone-only, jQuery DOM API-only, root plus Backbone, root plus jQuery, and root plus both adapters.
- Does not change runtime APIs, distribution exports, application behavior, release artifacts, or enforcement thresholds.

## Deployment Impact

No deployment or consumer redeploy is required. This PR does not publish the website, npm package, tag, or release.

## Testing

- `node --test test/performance/consumer-bundles.test.mjs` (8 passed; 18 scenario-format artifacts)
- `node --test test/performance/*.test.mjs` (105 passed)
- `npm run size`
- `npm run lint:ci`
- `npm run docs:check` (17 examples, 41 pages, 386 links)
- `npm run test:source`
- `npm run check:dist`
- Duplicate consumer report generation produced byte-identical JSON.
- `git diff --check`

## Agent-development failure addressed

The fixture pins public imports, entry digests, exports, externals, minifier options, compression parameters, toolchain versions, and exact scenario IDs so coding agents cannot silently compare incomplete or incompatible reports.

## Public behavior contract

None. This is reporting-only infrastructure. The versioned fixture is an internal evidence contract, not a new Marionette runtime API.

## Runtime cost

None for library consumers. The work runs only in performance reporting and tests.

## Package and browser impact

No package output or browser runtime behavior changes. Terser was promoted from a transitive dependency to an exact direct development dependency for reproducible reporting.

## Rollback or deprecation

The PR commits can be reverted without consumer migration. Baselines and ceilings remain deliberately inactive until representative values are reviewed separately.

## Review notes

Claude approved exact head `b17d390a39d77b79dfc0a4110952204855e4c24e` with no blockers after reviewing the implementation and final documentation correction. Cubic and required CI remain authoritative merge gates.
