### PR TITLE
docs(v5): make application and state guidance executable

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -20,6 +20,7 @@ The `Application` `cidPrefix` is `mna`.
 * [Instantiating An Application](#instantiating-an-application)
 * [Application Lifecycle](#application-lifecycle)
 * [Application Ownership](#application-ownership)
+* [Application and root View communication](#application-and-root-view-communication)
 * [Application State](#application-state)
 * [Application Region](#application-region)
 * [Application Region Methods](#application-region-methods)
@@ -210,6 +211,129 @@ started directly before entering destroy readiness. A concurrent direct child
 destroy joins terminal teardown and may remove that child before parent
 readiness. If child stop or destroy readiness fails, the parent returns to its
 prior stable state and retains that child so destruction can be retried.
+
+The canonical child-Application pattern is explicit construction followed by
+ownership registration. Registration means lifecycle ownership; it is not a
+dormant service registry and it has no per-child lifecycle flags. Put a service
+that must outlive an Application under a longer-lived owner and pass it to the
+shorter-lived child as a dependency.
+
+<!-- executable-example: application-child-ownership -->
+```javascript
+import { Application } from 'marionette';
+
+export const lifecycle = [];
+
+const SearchApplication = Application.extend({
+  onBeforeStart(app, options) {
+    lifecycle.push(`search:before:start:${ options.source }`);
+  },
+
+  onStart(app, options) {
+    lifecycle.push(`search:start:${ options.source }`);
+  },
+
+  onBeforeStop(app, options) {
+    lifecycle.push(`search:before:stop:${ options.source }`);
+  },
+
+  onStop(app, options) {
+    lifecycle.push(`search:stop:${ options.source }`);
+  },
+
+  onDestroy() {
+    lifecycle.push('search:destroy');
+  }
+});
+
+const RootApplication = Application.extend({
+  onBeforeStart(app, options) {
+    lifecycle.push(`root:before:start:${ options.source }`);
+  },
+
+  onStart(app, options) {
+    lifecycle.push(`root:start:${ options.source }`);
+  },
+
+  onBeforeStop(app, options) {
+    lifecycle.push(`root:before:stop:${ options.source }`);
+  },
+
+  onStop(app, options) {
+    lifecycle.push(`root:stop:${ options.source }`);
+  },
+
+  onDestroy() {
+    lifecycle.push('root:destroy');
+  }
+});
+
+export const root = new RootApplication();
+export const search = root.addChildApp('search', new SearchApplication());
+
+export const started = await root.start({ source: 'owner' });
+export const stopped = await root.stop({ source: 'owner' });
+```
+
+## Application and root View communication
+
+Keep the ownership direction visible. The Application constructs the root View,
+passes dependencies and initial values down through its options or public methods,
+and listens to semantic View events for messages back up. The View should not find
+its Application through DOM ancestry or private ownership fields. Use Radio only
+when the sender and receiver do not share this direct ownership boundary.
+
+<!-- executable-example: application-root-view-communication -->
+```javascript
+import { Application, View } from 'marionette';
+
+export const refreshes = [];
+
+const DashboardView = View.extend({
+  initialize(options) {
+    this.initialStatus = options.initialStatus;
+  },
+
+  template() {
+    return '<button class="refresh">Refresh</button><p class="status"></p>';
+  },
+
+  events: {
+    'click .refresh': 'requestRefresh'
+  },
+
+  onRender() {
+    this.showStatus(this.initialStatus);
+  },
+
+  requestRefresh() {
+    this.trigger('refresh:requested', this, { source: 'button' });
+  },
+
+  showStatus(status) {
+    this.el.querySelector('.status').textContent = status;
+  }
+});
+
+const DashboardApplication = Application.extend({
+  region: '#dashboard',
+
+  onStart() {
+    const view = new DashboardView({ initialStatus: 'Idle' });
+    this.listenTo(view, 'refresh:requested', this.refreshDashboard);
+    this.showView(view);
+  },
+
+  refreshDashboard(view, request) {
+    refreshes.push(request);
+    view.showStatus('Updated');
+  }
+});
+
+export const dashboard = new DashboardApplication();
+await dashboard.start();
+export const dashboardView = dashboard.getView();
+```
 
 ## Application State
 

--- a/docs/marionette.state.md
+++ b/docs/marionette.state.md
@@ -66,6 +66,58 @@ const ToggleView = View.extend({
 });
 ```
 
+A stateless View stays a plain View. Add State only when the value belongs to
+that View's lifetime and is not domain data.
+
+<!-- executable-example: view-local-state -->
+```javascript
+import { View } from 'marionette';
+
+const LabelView = View.extend({
+  template() {
+    return '<span>Account</span>';
+  }
+});
+
+const DisclosureView = View.extend({
+  state: {
+    open: false
+  },
+
+  template() {
+    return '<button class="toggle">Details</button>';
+  },
+
+  events: {
+    'click .toggle': 'toggle'
+  },
+
+  stateEvents: {
+    'change:open': 'showOpenState'
+  },
+
+  onRender() {
+    this.showOpenState(this.getState(), this.getState().get('open'));
+  },
+
+  toggle() {
+    const state = this.getState();
+    state.set('open', !state.get('open'));
+  },
+
+  showOpenState(state, open) {
+    this.el.dataset.open = String(open);
+  }
+});
+
+export const label = new LabelView({
+  el: document.querySelector('#label')
+}).render();
+export const disclosure = new DisclosureView({
+  el: document.querySelector('#disclosure')
+}).render();
+```
+
 Owners expose only `getState()`. Read and change local values through the
 returned State; owners do not duplicate `get`, `set`, `has`, `reset`, or
 toggle methods. State remains distinct from the owner's `model`, `collection`,
@@ -95,6 +147,147 @@ persists across its owning View's render. Application State persists across
 stop and restart. Owner destruction destroys State and releases `stateEvents`;
 late `getState()` calls return a destroyed State whose writes are
 lifecycle-safe no-ops.
+
+Application State follows the Application rather than one rendered View. Use it
+for local orchestration values that must survive stop and restart. Commit values
+from asynchronous readiness work only while its operation signal remains active.
+Application readiness hooks receive an operation context as their third argument;
+its `signal` is a browser `AbortSignal` that Marionette aborts when a later
+operation invalidates that readiness phase.
+
+<!-- executable-example: application-local-state -->
+```javascript
+import { Application } from 'marionette';
+
+export const SessionApplication = Application.extend({
+  state: {
+    phase: 'idle'
+  },
+
+  stateEvents: {
+    'change:phase': 'recordPhase'
+  },
+
+  initialize(options = {}) {
+    this.phases = [];
+    this.loadPhase = options.loadPhase || (phase => Promise.resolve(phase));
+  },
+
+  async onBeforeStart(app, options, { signal }) {
+    const phase = await this.loadPhase(options.phase);
+    if (!signal.aborted) {
+      this.getState().set('phase', phase);
+    }
+  },
+
+  onBeforeStop() {
+    this.getState().set('phase', 'stopped');
+  },
+
+  recordPhase(state, phase) {
+    this.phases.push(phase);
+  }
+});
+
+export const session = new SessionApplication();
+export const sessionState = session.getState();
+export const phases = session.phases;
+
+await session.start({ phase: 'ready' });
+await session.stop();
+await session.start({ phase: 'resumed' });
+
+let resolveStalePhase;
+const stalePhase = new Promise(complete => {
+  resolveStalePhase = complete;
+});
+export const cancelledSession = new SessionApplication({
+  loadPhase() {
+    return stalePhase;
+  }
+});
+export const cancelledState = cancelledSession.getState();
+
+const pendingStart = cancelledSession.start({ phase: 'stale' });
+const replacementStop = cancelledSession.stop();
+resolveStalePhase('stale');
+
+export const pendingStartResult = await pendingStart;
+export const replacementStopResult = await replacementStop;
+```
+
+Behavior State belongs to the Behavior only when the concern is private to that
+Behavior. State shared with its host belongs to the View; the Behavior reads the
+View's State through `this.view.getState()` but does not compose or destroy it.
+Cross-owner or persisted domain data belongs in a model, collection, or another
+explicit data source instead.
+
+<!-- executable-example: behavior-state-ownership -->
+```javascript
+import { Behavior, View } from 'marionette';
+
+const DisclosureBehavior = Behavior.extend({
+  state: {
+    open: false
+  },
+
+  events: {
+    'click .disclosure': 'toggleDisclosure'
+  },
+
+  stateEvents: {
+    'change:open': 'showDisclosureState'
+  },
+
+  toggleDisclosure() {
+    const state = this.getState();
+    state.set('open', !state.get('open'));
+  },
+
+  showDisclosureState(state, open) {
+    this.view.el.dataset.disclosureOpen = String(open);
+  }
+});
+
+const SelectionBehavior = Behavior.extend({
+  events: {
+    'click .selection': 'select'
+  },
+
+  select() {
+    this.view.getState().set('selected', true);
+  }
+});
+
+const SettingsView = View.extend({
+  state: {
+    selected: false
+  },
+
+  stateEvents: {
+    'change:selected': 'showSelectionState'
+  },
+
+  behaviors: [DisclosureBehavior, SelectionBehavior],
+
+  template() {
+    return '<button class="disclosure">Details</button><button class="selection">Select</button>';
+  },
+
+  onRender() {
+    this.el.dataset.disclosureOpen = 'false';
+    this.showSelectionState(this.getState(), this.getState().get('selected'));
+  },
+
+  showSelectionState(state, selected) {
+    this.el.dataset.selected = String(selected);
+  }
+});
+
+export const settings = new SettingsView({
+  el: document.querySelector('#settings')
+}).render();
+```
 
 ### Supplying a State instance
 

--- a/test/fixtures/docs-application-state/package.json
+++ b/test/fixtures/docs-application-state/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "dependencies": {
+    "jsdom": "30.0.1"
+  }
+}

--- a/test/fixtures/docs-application-state/validate.mjs
+++ b/test/fixtures/docs-application-state/validate.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(__dirname, 'dist');
+const markers = {
+  applicationOwnership: '<!-- executable-example: application-child-ownership -->',
+  applicationState: '<!-- executable-example: application-local-state -->',
+  applicationView: '<!-- executable-example: application-root-view-communication -->',
+  behaviorState: '<!-- executable-example: behavior-state-ownership -->',
+  viewState: '<!-- executable-example: view-local-state -->',
+};
+
+async function writeExample(documentName, marker, outputName) {
+  const docsPath = resolve(__dirname, `../../../docs/${ documentName }`);
+  const markdown = await readFile(docsPath, 'utf8');
+
+  assert.equal(markdown.split(marker).length - 1, 1, `expected one ${ marker }`);
+
+  const markedContent = markdown.slice(markdown.indexOf(marker) + marker.length);
+  const codeFence = markedContent.match(/^\s*```javascript\n([\s\S]*?)\n```/);
+
+  assert.ok(codeFence, `expected a JavaScript fence immediately after ${ marker }`);
+
+  const examplePath = resolve(distDir, outputName);
+  await writeFile(examplePath, codeFence[1], 'utf8');
+  return examplePath;
+}
+
+await mkdir(distDir, { recursive: true });
+
+const examples = {
+  applicationOwnership: await writeExample(
+    'marionette.application.md',
+    markers.applicationOwnership,
+    'application-child-ownership.mjs',
+  ),
+  applicationView: await writeExample(
+    'marionette.application.md',
+    markers.applicationView,
+    'application-root-view-communication.mjs',
+  ),
+  applicationState: await writeExample(
+    'marionette.state.md',
+    markers.applicationState,
+    'application-local-state.mjs',
+  ),
+  behaviorState: await writeExample(
+    'marionette.state.md',
+    markers.behaviorState,
+    'behavior-state-ownership.mjs',
+  ),
+  viewState: await writeExample(
+    'marionette.state.md',
+    markers.viewState,
+    'view-local-state.mjs',
+  ),
+};
+
+const dom = new JSDOM(`<!doctype html>
+  <html>
+    <body>
+      <main id="dashboard"></main>
+      <div id="label"></div>
+      <div id="disclosure"></div>
+      <div id="settings"></div>
+    </body>
+  </html>`);
+
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+
+let ownership;
+let applicationView;
+let applicationState;
+let behaviorState;
+let viewState;
+
+try {
+  ownership = await import(pathToFileURL(examples.applicationOwnership));
+
+  assert.equal(ownership.started, true, 'the owner start must complete');
+  assert.equal(ownership.stopped, true, 'the owner stop must complete');
+  assert.equal(ownership.root.isRunning(), false, 'the root must finish stopped');
+  assert.equal(ownership.search.isRunning(), false, 'the child must follow its owner stop');
+  assert.equal(ownership.root.getChildApp('search'), ownership.search, 'the child must be registered by name');
+  assert.equal(ownership.search.getParentApp(), ownership.root, 'the child must expose its owner');
+  assert.deepEqual(ownership.lifecycle, [
+    'root:before:start:owner',
+    'search:before:start:owner',
+    'search:start:owner',
+    'root:start:owner',
+    'root:before:stop:owner',
+    'search:before:stop:owner',
+    'search:stop:owner',
+    'root:stop:owner',
+  ], 'owner lifecycle must wrap sequential child lifecycle');
+
+  applicationView = await import(pathToFileURL(examples.applicationView));
+
+  assert.equal(applicationView.dashboard.isRunning(), true, 'the dashboard must finish startup');
+  assert.equal(applicationView.dashboard.getView(), applicationView.dashboardView, 'the Application must expose its root View');
+  assert.equal(document.querySelector('#dashboard .status').textContent, 'Idle', 'the root View must render its initial status');
+
+  applicationView.dashboardView.el.querySelector('.refresh').click();
+
+  assert.deepEqual(applicationView.refreshes, [{ source: 'button' }], 'the View must send one semantic request');
+  assert.equal(document.querySelector('#dashboard .status').textContent, 'Updated', 'the Application must communicate down through a public View method');
+
+  viewState = await import(pathToFileURL(examples.viewState));
+
+  assert.equal(viewState.label.el.textContent, 'Account', 'the stateless View must render normally');
+  assert.equal(viewState.disclosure.getState().get('open'), false, 'the View must own its initial local State');
+  assert.equal(viewState.disclosure.el.dataset.open, 'false', 'render must reflect initial State');
+
+  viewState.disclosure.el.querySelector('.toggle').click();
+
+  assert.equal(viewState.disclosure.getState().get('open'), true, 'the View event must update its State');
+  assert.equal(viewState.disclosure.el.dataset.open, 'true', 'the State event must update the View');
+
+  applicationState = await import(pathToFileURL(examples.applicationState));
+  const { State } = await import('marionette');
+
+  assert.equal(applicationState.session.isRunning(), true, 'the Session Application must finish restarted');
+  assert.ok(applicationState.sessionState instanceof State, 'State must be exported from the packed root entrypoint');
+  assert.equal(applicationState.session.getState(), applicationState.sessionState, 'Application State must persist across stop and restart');
+  assert.equal(applicationState.sessionState.get('phase'), 'resumed', 'the restarted Application must commit current readiness State');
+  assert.deepEqual(applicationState.phases, ['ready', 'stopped', 'resumed'], 'State events must observe each lifecycle-owned phase');
+  assert.equal(applicationState.pendingStartResult, false, 'stop must supersede the pending start');
+  assert.equal(applicationState.replacementStopResult, true, 'the replacement stop must complete');
+  assert.equal(applicationState.cancelledState.get('phase'), 'stopped', 'stale startup must not overwrite State after cancellation');
+
+  const destroyedBehaviorStates = new Set();
+  const destroyState = State.prototype.destroy;
+  State.prototype.destroy = function() {
+    destroyedBehaviorStates.add(this);
+    return destroyState.call(this);
+  };
+
+  try {
+    behaviorState = await import(pathToFileURL(examples.behaviorState));
+
+    assert.equal(behaviorState.settings.el.dataset.disclosureOpen, 'false', 'the host must reflect private Behavior State initially');
+    assert.equal(behaviorState.settings.el.dataset.selected, 'false', 'the host must reflect shared View State initially');
+
+    behaviorState.settings.el.querySelector('.disclosure').click();
+    behaviorState.settings.el.querySelector('.selection').click();
+
+    assert.equal(behaviorState.settings.el.dataset.disclosureOpen, 'true', 'private Behavior State must update its host through the Behavior');
+    assert.equal(behaviorState.settings.getState().get('selected'), true, 'shared State must belong to the host View');
+    assert.equal(behaviorState.settings.el.dataset.selected, 'true', 'shared View State must notify the host');
+
+    const settingsState = behaviorState.settings.getState();
+    behaviorState.settings.destroy();
+
+    assert.equal(settingsState.isDestroyed(), true, 'host destroy must destroy shared View State');
+    assert.equal(destroyedBehaviorStates.size, 2, 'host destroy must destroy shared View and private Behavior State');
+  } finally {
+    State.prototype.destroy = destroyState;
+  }
+} finally {
+  if (applicationState?.session && !applicationState.session.isDestroyed()) {
+    await applicationState.session.destroy();
+    assert.equal(applicationState.sessionState.isDestroyed(), true, 'Application destroy must destroy owned State');
+  }
+  if (applicationState?.cancelledSession && !applicationState.cancelledSession.isDestroyed()) {
+    await applicationState.cancelledSession.destroy();
+    assert.equal(applicationState.cancelledState.isDestroyed(), true, 'cancelled Application teardown must destroy owned State');
+  }
+  behaviorState?.settings?.destroy();
+  if (viewState?.label && !viewState.label.isDestroyed()) {
+    viewState.label.destroy();
+  }
+  if (viewState?.disclosure && !viewState.disclosure.isDestroyed()) {
+    const disclosureState = viewState.disclosure.getState();
+    viewState.disclosure.destroy();
+    assert.equal(disclosureState.isDestroyed(), true, 'View destroy must destroy owned State');
+  }
+  if (applicationView?.dashboard && !applicationView.dashboard.isDestroyed()) {
+    const dashboardView = applicationView.dashboardView;
+    await applicationView.dashboard.destroy();
+    assert.equal(dashboardView.isDestroyed(), true, 'Application teardown must destroy its root View through the Region');
+  }
+  if (ownership?.root && !ownership.root.isDestroyed()) {
+    await ownership.root.destroy();
+    assert.equal(ownership.search.isDestroyed(), true, 'owner destroy must destroy the child Application');
+    assert.equal(ownership.root.getChildApp('search'), undefined, 'owner destroy must clear child registration');
+    assert.deepEqual(
+      ownership.lifecycle.slice(-2),
+      ['search:destroy', 'root:destroy'],
+      'owner destroy must complete child destruction first',
+    );
+  }
+  dom.window.close();
+  delete globalThis.document;
+  delete globalThis.window;
+}


### PR DESCRIPTION
## Linked issue

- Related #190
- Related #191
- Related #140

## What

- Document explicit child Application ownership and direct Application/root-View communication.
- Add executable View, Application, and Behavior State ownership examples.
- Validate all five examples against the freshly packed package, including lifecycle order, stale-start cancellation, and teardown.

## Why

The v5 runtime contracts are implemented, but the remaining stable-release work requires canonical patterns that agents and humans can execute instead of inferring ownership and lifecycle behavior from source.

## Agent-development failure addressed

- Makes ownership direction, lifecycle propagation, State placement, cancellation, and teardown observable through copyable public-API examples.
- Prevents agents from treating child registration as a dormant service registry or finding an Application through DOM/private ownership state.

## Public behavior contract

- Canonical behavior after this PR: construct child Applications explicitly, register only owned children, communicate across the direct root boundary with View options/methods downward and semantic View events upward, and place local State on the owner whose lifetime it follows.
- Superseded behavior removed, if any: none; this documents existing v5 behavior.
- Compatibility exception and removal condition, if any: none.

## Runtime cost

- [x] Static or documentation only
- [x] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: 0 B across all production artifacts and canonical consumer scenarios.
- Startup/hot path: no production change; hosted timing remained reporting-only with no warning.
- Allocations/retention: no production change; the packed fixture verifies owner-driven teardown.

## Scope

This changes Application and State documentation plus one packed-package fixture. It does not change production runtime behavior, package exports, generated distributions, performance budgets, or the benchmark corpus.

## Deployment Impact

No application redeploy or package publication is required. Documentation publication remains governed by the existing post-beta release process.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npm run docs:check
npm run lint:ci
npm run test:source
npm run test:fixtures
```

All four commands passed locally. PR CI also passed documentation build, Node 24, Node-current advisory, CodeQL, bundle size, package smoke on macOS and Windows, verified-tarball smoke, performance reporting, and promotion dry run.

## Package and browser impact

- Entry points or install fixtures affected: no entrypoint changes; adds one packed-package documentation fixture.
- Browser contracts affected: validates root-View communication and State behavior in JSDOM; no runtime browser behavior changes.
- Production/dev/test module-graph impact: no production graph change; one test-only fixture.

## Rollback or deprecation

Revert the documentation and its fixture together if a referenced v5 contract changes before stable. Do not leave examples that no longer pass the packed-package fixture.

## Review notes

- The packed fixture extracts the exact marked code fences rather than duplicating their implementation.
- Bounded Claude review received the actual diff. It led to explicit AbortSignal guidance, a documented stale-start race, executable private-Behavior versus shared-View State ownership, and teardown assertions for both State instances.
- CodeRabbit and Copilot generated no actionable inline comments.
