### PR TITLE
perf(build): authorize Application ownership budget

### DIFF
--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -123,6 +123,47 @@
       ],
       "rationale": "Authorize a deliberate 75000-byte aggregate development envelope for the remaining v5 alpha runtime work. The exact stack-fallback and unbound-getUI diagnostic prototype proves the previous ceiling is exhausted and grows every main delivery format, while the larger envelope keeps the duplicated-format package sum as a runaway-growth backstop instead of an incentive to byte-golf clean runtime contracts. Exact-base artifact and graph reporting, growth approval, resource checks, and later consumer-scenario budgets remain independent gates.",
       "rollbackCondition": "If the stack-fallback and unbound-getUI prototype is abandoned before consumption, append a governance-only BA0003 revocation. Never edit or delete this authorization. Before beta promotion, review the envelope against the completed core and canonical dependency-inclusive consumer scenarios; if a final runtime implementation exceeds 75000 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
+    },
+    {
+      "kind": "authorization",
+      "id": "BA0004",
+      "target": "aggregate-shipped-package",
+      "previousCeilingBytes": 75000,
+      "proposedCeilingBytes": 75799,
+      "prototypeBaseCommit": "8a325835dee059ec0b2ec4f13205887113aeffd1",
+      "prototypeCommit": "7d927a4c87e73e4a4f14cac33049caac69edfb67",
+      "implementationIssueUrl": "https://github.com/marionettejs/marionette/issues/190",
+      "authorizedArtifactPaths": [
+        "dist/marionette.cjs",
+        "dist/marionette.js",
+        "dist/marionette.min.js",
+        "dist/marionette.umd.js"
+      ],
+      "authorizedNewSubpaths": [],
+      "reports": [
+        {
+          "path": "evidence/performance-budget-amendments/BA0004/base.json",
+          "role": "base",
+          "sha256": "8229294337280e06f2bf612d37ebfa14082da7500b5a7f68552ef1168faa37f8"
+        },
+        {
+          "path": "evidence/performance-budget-amendments/BA0004/prototype.json",
+          "role": "prototype",
+          "sha256": "63f6f44abd2ce99ea33573c67987a14f9011c8ff8439ce49d7be69edada1306a"
+        }
+      ],
+      "prototypeContract": {
+        "path": "evidence/performance-budget-amendments/BA0004/prototype-contract.json",
+        "sha256": "14dc09d94aebc78b776ee17c5a28436e2438b83323326cc5a1244ce2b7d1cec8"
+      },
+      "approvalUrls": [
+        "https://github.com/marionettejs/marionette/pull/351#issuecomment-5494696235"
+      ],
+      "evidenceUrls": [
+        "https://github.com/marionettejs/marionette/issues/127#issuecomment-5494678733"
+      ],
+      "rationale": "Authorize the exact measured distribution cost of completing Application root View and Region ownership together with Application State composition. The prototype uses one Application lifecycle and one existing State mixin, grows only the four established main artifacts, adds no module-graph edge, external import, package subpath, eager stateless allocation, Toolkit lifecycle flag, compatibility alias, or speculative headroom.",
+      "rollbackCondition": "If the Application root ownership and State prototype is abandoned before consumption, append a governance-only BA0004 revocation. Never edit or delete this authorization. If the final implementation exceeds 75799 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
     }
   ]
 }

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -136,9 +136,9 @@ prototype completes root View and constructed-versus-borrowed Region ownership
 together with lazy Application State composition. It grows only the four existing
 main delivery artifacts, adds no production graph edge, external import, package
 subpath, stateless allocation proxy, or speculative headroom, and leaves the 18
-consumer scenarios reporting-only. A later runtime pull request must consume the
-authorization from its merged exact base and obtain independent exact-head growth
-approval.
+consumer scenario/format combinations reporting-only. A later runtime pull request
+must consume the authorization from its merged exact base and obtain independent
+exact-head growth approval.
 
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -112,7 +112,7 @@ the reviewed prototype total without padding, adds no production subpath, and
 does not include allowance for later Underscore work. #254 consumed that
 authorization.
 
-BA0003 authorizes a pending increase from 52,565 to 75,000 bytes as a deliberate
+BA0003 authorized an increase from 52,565 to 75,000 bytes as a deliberate
 development envelope for the remaining v5 alpha runtime work. Its exact-base
 [#134](https://github.com/marionettejs/marionette/issues/134) stack-fallback and
 unbound-`getUI` diagnostic prototype proves that the previous ceiling is exhausted
@@ -125,6 +125,20 @@ and graph reports, exact-head growth approval, resource checks, and adopted cons
 scenario budgets remain independent gates. Before beta promotion, the envelope must
 be reviewed against the completed core and canonical dependency-inclusive consumer
 scenarios; unused headroom does not establish release readiness.
+[PR #257](https://github.com/marionettejs/marionette/pull/257) consumed that
+authorization.
+
+BA0004 authorizes a pending exact-prototype increase from 75,000 to 75,799
+bytes for the remaining production-runtime Application work tracked by
+[#190](https://github.com/marionettejs/marionette/issues/190) and
+[#191](https://github.com/marionettejs/marionette/issues/191). The measured
+prototype completes root View and constructed-versus-borrowed Region ownership
+together with lazy Application State composition. It grows only the four existing
+main delivery artifacts, adds no production graph edge, external import, package
+subpath, stateless allocation proxy, or speculative headroom, and leaves the 18
+consumer scenarios reporting-only. A later runtime pull request must consume the
+authorization from its merged exact base and obtain independent exact-head growth
+approval.
 
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole

--- a/evidence/performance-budget-amendments/BA0004/base.json
+++ b/evidence/performance-budget-amendments/BA0004/base.json
@@ -1,0 +1,679 @@
+{
+  "schemaVersion": 1,
+  "revision": "8a325835dee059ec0b2ec4f13205887113aeffd1",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 19649,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 19728,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 20029,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 14876,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 161,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 180,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 74976,
+      "baselineSize": 49500,
+      "absoluteCeiling": 75000
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/features.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/features.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 14784,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14793,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 14839,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 14634,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14642,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 14681,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 14825,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14822,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 14880,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 14831,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14836,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 14885,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 14868,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14872,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 14945,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": []
+  }
+}

--- a/evidence/performance-budget-amendments/BA0004/prototype-contract.json
+++ b/evidence/performance-budget-amendments/BA0004/prototype-contract.json
@@ -1,0 +1,343 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "sourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "totalBrotliBytes": 49500,
+    "absoluteCeilingBytes": 75000
+  },
+  "toolchain": {
+    "releaseProfile": {
+      "path": "config/release-profile.json",
+      "sha256": "405b0135261d44bc5c1cb7832f7bbdbcadfe8415704e40e14abee217ce2e5162",
+      "node": "24.19.0",
+      "npm": "11.17.0",
+      "lockfileVersion": 3,
+      "canonicalHost": {
+        "id": "linux-x64",
+        "runner": "ubuntu-24.04",
+        "platform": "linux",
+        "architecture": "x64"
+      }
+    },
+    "lockedDependencies": {
+      "backbone": "1.4.0",
+      "jsdom": "30.0.1",
+      "rollup": "4.63.0"
+    },
+    "commands": {
+      "deterministic": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run size"
+      ],
+      "hostedTiming": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run performance:timing"
+      ]
+    }
+  },
+  "thresholds": {
+    "cumulativeGrowthPercent": 5,
+    "pullRequestApprovalPercent": 1,
+    "hostedTimingWarningPercent": 10,
+    "controlledMedianRegressionPercent": 5,
+    "controlledP95RegressionPercent": 10
+  },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
+  "runtimeArtifacts": [
+    {
+      "name": "Main ES module",
+      "path": "dist/marionette.js",
+      "baselineBrotliBytes": 12776
+    },
+    {
+      "name": "Main CommonJS",
+      "path": "dist/marionette.cjs",
+      "baselineBrotliBytes": 12932
+    },
+    {
+      "name": "Main UMD",
+      "path": "dist/marionette.umd.js",
+      "baselineBrotliBytes": 13197
+    },
+    {
+      "name": "Main minified UMD",
+      "path": "dist/marionette.min.js",
+      "baselineBrotliBytes": 10001,
+      "additionalShippedArtifact": true
+    },
+    {
+      "name": "Backbone shim ES module",
+      "path": "dist/backbone.js",
+      "baselineBrotliBytes": 121
+    },
+    {
+      "name": "Backbone shim CommonJS",
+      "path": "dist/backbone.cjs",
+      "baselineBrotliBytes": 135
+    },
+    {
+      "name": "jQuery DomApi ES module",
+      "path": "dist/jquery-dom-api.js",
+      "baselineBrotliBytes": 169
+    },
+    {
+      "name": "jQuery DomApi CommonJS",
+      "path": "dist/jquery-dom-api.cjs",
+      "baselineBrotliBytes": 169
+    }
+  ],
+  "productionGraphs": [
+    {
+      "subpath": ".",
+      "input": "index.js",
+      "output": "dist/marionette.js",
+      "baselineModules": [
+        "config/dom.js",
+        "config/event-delegator.js",
+        "config/features.js",
+        "config/renderer.js",
+        "index.js",
+        "mixins/behaviors.js",
+        "mixins/common.js",
+        "mixins/delegate-entity-events.js",
+        "mixins/destroy.js",
+        "mixins/events.js",
+        "mixins/radio.js",
+        "mixins/requests.js",
+        "mixins/template-render.js",
+        "mixins/ui.js",
+        "mixins/view-events.js",
+        "mixins/view.js",
+        "modules/application.js",
+        "modules/behavior.js",
+        "modules/child-view-container.js",
+        "modules/collection-view.js",
+        "modules/common/bind-events.js",
+        "modules/common/bind-requests.js",
+        "modules/common/get-option.js",
+        "modules/common/merge-options.js",
+        "modules/common/monitor-view-events.js",
+        "modules/common/normalize-methods.js",
+        "modules/common/radio.js",
+        "modules/common/trigger-method.js",
+        "modules/common/view.js",
+        "modules/object.js",
+        "modules/radio.js",
+        "modules/view-region.js",
+        "utils/build-event-args.js",
+        "utils/call-handler.js",
+        "utils/error.js",
+        "utils/extend.js",
+        "utils/make-callback.js",
+        "utils/once-wrap.js",
+        "utils/proxy.js",
+        "version.js"
+      ],
+      "baselineExternalImports": [
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./backbone",
+      "input": "backbone.js",
+      "output": "dist/backbone.js",
+      "baselineModules": [
+        "backbone.js"
+      ],
+      "baselineExternalImports": [
+        "backbone",
+        "marionette",
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./jquery-dom-api",
+      "input": "jquery-dom-api.js",
+      "output": "dist/jquery-dom-api.js",
+      "baselineModules": [
+        "jquery-dom-api.js"
+      ],
+      "baselineExternalImports": [
+        "jquery"
+      ]
+    }
+  ],
+  "forbiddenExternalImports": [
+    "underscore"
+  ],
+  "forbiddenProductionModulePrefixes": [
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "docs-site/",
+    "node_modules/",
+    "scripts/",
+    "test/",
+    "config/diagnostics/",
+    "config/release/"
+  ],
+  "forbiddenProductionModules": [
+    "config/performance.json",
+    "config/release-profile.json",
+    "config/release-promotion.json"
+  ],
+  "deterministicResources": {
+    "attachDetachCycles": 100,
+    "mountDestroyCycles": 1000,
+    "instanceShapes": {
+      "View": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_domEvents",
+        "_eventPrefix",
+        "_isAttached",
+        "_isRendered",
+        "_rdEvents",
+        "_regions",
+        "cid",
+        "el",
+        "options",
+        "regions"
+      ],
+      "Region": [
+        "_initEl",
+        "cid",
+        "el",
+        "options"
+      ],
+      "Behavior": [
+        "_domEvents",
+        "_rdListenId",
+        "_rdListeningTo",
+        "cid",
+        "el",
+        "options",
+        "ui",
+        "view"
+      ],
+      "CollectionView": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_children",
+        "_collectionEvents",
+        "_domEvents",
+        "_emptyRegion",
+        "_eventPrefix",
+        "_isAttached",
+        "_rdEvents",
+        "childView",
+        "children",
+        "cid",
+        "collection",
+        "el",
+        "options"
+      ]
+    },
+    "allocationShapes": {
+      "View": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "_regions",
+          "options",
+          "regions"
+        ],
+        "marionetteEventRegistrations": 6
+      },
+      "Behavior": {
+        "emptyArrays": [
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "options",
+          "ui"
+        ],
+        "listeningContainers": 1
+      },
+      "CollectionView": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyChildViewContainers": [
+          "_children",
+          "children"
+        ],
+        "eagerEmptyRegion": true,
+        "marionetteEventRegistrations": 6
+      }
+    },
+    "retentionShapes": {
+      "regionRegistrationsWhileShown": 1,
+      "collectionRegistrationsWhileMounted": 3,
+      "modelRegistrationsWhileMounted": 1,
+      "externalListenerOwnersWhileMounted": 1,
+      "collectionViewListeningToWhileMounted": 1,
+      "behaviorListeningToWhileMounted": 2,
+      "destroyedBehaviorRetainsHostReference": true,
+      "destroyedHostRetainsBehaviorCount": 1,
+      "externalRegistrationsAfterDestroy": 0,
+      "externalListenerOwnersAfterDestroy": 0,
+      "frameworkListeningToAfterDestroy": 0,
+      "childContainerEntriesAfterDestroy": 0,
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
+    }
+  },
+  "timing": {
+    "harnessSchemaVersion": 1,
+    "harnessRevision": "271128bee00c66b3168424d65220dbe6c5dbea1f336082c21b45a07a344bb1d9",
+    "sampleCount": 20,
+    "warmupBatches": 5,
+    "cases": [
+      {
+        "id": "view-construct-destroy",
+        "iterationsPerSample": 200
+      },
+      {
+        "id": "view-render-rerender",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "behavior-view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "region-show-empty",
+        "iterationsPerSample": 50
+      },
+      {
+        "id": "collection-view-render-destroy",
+        "iterationsPerSample": 10
+      },
+      {
+        "id": "collection-view-add-remove",
+        "iterationsPerSample": 20
+      }
+    ],
+    "controlledRunner": {
+      "status": "pending-pr-b"
+    }
+  }
+}

--- a/evidence/performance-budget-amendments/BA0004/prototype.json
+++ b/evidence/performance-budget-amendments/BA0004/prototype.json
@@ -1,0 +1,681 @@
+{
+  "schemaVersion": 1,
+  "revision": "7d927a4c87e73e4a4f14cac33049caac69edfb67",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 19874,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 19941,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 20239,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 15051,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 161,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 180,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 75799,
+      "baselineSize": 49500,
+      "absoluteCeiling": 75000
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/features.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/features.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 14966,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14977,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 15016,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 14820,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14825,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 14867,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 15010,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15009,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 15067,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15015,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15015,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15077,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15044,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15054,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15116,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": [
+      "Cumulative Brotli-11 size 75799 exceeds the absolute ceiling 75000"
+    ]
+  }
+}


### PR DESCRIPTION
Related #190
Related #191

## What

- Record immutable exact-base and exact-prototype bundle, graph, consumer, and resource evidence for BA0004.
- Authorize an aggregate shipped-package ceiling of 75,799 bytes for the measured Application root ownership and State prototype.
- Preserve the two-stage contract: this governance PR does not change runtime source, distribution artifacts, or the active ceiling.

## Why

Current `master` measures 74,976 bytes against the 75,000-byte v5 alpha envelope. The exact reviewed prototype at `7d927a4c87e73e4a4f14cac33049caac69edfb67` measures 75,799 bytes, so the runtime PR cannot pass or authorize its own size gate. BA0004 raises the ceiling only to the measured prototype total, with no speculative headroom.

## Scope

This PR is governance-only: the append-only budget ledger, immutable BA0004 evidence, and performance-baseline documentation. It authorizes positive deltas only in the four existing main Marionette artifacts and no new package subpath.

Runtime Application behavior, `dist/`, package exports, workflows, repository settings, and PR #333 are intentionally unchanged.

## Deployment Impact

No package publication, deployment, tag, or repository-setting change is included. A later runtime PR based on this merged authorization must independently consume the ceiling and pass exact-head growth approval.

## Testing

- Measured base `8a325835dee059ec0b2ec4f13205887113aeffd1`: 74,976 bytes, no contract violations.
- Measured prototype `7d927a4c87e73e4a4f14cac33049caac69edfb67`: 75,799 bytes, only the expected current-ceiling violation.
- Verified all 18 consumer scenarios/formats on both revisions.
- Verified unchanged root production graph size, external imports, and deterministic allocation/retention proxies.
- Parsed all three evidence files with `jq` and verified their SHA-256 hashes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorizes the BA0004 budget amendment by raising the shipped-package ceiling from 75,000 to 75,799 bytes for the Application root ownership and State prototype (#190, #191), and records immutable evidence. This is a governance-only PR: no runtime source, `dist/` artifacts, package exports, workflows, or repository settings change.

**Evidence**
- Adds base, prototype, and contract evidence files under `evidence/performance-budget-amendments/BA0004/`, and marks the BA0003 authorization as consumed.
- The new ceiling matches the exact measured prototype total with no speculative headroom, growing only the four main delivery artifacts.
- Consumer measurements stay reporting-only, and a later runtime PR must consume the new ceiling independently and pass exact-head growth approval.

<sup>Written for commit 1458932e6479b2c2754e21bc4150f2ddfa52287b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Updated performance budget records to document the approved aggregate package-size ceiling increase from 75,000 to 75,799 bytes.
  - Marked the previous budget amendment as consumed and linked it to the completed change.
  - Added baseline and prototype measurement reports covering build sizes, bundle composition, dependencies, resource usage, and timing thresholds.
  - Documented a current cumulative-size limit exceedance for tracking and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->