### PR TITLE
feat(performance): govern timing harness revisions

### DIFF
--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -311,6 +311,25 @@ fields:
 ```
 ````
 
+A timing-harness-only record also leaves `approvedPaths` empty and binds the
+candidate contract to the SHA-256 of the committed harness file:
+
+````markdown
+<!-- marionette-performance-growth-approval:v1 -->
+```json
+{
+  "schemaVersion": 1,
+  "headSha": "0123456789abcdef0123456789abcdef01234567",
+  "issueUrl": "https://github.com/marionettejs/marionette/issues/127",
+  "approvedPaths": [],
+  "approvedTimingHarnessRevision": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "evidenceUrls": [
+    "https://github.com/marionettejs/marionette/issues/127#issuecomment-123456789"
+  ]
+}
+```
+````
+
 `approvedNewArtifacts` is empty when a new public subpath aliases an already tracked
 runtime artifact. The new subpath still requires exact-head approval even though it
 adds zero artifact bytes. Conversely, a new runtime artifact without a corresponding
@@ -328,7 +347,15 @@ well-formed `forbiddenExternalImports` list or add entries to an existing list, 
 cannot remove or replace an existing forbidden import. This is a tightening-only
 transition: Phase 0 `baselineExternalImports` remain immutable historical observations,
 not current allowlists. A candidate cannot change the base thresholds, allowlist,
-baseline, ceiling, forbidden modules, resource contract, timing contract, or any
+baseline, ceiling, forbidden modules, resource contract, or timing workloads. It may
+replace only `timing.harnessRevision` when that value is a lowercase SHA-256 matching
+the non-executable regular file committed at `scripts/performance/timing.mjs`. That transition always
+requires an exact-head approval whose `approvedTimingHarnessRevision` exactly matches;
+missing, stale, extra, or mismatched timing revisions fail closed. No caller-selected
+path or candidate-owned validator determines the digest. CI loads the evaluator and
+allowed-maintainer policy from the exact pull request base, reads the harness blob from
+the exact candidate `HEAD`, and obtains the approval record from the pull request's
+GitHub comment snapshot rather than a candidate-owned file. A candidate cannot change any
 existing artifact or graph. The only permitted toolchain transition is a valid SHA-256
 revision at `toolchain.releaseProfile.sha256`; every other toolchain field remains
 exact-base, and the candidate report must prove that digest matches the actual

--- a/scripts/performance/growth-approval.mjs
+++ b/scripts/performance/growth-approval.mjs
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import process from 'node:process';
@@ -11,13 +12,22 @@ import {
 
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
 const requiredRecordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
-const optionalRecordFields = ['approvedNewArtifacts', 'approvedNewSubpaths'];
+const optionalRecordFields = [
+  'approvedNewArtifacts',
+  'approvedNewSubpaths',
+  'approvedTimingHarnessRevision',
+];
 const recordFields = [...requiredRecordFields, ...optionalRecordFields];
 const allowedAuthorAssociations = new Set(['COLLABORATOR', 'MEMBER', 'OWNER']);
 const bodyLimit = 16 * 1024;
 const execFileAsync = promisify(execFile);
 const pathLimit = 50;
 const evidenceLimit = 20;
+const timingHarnessPath = 'scripts/performance/timing.mjs';
+
+function validSha256(value) {
+  return typeof value === 'string' && /^[a-f\d]{64}$/.test(value);
+}
 
 function diagnostic(code, message, commentUrl) {
   return commentUrl ? { code, commentUrl, message } : { code, message };
@@ -106,6 +116,9 @@ function canonicalRecord(record) {
   if (Object.hasOwn(record, 'approvedNewArtifacts')) {
     canonical.approvedNewArtifacts = record.approvedNewArtifacts;
   }
+  if (Object.hasOwn(record, 'approvedTimingHarnessRevision')) {
+    canonical.approvedTimingHarnessRevision = record.approvedTimingHarnessRevision;
+  }
   canonical.evidenceUrls = record.evidenceUrls;
   return canonical;
 }
@@ -186,7 +199,13 @@ function validateRecord(record, policy) {
   }
   const hasNewSubpaths = Object.hasOwn(record, 'approvedNewSubpaths');
   const hasNewArtifacts = Object.hasOwn(record, 'approvedNewArtifacts');
-  if (!uniqueSortedStrings(record.approvedPaths, pathLimit, hasNewSubpaths && hasNewArtifacts) ||
+  const hasTimingRevision = Object.hasOwn(record, 'approvedTimingHarnessRevision');
+  const allowsEmptyPaths = (hasNewSubpaths && hasNewArtifacts) || hasTimingRevision;
+  if (!uniqueSortedStrings(
+    record.approvedPaths,
+    pathLimit,
+    allowsEmptyPaths
+  ) ||
       !record.approvedPaths.every(validArtifactPath)) {
     diagnostics.push(diagnostic(
       'GROWTH_APPROVAL_PATHS',
@@ -205,6 +224,12 @@ function validateRecord(record, policy) {
     diagnostics.push(diagnostic(
       'GROWTH_APPROVAL_NEW_ARTIFACTS',
       'Approval approvedNewArtifacts must contain sorted, unique safe paths with full non-negative integer Brotli sizes'
+    ));
+  }
+  if (hasTimingRevision && !validSha256(record.approvedTimingHarnessRevision)) {
+    diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_TIMING_REVISION',
+      'Approval approvedTimingHarnessRevision must be a lowercase 64-character SHA-256'
     ));
   }
   if (!uniqueSortedStrings(record.evidenceUrls, evidenceLimit) ||
@@ -361,7 +386,29 @@ function validForbiddenExternalImportsTransition(authority, candidate) {
   return authority.forbiddenExternalImports.every(value => candidateImports.has(value));
 }
 
-export function validateCandidateGrowthContract(authority, candidate, { budgetAmendment } = {}) {
+function timingHarnessTransition(authority, candidate, timingHarnessRevision) {
+  if (!Object.hasOwn(authority, 'timing')) {
+    return !Object.hasOwn(candidate, 'timing');
+  }
+  if (!validSha256(timingHarnessRevision) ||
+      candidate?.timing?.harnessRevision !== timingHarnessRevision) {
+    return false;
+  }
+  if (isDeepStrictEqual(authority.timing, candidate.timing)) {
+    return true;
+  }
+
+  return isDeepStrictEqual(candidate.timing, {
+    ...authority.timing,
+    harnessRevision: timingHarnessRevision,
+  });
+}
+
+export function validateCandidateGrowthContract(
+  authority,
+  candidate,
+  { budgetAmendment, timingHarnessRevision } = {}
+) {
   const violations = [];
   if (!authority || typeof authority !== 'object' || !candidate || typeof candidate !== 'object') {
     return ['Authority and candidate performance contracts must be objects'];
@@ -388,6 +435,12 @@ export function validateCandidateGrowthContract(authority, candidate, { budgetAm
     if (key === 'toolchain') {
       if (!validReleaseProfileTransition(authority.toolchain, candidate.toolchain)) {
         violations.push('Candidate performance contract changes exact-base toolchain beyond releaseProfile.sha256');
+      }
+      continue;
+    }
+    if (key === 'timing') {
+      if (!timingHarnessTransition(authority, candidate, timingHarnessRevision)) {
+        violations.push('Candidate performance contract timing must match the committed timing harness and may change only harnessRevision');
       }
       continue;
     }
@@ -603,6 +656,7 @@ export function requiredNewProductionApproval({
   budgetAmendment,
   candidateContract,
   currentReport,
+  timingHarnessRevision,
 }) {
   const baseViolations = reportContractViolations(
     baseReport,
@@ -616,6 +670,7 @@ export function requiredNewProductionApproval({
   const effectiveContract = candidateContract || authorityContract;
   const contractViolations = validateCandidateGrowthContract(authorityContract, effectiveContract, {
     budgetAmendment,
+    timingHarnessRevision,
   });
   if (contractViolations.length) {
     throw new Error(contractViolations.join('; '));
@@ -722,11 +777,13 @@ export function validateGrowthApproval({
   policy,
   pullRequestNumber,
   thresholdPercent,
+  timingHarnessRevision,
 }) {
   let required = [];
   let newArtifacts = [];
   let newProductionEnforced = false;
   let newSubpaths = [];
+  let requiredTimingHarnessRevision = null;
   const diagnostics = validateGrowthApprovalPolicy(policy);
   const consumingBudget = budgetAmendment?.status === 'accepted' &&
     budgetAmendment.mode === 'consume';
@@ -743,12 +800,17 @@ export function validateGrowthApproval({
       consumingBudget ? 0 : thresholdPercent
     );
     if (authorityContract) {
+      if (candidateContract &&
+          !isDeepStrictEqual(authorityContract.timing, candidateContract.timing)) {
+        requiredTimingHarnessRevision = candidateContract?.timing?.harnessRevision || null;
+      }
       const validated = requiredNewProductionApproval({
         authorityContract,
         baseReport,
         budgetAmendment,
         candidateContract,
         currentReport,
+        timingHarnessRevision,
       });
       newArtifacts = validated.artifacts;
       newProductionEnforced = validated.enforced;
@@ -780,6 +842,7 @@ export function validateGrowthApproval({
     newProductionEnforced,
     newSubpaths,
     required,
+    requiredTimingHarnessRevision,
     schemaVersion: 1,
     status: 'required',
     thresholdPercent,
@@ -800,7 +863,7 @@ export function validateGrowthApproval({
     result.status = 'blocked';
     return result;
   }
-  if (!required.length && (!newProductionEnforced ||
+  if (!required.length && !requiredTimingHarnessRevision && (!newProductionEnforced ||
       !newArtifacts.length && !newSubpaths.length)) {
     result.status = 'not-required';
     return result;
@@ -884,6 +947,7 @@ export function validateGrowthApproval({
       approvedNewArtifacts: parsed.approval.approvedNewArtifacts,
       approvedNewSubpaths: parsed.approval.approvedNewSubpaths,
       approvedPaths: parsed.approval.approvedPaths,
+      approvedTimingHarnessRevision: parsed.approval.approvedTimingHarnessRevision,
       authorLogin,
       commentId: comment.id,
       commentUrl,
@@ -952,6 +1016,17 @@ export function validateGrowthApproval({
     }
   }
 
+  if ((result.approval.approvedTimingHarnessRevision || null) !==
+      requiredTimingHarnessRevision) {
+    result.status = 'invalid';
+    result.diagnostics.push(diagnostic(
+      'GROWTH_APPROVAL_TIMING_REVISION_MISMATCH',
+      `Approval timing harness revision must be ${requiredTimingHarnessRevision || 'absent'}`,
+      result.approval.commentUrl
+    ));
+    return result;
+  }
+
   const availableEvidence = new Set(evidenceComments.comments
     .filter(comment => comment?.user?.type === 'User' &&
       allowedAuthorAssociations.has(comment?.author_association) &&
@@ -993,6 +1068,24 @@ async function currentCheckoutHead() {
     encoding: 'utf8',
   });
   return stdout.trim();
+}
+
+export async function committedTimingHarnessRevision(checkoutRoot = process.cwd()) {
+  const { stdout: entry } = await execFileAsync(
+    'git',
+    ['ls-tree', 'HEAD', '--', timingHarnessPath],
+    { cwd: checkoutRoot, encoding: 'utf8' }
+  );
+  const match = entry.trim().match(/^100644 blob ([a-f\d]{40})\t(.+)$/);
+  if (!match || match[2] !== timingHarnessPath) {
+    throw new Error(`Committed ${timingHarnessPath} must be a non-executable regular file`);
+  }
+  const { stdout: contents } = await execFileAsync(
+    'git',
+    ['cat-file', 'blob', match[1]],
+    { cwd: checkoutRoot, encoding: null }
+  );
+  return createHash('sha256').update(contents).digest('hex');
 }
 
 function parsePullRequestNumber(value) {
@@ -1037,6 +1130,7 @@ function blockedResult(error, headSha = null) {
     newProductionEnforced: false,
     newSubpaths: [],
     required: [],
+    requiredTimingHarnessRevision: null,
     schemaVersion: 1,
     status: 'blocked',
     thresholdPercent: null,
@@ -1073,6 +1167,7 @@ export async function main(args = process.argv.slice(2)) {
         readJson(getArgument(args, '--comments')),
         readJson(getArgument(args, '--evidence-comments')),
       ]);
+    const timingHarnessRevision = await committedTimingHarnessRevision();
     let hasBudgetAmendmentAuthority = Boolean(identity);
     try {
       await readFile(resolve(
@@ -1112,6 +1207,7 @@ export async function main(args = process.argv.slice(2)) {
       policy: contract.pullRequestGrowthApproval,
       pullRequestNumber,
       thresholdPercent: contract.thresholds?.pullRequestApprovalPercent,
+      timingHarnessRevision,
     });
   } catch (error) {
     result = blockedResult(error, headSha);

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import {
+  committedTimingHarnessRevision,
   formatGrowthApprovalComment,
   parseGrowthApprovalComment,
   requiredArtifactGrowth,
@@ -26,6 +28,8 @@ const policy = {
   trackingIssueUrl: 'https://github.com/marionettejs/marionette/issues/127',
   allowedLogins: ['paulfalgout'],
 };
+const authorityTimingRevision = 'c'.repeat(64);
+const candidateTimingRevision = 'd'.repeat(64);
 
 function report(artifacts, graphs = []) {
   return { artifacts, graphs };
@@ -128,6 +132,15 @@ function candidateAliasContract() {
     baselineModules: [],
     baselineExternalImports: [],
   });
+  return contract;
+}
+
+function timingContract(revision = authorityTimingRevision) {
+  const contract = growthContract();
+  contract.timing = {
+    harnessRevision: revision,
+    cases: [{ id: 'render', iterations: 10 }],
+  };
   return contract;
 }
 
@@ -612,6 +625,39 @@ describe('exact-head performance growth approval contract', () => {
     }
   });
 
+  test('permits only a committed timing harness revision transition', () => {
+    const authority = timingContract();
+    const candidate = timingContract(candidateTimingRevision);
+
+    assert.deepEqual(validateCandidateGrowthContract(authority, candidate, {
+      timingHarnessRevision: candidateTimingRevision,
+    }), []);
+
+    const changedCase = timingContract(candidateTimingRevision);
+    changedCase.timing.cases[0].iterations = 1;
+    assert.match(validateCandidateGrowthContract(authority, changedCase, {
+      timingHarnessRevision: candidateTimingRevision,
+    }).join('\n'), /may change only harnessRevision/);
+
+    assert.match(validateCandidateGrowthContract(authority, candidate, {
+      timingHarnessRevision: authorityTimingRevision,
+    }).join('\n'), /match the committed timing harness/);
+
+    assert.match(validateCandidateGrowthContract(authority, authority, {
+      timingHarnessRevision: candidateTimingRevision,
+    }).join('\n'), /match the committed timing harness/);
+
+    assert.deepEqual(validateCandidateGrowthContract(growthContract(), growthContract(), {
+      timingHarnessRevision: candidateTimingRevision,
+    }), []);
+    assert.match(validateCandidateGrowthContract(growthContract(), candidate, {
+      timingHarnessRevision: candidateTimingRevision,
+    }).join('\n'), /top-level fields differ/);
+    assert.match(validateCandidateGrowthContract(authority, growthContract(), {
+      timingHarnessRevision: candidateTimingRevision,
+    }).join('\n'), /top-level fields differ/);
+  });
+
   test('requires the candidate report to prove the release-profile digest', () => {
     const candidateContract = growthContract();
     candidateContract.toolchain.releaseProfile.sha256 = 'b'.repeat(64);
@@ -930,6 +976,25 @@ describe('exact-head performance growth approval contract', () => {
     assert.equal(Object.hasOwn(approvalRecord(), 'approvedNewArtifacts'), false);
   });
 
+  test('formats and parses a canonical timing-only approval', () => {
+    const record = approvalRecord([]);
+    record.approvedTimingHarnessRevision = candidateTimingRevision;
+
+    assert.deepEqual(parseGrowthApprovalComment(formatGrowthApprovalComment(record), policy), {
+      matched: true,
+      approval: record,
+    });
+
+    for (const revision of ['D'.repeat(64), 'd'.repeat(63), 1]) {
+      const malformed = { ...record, approvedTimingHarnessRevision: revision };
+      assert.equal(
+        parseGrowthApprovalComment(formatGrowthApprovalComment(malformed), policy)
+          .diagnostics[0].code,
+        'GROWTH_APPROVAL_TIMING_REVISION'
+      );
+    }
+  });
+
   test('rejects ambiguous formatting, fields, paths, and evidence', () => {
     const record = approvalRecord();
     const noncanonical = `${formatGrowthApprovalComment(record)}\nextra`;
@@ -1017,6 +1082,161 @@ describe('exact-head performance growth approval contract', () => {
     assert.deepEqual(result.diagnostics, []);
     assert.equal(result.approval.authorLogin, 'paulfalgout');
     assert.deepEqual(result.approval.approvedPaths, ['dist/over.js']);
+  });
+
+  test('requires an exact-head approval for a timing harness revision', () => {
+    const authorityContract = timingContract();
+    const candidateContract = timingContract(candidateTimingRevision);
+    const options = {
+      authorityContract,
+      baseReport: productionReport(),
+      candidateContract,
+      currentReport: productionReport(),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+      timingHarnessRevision: candidateTimingRevision,
+    };
+    const record = approvalRecord([]);
+    record.approvedTimingHarnessRevision = candidateTimingRevision;
+
+    const missing = validateGrowthApproval({ ...options, comments: snapshot([]) });
+    assert.equal(missing.status, 'required');
+    assert.equal(missing.requiredTimingHarnessRevision, candidateTimingRevision);
+
+    const approved = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(record)]),
+    });
+    assert.equal(approved.status, 'approved');
+
+    const wrong = { ...record, approvedTimingHarnessRevision: authorityTimingRevision };
+    const mismatched = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(wrong)]),
+    });
+    assert.equal(mismatched.status, 'invalid');
+    assert.equal(
+      mismatched.diagnostics[0].code,
+      'GROWTH_APPROVAL_TIMING_REVISION_MISMATCH'
+    );
+
+    const digestMismatch = validateGrowthApproval({
+      ...options,
+      comments: snapshot([comment(record)]),
+      timingHarnessRevision: authorityTimingRevision,
+    });
+    assert.equal(digestMismatch.status, 'blocked');
+    assert.equal(digestMismatch.diagnostics[0].code, 'GROWTH_APPROVAL_REPORT');
+  });
+
+  test('rejects an extra timing revision on an artifact-growth approval', () => {
+    const record = approvalRecord(['dist/main.js']);
+    record.approvedTimingHarnessRevision = candidateTimingRevision;
+    const result = validateGrowthApproval({
+      authorityContract: timingContract(),
+      baseReport: productionReport(),
+      candidateContract: timingContract(),
+      comments: snapshot([comment(record)]),
+      currentReport: grownProductionReport(),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+      timingHarnessRevision: authorityTimingRevision,
+    });
+
+    assert.equal(result.status, 'invalid');
+    assert.equal(result.diagnostics[0].code, 'GROWTH_APPROVAL_TIMING_REVISION_MISMATCH');
+  });
+
+  test('accepts one approval for simultaneous artifact and timing growth', () => {
+    const record = approvalRecord(['dist/main.js']);
+    record.approvedTimingHarnessRevision = candidateTimingRevision;
+    const result = validateGrowthApproval({
+      authorityContract: timingContract(),
+      baseReport: productionReport(),
+      candidateContract: timingContract(candidateTimingRevision),
+      comments: snapshot([comment(record)]),
+      currentReport: grownProductionReport(),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+      timingHarnessRevision: candidateTimingRevision,
+    });
+
+    assert.equal(result.status, 'approved');
+    assert.deepEqual(result.approval.approvedPaths, ['dist/main.js']);
+    assert.equal(result.approval.approvedTimingHarnessRevision, candidateTimingRevision);
+  });
+
+  test('hashes only a committed regular timing harness file', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-timing-harness-'));
+    const harnessPath = join(fixtureRoot, 'scripts/performance/timing.mjs');
+    const runGit = args => {
+      const result = spawnSync('git', args, {
+        cwd: fixtureRoot,
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, 0, result.stderr);
+      return result;
+    };
+
+    try {
+      await mkdir(join(fixtureRoot, 'scripts/performance'), { recursive: true });
+      await writeFile(harnessPath, 'export default true;\n');
+      await assert.rejects(committedTimingHarnessRevision(fixtureRoot));
+      runGit(['init']);
+      runGit(['config', 'user.email', 'test@example.com']);
+      runGit(['config', 'user.name', 'Test']);
+      runGit(['config', 'core.filemode', 'true']);
+      runGit(['add', '.']);
+      runGit(['commit', '-m', 'fixture']);
+
+      assert.equal(
+        await committedTimingHarnessRevision(fixtureRoot),
+        createHash('sha256').update('export default true;\n').digest('hex')
+      );
+
+      await writeFile(harnessPath, 'export default false;\n');
+      assert.equal(
+        await committedTimingHarnessRevision(fixtureRoot),
+        createHash('sha256').update('export default true;\n').digest('hex')
+      );
+
+      await writeFile(harnessPath, 'export default true;\n');
+      await chmod(harnessPath, 0o755);
+      runGit(['add', '--all']);
+      runGit(['commit', '-m', 'executable']);
+      await assert.rejects(
+        committedTimingHarnessRevision(fixtureRoot),
+        /must be a non-executable regular file/
+      );
+
+      await rm(harnessPath);
+      await symlink('../target.mjs', harnessPath);
+      runGit(['add', '--all']);
+      runGit(['commit', '-m', 'symlink']);
+      await assert.rejects(
+        committedTimingHarnessRevision(fixtureRoot),
+        /must be a non-executable regular file/
+      );
+
+      await rm(harnessPath);
+      runGit(['add', '--all']);
+      runGit(['commit', '-m', 'missing']);
+      await assert.rejects(
+        committedTimingHarnessRevision(fixtureRoot),
+        /must be a non-executable regular file/
+      );
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   test('accepts one exact-head approval for the exact new subpath and full artifact size', () => {
@@ -1348,6 +1568,43 @@ describe('exact-head performance growth approval contract', () => {
       ]);
       assert.equal(newSubpath.status, 0);
       assert.deepEqual(JSON.parse(newSubpath.stdout).newSubpaths, ['./feature']);
+
+      const committedRevision = await committedTimingHarnessRevision(root);
+      const timingApproval = approvalRecord([]);
+      timingApproval.headSha = checkoutHead;
+      timingApproval.approvedTimingHarnessRevision = committedRevision;
+      await Promise.all([
+        writeFile(paths.contract, JSON.stringify(timingContract())),
+        writeFile(paths.candidate, JSON.stringify(timingContract(committedRevision))),
+        writeFile(paths.base, JSON.stringify(productionReport())),
+        writeFile(paths.current, JSON.stringify(productionReport())),
+        writeFile(paths.comments, JSON.stringify(snapshot([comment(timingApproval)]))),
+      ]);
+      const timingApproved = runCli([
+        ...args,
+        '--candidate-contract', paths.candidate,
+      ]);
+      assert.equal(timingApproved.status, 0);
+      assert.equal(JSON.parse(timingApproved.stdout).status, 'approved');
+
+      const wrongRevision = 'e'.repeat(64);
+      const wrongTimingApproval = approvalRecord([]);
+      wrongTimingApproval.headSha = checkoutHead;
+      wrongTimingApproval.approvedTimingHarnessRevision = wrongRevision;
+      await Promise.all([
+        writeFile(paths.candidate, JSON.stringify(timingContract(wrongRevision))),
+        writeFile(paths.comments, JSON.stringify(snapshot([comment(wrongTimingApproval)]))),
+      ]);
+      const timingBlocked = runCli([
+        ...args,
+        '--candidate-contract', paths.candidate,
+      ]);
+      assert.equal(timingBlocked.status, 1);
+      assert.equal(JSON.parse(timingBlocked.stdout).status, 'blocked');
+      assert.match(
+        JSON.parse(timingBlocked.stdout).diagnostics[0].message,
+        /match the committed timing harness/
+      );
 
       await Promise.all([
         writeFile(paths.contract, JSON.stringify(growthContract())),


### PR DESCRIPTION
Related #127

## What

- Allow the exact-base performance evaluator to authorize a timing-harness revision independently of runtime artifact growth.
- Bind the approved revision to the SHA-256 of the regular `scripts/performance/timing.mjs` blob committed at the exact candidate head.
- Document the approval boundary and add fail-closed coverage for stale, extra, malformed, combined, missing, symlinked, executable, and dirty-worktree cases.

## Why

The current contract makes the timing harness immutable, so a corrected workload cannot land without weakening or bypassing performance governance. This adds a narrow exact-head approval path while keeping the evaluator and allowed-maintainer policy under the exact pull-request base.

## Scope

This changes performance-governance code, tests, and documentation only. It does not change the timing harness, runtime code, package output, repository settings, or any performance ceiling.

## Deployment Impact

No application or package deployment is required. This affects only pull-request performance validation after merge.

## Testing

- `node --test test/performance/growth-approval.test.mjs` — 37 passed.
- `npm run test:performance` — 112 passed.
- `npm run lint:ci` — passed.
- `npm run docs:check` — 21 executable examples, 12 validators, 48 pages, 49 HTML files, and 444 links passed.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Related to #127: opens a narrow exact-head approval path so a timing-harness revision can land without weakening performance governance. Previously the timing harness was immutable; now a corrected workload is approved only when the approval binds to the SHA-256 of the committed non-executable `scripts/performance/timing.mjs` blob at the exact candidate head.

**Behavior**
- Only `timing.harnessRevision` may change; timing workloads and all other governance fields remain exact-base.
- Missing, stale, extra, malformed, mismatched, symlinked, executable, or dirty-worktree timing-harness cases fail closed.
- The evaluator and allowed-maintainer policy still come from the exact pull-request base, and approval records are read from the pull-request comment snapshot.

<sup>Written for commit 35e3df18738151c19b2c2e5c87833acc9391aca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for approving performance timing-harness-only changes through a dedicated approval record tied to the committed harness revision.
  - Timing-harness changes now require exact-head approval and matching revision validation.

- **Documentation**
  - Clarified how pull request base and candidate revisions, approval records, and timing-harness content are selected during performance approval checks.

- **Bug Fixes**
  - Strengthened validation to reject missing, stale, invalid, or mismatched timing-harness revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->