### PR TITLE
perf(build): authorize DataApi budget

### DIFF
--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -164,6 +164,49 @@
       ],
       "rationale": "Authorize the exact measured distribution cost of completing Application root View and Region ownership together with Application State composition. The prototype uses one Application lifecycle and one existing State mixin, grows only the four established main artifacts, adds no module-graph edge, external import, package subpath, eager stateless allocation, Toolkit lifecycle flag, compatibility alias, or speculative headroom.",
       "rollbackCondition": "If the Application root ownership and State prototype is abandoned before consumption, append a governance-only BA0004 revocation. Never edit or delete this authorization. If the final implementation exceeds 75799 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
+    },
+    {
+      "kind": "authorization",
+      "id": "BA0005",
+      "target": "aggregate-shipped-package",
+      "previousCeilingBytes": 75799,
+      "proposedCeilingBytes": 78665,
+      "prototypeBaseCommit": "a1eafb48b9afd3b23a985fe1af0597b4377f79bc",
+      "prototypeCommit": "c3a627448874faf5ae44c8b6ffc516cdb35961b3",
+      "implementationIssueUrl": "https://github.com/marionettejs/marionette/issues/104",
+      "authorizedArtifactPaths": [
+        "dist/backbone.cjs",
+        "dist/backbone.js",
+        "dist/marionette.cjs",
+        "dist/marionette.js",
+        "dist/marionette.min.js",
+        "dist/marionette.umd.js"
+      ],
+      "authorizedNewSubpaths": [],
+      "reports": [
+        {
+          "path": "evidence/performance-budget-amendments/BA0005/base.json",
+          "role": "base",
+          "sha256": "951a8deff4442f89da1976cee8294f5d35df7f0658ae421197c28db84cdbb316"
+        },
+        {
+          "path": "evidence/performance-budget-amendments/BA0005/prototype.json",
+          "role": "prototype",
+          "sha256": "a152f859667df2d7c3a8d16f77c69cb455d88a82fdf7c543f85a2b62f07605bd"
+        }
+      ],
+      "prototypeContract": {
+        "path": "evidence/performance-budget-amendments/BA0005/prototype-contract.json",
+        "sha256": "c7f1c58e9ae39d655828ad622c85b0ee779ddbdb0427ed19fd598a1bfa4a8c27"
+      },
+      "approvalUrls": [
+        "https://github.com/marionettejs/marionette/pull/362#issuecomment-5506373154"
+      ],
+      "evidenceUrls": [
+        "https://github.com/marionettejs/marionette/issues/127#issuecomment-5506372304"
+      ],
+      "rationale": "Authorize the exact measured distribution cost of the v5 DataApi seam and its Backbone adapter. The prototype centralizes data lookup, identity, observation, and collection updates without speculative padding, a new package subpath, an external import, or growth in the jQuery adapter artifacts. Exact-head artifact-growth and timing-harness approvals remain independent gates for the later runtime pull request.",
+      "rollbackCondition": "If the DataApi prototype is abandoned before consumption, append a governance-only BA0005 revocation. Never edit or delete this authorization. If the final implementation exceeds 78665 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
     }
   ]
 }

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -133,7 +133,7 @@ scenarios; unused headroom does not establish release readiness.
 [PR #257](https://github.com/marionettejs/marionette/pull/257) consumed that
 authorization.
 
-BA0004 authorizes a pending exact-prototype increase from 75,000 to 75,799
+BA0004 authorized an exact-prototype increase from 75,000 to 75,799
 bytes for the remaining production-runtime Application work tracked by
 [#190](https://github.com/marionettejs/marionette/issues/190) and
 [#191](https://github.com/marionettejs/marionette/issues/191). The measured
@@ -141,9 +141,19 @@ prototype completes root View and constructed-versus-borrowed Region ownership
 together with lazy Application State composition. It grows only the four existing
 main delivery artifacts, adds no production graph edge, external import, package
 subpath, stateless allocation proxy, or speculative headroom, and leaves the 18
-consumer scenario/format combinations reporting-only. A later runtime pull request
-must consume the authorization from its merged exact base and obtain independent
-exact-head growth approval.
+consumer scenario/format combinations reporting-only.
+[PR #352](https://github.com/marionettejs/marionette/pull/352) consumed that
+authorization with independent exact-head growth approval.
+
+BA0005 authorizes a pending exact-prototype increase from 75,799 to 78,665
+bytes for the DataApi seam tracked by
+[#104](https://github.com/marionettejs/marionette/issues/104). The measured
+prototype centralizes data lookup, identity, observation, and collection updates
+behind a native default and a Backbone adapter. It grows six existing main and
+Backbone artifacts, adds no package subpath or external import, leaves the jQuery
+adapter artifacts unchanged, and includes no speculative headroom. The later
+runtime pull request must consume the authorization from its merged exact base and
+obtain independent exact-head artifact-growth and timing-harness approvals.
 
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole

--- a/evidence/performance-budget-amendments/BA0005/base.json
+++ b/evidence/performance-budget-amendments/BA0005/base.json
@@ -1,0 +1,677 @@
+{
+  "schemaVersion": 1,
+  "revision": "a1eafb48b9afd3b23a985fe1af0597b4377f79bc",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 19751,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 19812,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 20098,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 14928,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 161,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 180,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 75283,
+      "baselineSize": 49500,
+      "absoluteCeiling": 75799
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 14839,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14851,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 14892,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 13037,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 13047,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 13090,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 14896,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14890,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 14949,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 14890,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14903,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 14956,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 14920,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14921,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 14993,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 1,
+        "collectionViewListeningToWhileMounted": 1,
+        "behaviorListeningToWhileMounted": 2,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": []
+  }
+}

--- a/evidence/performance-budget-amendments/BA0005/prototype-contract.json
+++ b/evidence/performance-budget-amendments/BA0005/prototype-contract.json
@@ -1,0 +1,343 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "sourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "totalBrotliBytes": 49500,
+    "absoluteCeilingBytes": 75799
+  },
+  "toolchain": {
+    "releaseProfile": {
+      "path": "config/release-profile.json",
+      "sha256": "405b0135261d44bc5c1cb7832f7bbdbcadfe8415704e40e14abee217ce2e5162",
+      "node": "24.19.0",
+      "npm": "11.17.0",
+      "lockfileVersion": 3,
+      "canonicalHost": {
+        "id": "linux-x64",
+        "runner": "ubuntu-24.04",
+        "platform": "linux",
+        "architecture": "x64"
+      }
+    },
+    "lockedDependencies": {
+      "backbone": "1.4.0",
+      "jsdom": "30.0.1",
+      "rollup": "4.63.0"
+    },
+    "commands": {
+      "deterministic": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run size"
+      ],
+      "hostedTiming": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run performance:timing"
+      ]
+    }
+  },
+  "thresholds": {
+    "cumulativeGrowthPercent": 5,
+    "pullRequestApprovalPercent": 1,
+    "hostedTimingWarningPercent": 10,
+    "controlledMedianRegressionPercent": 5,
+    "controlledP95RegressionPercent": 10
+  },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
+  "runtimeArtifacts": [
+    {
+      "name": "Main ES module",
+      "path": "dist/marionette.js",
+      "baselineBrotliBytes": 12776
+    },
+    {
+      "name": "Main CommonJS",
+      "path": "dist/marionette.cjs",
+      "baselineBrotliBytes": 12932
+    },
+    {
+      "name": "Main UMD",
+      "path": "dist/marionette.umd.js",
+      "baselineBrotliBytes": 13197
+    },
+    {
+      "name": "Main minified UMD",
+      "path": "dist/marionette.min.js",
+      "baselineBrotliBytes": 10001,
+      "additionalShippedArtifact": true
+    },
+    {
+      "name": "Backbone shim ES module",
+      "path": "dist/backbone.js",
+      "baselineBrotliBytes": 121
+    },
+    {
+      "name": "Backbone shim CommonJS",
+      "path": "dist/backbone.cjs",
+      "baselineBrotliBytes": 135
+    },
+    {
+      "name": "jQuery DomApi ES module",
+      "path": "dist/jquery-dom-api.js",
+      "baselineBrotliBytes": 169
+    },
+    {
+      "name": "jQuery DomApi CommonJS",
+      "path": "dist/jquery-dom-api.cjs",
+      "baselineBrotliBytes": 169
+    }
+  ],
+  "productionGraphs": [
+    {
+      "subpath": ".",
+      "input": "index.js",
+      "output": "dist/marionette.js",
+      "baselineModules": [
+        "config/dom.js",
+        "config/event-delegator.js",
+        "config/features.js",
+        "config/renderer.js",
+        "index.js",
+        "mixins/behaviors.js",
+        "mixins/common.js",
+        "mixins/delegate-entity-events.js",
+        "mixins/destroy.js",
+        "mixins/events.js",
+        "mixins/radio.js",
+        "mixins/requests.js",
+        "mixins/template-render.js",
+        "mixins/ui.js",
+        "mixins/view-events.js",
+        "mixins/view.js",
+        "modules/application.js",
+        "modules/behavior.js",
+        "modules/child-view-container.js",
+        "modules/collection-view.js",
+        "modules/common/bind-events.js",
+        "modules/common/bind-requests.js",
+        "modules/common/get-option.js",
+        "modules/common/merge-options.js",
+        "modules/common/monitor-view-events.js",
+        "modules/common/normalize-methods.js",
+        "modules/common/radio.js",
+        "modules/common/trigger-method.js",
+        "modules/common/view.js",
+        "modules/object.js",
+        "modules/radio.js",
+        "modules/view-region.js",
+        "utils/build-event-args.js",
+        "utils/call-handler.js",
+        "utils/error.js",
+        "utils/extend.js",
+        "utils/make-callback.js",
+        "utils/once-wrap.js",
+        "utils/proxy.js",
+        "version.js"
+      ],
+      "baselineExternalImports": [
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./backbone",
+      "input": "backbone.js",
+      "output": "dist/backbone.js",
+      "baselineModules": [
+        "backbone.js"
+      ],
+      "baselineExternalImports": [
+        "backbone",
+        "marionette",
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./jquery-dom-api",
+      "input": "jquery-dom-api.js",
+      "output": "dist/jquery-dom-api.js",
+      "baselineModules": [
+        "jquery-dom-api.js"
+      ],
+      "baselineExternalImports": [
+        "jquery"
+      ]
+    }
+  ],
+  "forbiddenExternalImports": [
+    "underscore"
+  ],
+  "forbiddenProductionModulePrefixes": [
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "docs-site/",
+    "node_modules/",
+    "scripts/",
+    "test/",
+    "config/diagnostics/",
+    "config/release/"
+  ],
+  "forbiddenProductionModules": [
+    "config/performance.json",
+    "config/release-profile.json",
+    "config/release-promotion.json"
+  ],
+  "deterministicResources": {
+    "attachDetachCycles": 100,
+    "mountDestroyCycles": 1000,
+    "instanceShapes": {
+      "View": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_domEvents",
+        "_eventPrefix",
+        "_isAttached",
+        "_isRendered",
+        "_rdEvents",
+        "_regions",
+        "cid",
+        "el",
+        "options",
+        "regions"
+      ],
+      "Region": [
+        "_initEl",
+        "cid",
+        "el",
+        "options"
+      ],
+      "Behavior": [
+        "_domEvents",
+        "_rdListenId",
+        "_rdListeningTo",
+        "cid",
+        "el",
+        "options",
+        "ui",
+        "view"
+      ],
+      "CollectionView": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_children",
+        "_collectionEvents",
+        "_domEvents",
+        "_emptyRegion",
+        "_eventPrefix",
+        "_isAttached",
+        "_rdEvents",
+        "childView",
+        "children",
+        "cid",
+        "collection",
+        "el",
+        "options"
+      ]
+    },
+    "allocationShapes": {
+      "View": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "_regions",
+          "options",
+          "regions"
+        ],
+        "marionetteEventRegistrations": 6
+      },
+      "Behavior": {
+        "emptyArrays": [
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "options",
+          "ui"
+        ],
+        "listeningContainers": 1
+      },
+      "CollectionView": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyChildViewContainers": [
+          "_children",
+          "children"
+        ],
+        "eagerEmptyRegion": true,
+        "marionetteEventRegistrations": 6
+      }
+    },
+    "retentionShapes": {
+      "regionRegistrationsWhileShown": 1,
+      "collectionRegistrationsWhileMounted": 3,
+      "modelRegistrationsWhileMounted": 1,
+      "externalListenerOwnersWhileMounted": 1,
+      "collectionViewListeningToWhileMounted": 1,
+      "behaviorListeningToWhileMounted": 2,
+      "destroyedBehaviorRetainsHostReference": true,
+      "destroyedHostRetainsBehaviorCount": 1,
+      "externalRegistrationsAfterDestroy": 0,
+      "externalListenerOwnersAfterDestroy": 0,
+      "frameworkListeningToAfterDestroy": 0,
+      "childContainerEntriesAfterDestroy": 0,
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
+    }
+  },
+  "timing": {
+    "harnessSchemaVersion": 1,
+    "harnessRevision": "271128bee00c66b3168424d65220dbe6c5dbea1f336082c21b45a07a344bb1d9",
+    "sampleCount": 20,
+    "warmupBatches": 5,
+    "cases": [
+      {
+        "id": "view-construct-destroy",
+        "iterationsPerSample": 200
+      },
+      {
+        "id": "view-render-rerender",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "behavior-view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "region-show-empty",
+        "iterationsPerSample": 50
+      },
+      {
+        "id": "collection-view-render-destroy",
+        "iterationsPerSample": 10
+      },
+      {
+        "id": "collection-view-add-remove",
+        "iterationsPerSample": 20
+      }
+    ],
+    "controlledRunner": {
+      "status": "pending-pr-b"
+    }
+  }
+}

--- a/evidence/performance-budget-amendments/BA0005/prototype.json
+++ b/evidence/performance-budget-amendments/BA0005/prototype.json
@@ -1,0 +1,688 @@
+{
+  "schemaVersion": 1,
+  "revision": "c3a627448874faf5ae44c8b6ffc516cdb35961b3",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 20363,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 20435,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 20750,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 15387,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 686,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 691,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 78665,
+      "baselineSize": 49500,
+      "absoluteCeiling": 75799
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js",
+          "runtime/backbone-data-api.js",
+          "utils/dispose-all.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [
+          "runtime/backbone-data-api.js",
+          "utils/dispose-all.js"
+        ],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 15311,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15313,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 15371,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 13675,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 13671,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 13720,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 15522,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15536,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 15581,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15353,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15353,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15398,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15578,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15584,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15643,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 0,
+        "collectionViewListeningToWhileMounted": 0,
+        "behaviorListeningToWhileMounted": 1,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": [
+      "Cumulative Brotli-11 size 78665 exceeds the absolute ceiling 75799"
+    ]
+  }
+}


### PR DESCRIPTION
Related #104

## What

- Record immutable exact-base and exact-prototype bundle, graph, consumer, resource, and hosted-timing evidence for BA0005.
- Authorize a pending aggregate shipped-package ceiling of 78,665 bytes for the measured DataApi prototype.
- Preserve the two-stage contract: this governance PR does not change runtime source, distribution artifacts, or the active ceiling.

## Why

Current `master` measures 75,283 bytes against the 75,799-byte v5 alpha ceiling. The exact reviewed DataApi prototype at `c3a627448874faf5ae44c8b6ffc516cdb35961b3` measures 78,665 bytes, so the runtime PR cannot pass or authorize its own size gate. BA0005 raises the ceiling only to the measured prototype total, with no speculative headroom.

## Scope

This PR is governance-only: the append-only budget ledger, immutable BA0005 evidence, and performance-baseline documentation. It authorizes positive deltas only in six existing Marionette artifacts and no new package subpath.

Runtime DataApi behavior, `config/performance.json`, `dist/`, package exports, workflows, repository settings, and PR #333 are intentionally unchanged.

## Deployment Impact

No package publication, deployment, tag, or repository-setting change is included. A later runtime PR based on this merged authorization must independently consume the ceiling and pass exact-head artifact-growth and timing-harness approvals.

## Testing

- `node --test test/performance/budget-amendment.test.mjs` — 20/20 pass, including pending authorization leaving the active ceiling unchanged.
- `npm run docs:build` — built 48 documentation pages.
- `npm run lint:ci` — pass.
- `jq empty evidence/performance-budget-amendments/BA0005/*.json` — all three evidence files parse.
- `shasum -a 256 evidence/performance-budget-amendments/BA0005/*.json` — hashes match the ledger.
- `git diff --check` — pass.
- Verified `a1eafb48` is an ancestor of PR head `c261298b` and follows the merged PR #352 consumption commit.
- Verified the exact set of artifacts with nonzero base-to-prototype deltas equals `authorizedArtifactPaths`.

## Review notes

- `config/performance.json` remains the active 75,799-byte authority; the appended ledger entry is pending until a later PR consumes it.
- Issue #104 tracks the DataApi implementation. Issue #127 is intentionally the contract-configured durable performance-evidence registry.
- The exact-base allowlist contains only `paulfalgout`, so the documented sole-maintainer attestation rule applies to the canonical approval comment.
- The measured runtime base predates #361 because #361 changed only performance-governance tooling; it is still an ancestor of this PR and the immutable reports bind the exact base and prototype commits.