### PR TITLE
perf(build): authorize constructor rollback budget

### DIFF
--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -248,6 +248,47 @@
       ],
       "rationale": "Authorize the exact measured distribution cost of stabilizing the public EventDelegator cleanup protocol and constructor-failure rollback tracked by #147. The prototype replaces mutable private listener records with opaque idempotent cleanup, preserves registration-time capture, covers native focus ordering and optional jQuery compatibility, grows only the four established main artifacts, and adds no graph edge, external import, package subpath, eager allocation, retained resource, or speculative headroom.",
       "rollbackCondition": "If the EventDelegator contract prototype is abandoned before consumption, append a governance-only BA0006 revocation. Never edit or delete this authorization. If the final implementation exceeds 79084 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
+    },
+    {
+      "kind": "authorization",
+      "id": "BA0007",
+      "target": "aggregate-shipped-package",
+      "previousCeilingBytes": 79084,
+      "proposedCeilingBytes": 79137,
+      "prototypeBaseCommit": "1c38284d03f4ab0a00faef9209fd514d211904d7",
+      "prototypeCommit": "5714bee19c57d738e94bd724168bb28e9dec388b",
+      "implementationIssueUrl": "https://github.com/marionettejs/marionette/issues/366",
+      "authorizedArtifactPaths": [
+        "dist/marionette.cjs",
+        "dist/marionette.js",
+        "dist/marionette.min.js",
+        "dist/marionette.umd.js"
+      ],
+      "authorizedNewSubpaths": [],
+      "reports": [
+        {
+          "path": "evidence/performance-budget-amendments/BA0007/base.json",
+          "role": "base",
+          "sha256": "4978702ebc1bd26c6771563ce70bfc0cdcf9805376591e2009362c2b0d53effd"
+        },
+        {
+          "path": "evidence/performance-budget-amendments/BA0007/prototype.json",
+          "role": "prototype",
+          "sha256": "cfb0451672c34379d03ec10d6a3c186912e4f3db373bbdc73b9c2b6499ba9747"
+        }
+      ],
+      "prototypeContract": {
+        "path": "evidence/performance-budget-amendments/BA0007/prototype-contract.json",
+        "sha256": "004ce4407457000cf04c47088fa8f9712c63f1c42b8e761577132e6b47272e7b"
+      },
+      "approvalUrls": [
+        "https://github.com/marionettejs/marionette/pull/369#issuecomment-5509104519"
+      ],
+      "evidenceUrls": [
+        "https://github.com/marionettejs/marionette/issues/127#issuecomment-5509104242"
+      ],
+      "rationale": "Authorize the exact measured distribution cost of complete failed-constructor rollback tracked by #366. The prototype destroys child Views and Regions created by render during initialize, removes their DOM, disposes the collection observer exactly once, continues remaining rollback after cleanup errors, and preserves the original construction failure. It grows only the four established main artifacts and adds no graph edge, external import, package subpath, allocation or retention proxy, or speculative headroom.",
+      "rollbackCondition": "If the constructor rollback prototype is abandoned before consumption, append a governance-only BA0007 revocation. Never edit or delete this authorization. If the final implementation exceeds 79137 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
     }
   ]
 }

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -168,6 +168,19 @@ optional adapter artifacts unchanged. [PR #364](https://github.com/marionettejs/
 recorded the authorization. [PR #365](https://github.com/marionettejs/marionette/pull/365)
 consumed it with independent exact-head artifact-growth approval.
 
+BA0007 authorizes an exact-prototype increase from 79,084 to 79,137
+bytes for complete failed-constructor rollback tracked by
+[#366](https://github.com/marionettejs/marionette/issues/366). The measured
+prototype destroys child Views and Regions created by rendering during
+`initialize()`, removes their DOM, disposes the collection observer exactly once,
+continues remaining rollback after cleanup errors, and preserves the original
+construction failure. It grows only the four existing main artifacts, adds no
+production graph edge, external import, package subpath, allocation or retention
+proxy, or speculative headroom, and leaves the optional adapter artifacts unchanged.
+[PR #369](https://github.com/marionettejs/marionette/pull/369) records the pending
+authorization; a later runtime PR must consume it with independent exact-head
+artifact-growth approval.
+
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole
 allowlisted maintainer, that maintainer may provide the canonical exact-head

--- a/evidence/performance-budget-amendments/BA0007/base.json
+++ b/evidence/performance-budget-amendments/BA0007/base.json
@@ -1,0 +1,684 @@
+{
+  "schemaVersion": 1,
+  "revision": "1c38284d03f4ab0a00faef9209fd514d211904d7",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 20506,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 20571,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 20890,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 15456,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 644,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 656,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 79076,
+      "baselineSize": 49500,
+      "absoluteCeiling": 79084
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js",
+          "runtime/backbone-data-api.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [
+          "runtime/backbone-data-api.js"
+        ],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 15371,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15374,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 15429,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 13762,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 13766,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 13815,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 15621,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15624,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 15667,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15423,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15429,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15484,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15659,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15675,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15722,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 0,
+        "collectionViewListeningToWhileMounted": 0,
+        "behaviorListeningToWhileMounted": 1,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": []
+  }
+}

--- a/evidence/performance-budget-amendments/BA0007/prototype-contract.json
+++ b/evidence/performance-budget-amendments/BA0007/prototype-contract.json
@@ -1,0 +1,343 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "sourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "totalBrotliBytes": 49500,
+    "absoluteCeilingBytes": 79084
+  },
+  "toolchain": {
+    "releaseProfile": {
+      "path": "config/release-profile.json",
+      "sha256": "405b0135261d44bc5c1cb7832f7bbdbcadfe8415704e40e14abee217ce2e5162",
+      "node": "24.19.0",
+      "npm": "11.17.0",
+      "lockfileVersion": 3,
+      "canonicalHost": {
+        "id": "linux-x64",
+        "runner": "ubuntu-24.04",
+        "platform": "linux",
+        "architecture": "x64"
+      }
+    },
+    "lockedDependencies": {
+      "backbone": "1.4.0",
+      "jsdom": "30.0.1",
+      "rollup": "4.63.0"
+    },
+    "commands": {
+      "deterministic": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run size"
+      ],
+      "hostedTiming": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run performance:timing"
+      ]
+    }
+  },
+  "thresholds": {
+    "cumulativeGrowthPercent": 5,
+    "pullRequestApprovalPercent": 1,
+    "hostedTimingWarningPercent": 10,
+    "controlledMedianRegressionPercent": 5,
+    "controlledP95RegressionPercent": 10
+  },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
+  "runtimeArtifacts": [
+    {
+      "name": "Main ES module",
+      "path": "dist/marionette.js",
+      "baselineBrotliBytes": 12776
+    },
+    {
+      "name": "Main CommonJS",
+      "path": "dist/marionette.cjs",
+      "baselineBrotliBytes": 12932
+    },
+    {
+      "name": "Main UMD",
+      "path": "dist/marionette.umd.js",
+      "baselineBrotliBytes": 13197
+    },
+    {
+      "name": "Main minified UMD",
+      "path": "dist/marionette.min.js",
+      "baselineBrotliBytes": 10001,
+      "additionalShippedArtifact": true
+    },
+    {
+      "name": "Backbone shim ES module",
+      "path": "dist/backbone.js",
+      "baselineBrotliBytes": 121
+    },
+    {
+      "name": "Backbone shim CommonJS",
+      "path": "dist/backbone.cjs",
+      "baselineBrotliBytes": 135
+    },
+    {
+      "name": "jQuery DomApi ES module",
+      "path": "dist/jquery-dom-api.js",
+      "baselineBrotliBytes": 169
+    },
+    {
+      "name": "jQuery DomApi CommonJS",
+      "path": "dist/jquery-dom-api.cjs",
+      "baselineBrotliBytes": 169
+    }
+  ],
+  "productionGraphs": [
+    {
+      "subpath": ".",
+      "input": "index.js",
+      "output": "dist/marionette.js",
+      "baselineModules": [
+        "config/dom.js",
+        "config/event-delegator.js",
+        "config/features.js",
+        "config/renderer.js",
+        "index.js",
+        "mixins/behaviors.js",
+        "mixins/common.js",
+        "mixins/delegate-entity-events.js",
+        "mixins/destroy.js",
+        "mixins/events.js",
+        "mixins/radio.js",
+        "mixins/requests.js",
+        "mixins/template-render.js",
+        "mixins/ui.js",
+        "mixins/view-events.js",
+        "mixins/view.js",
+        "modules/application.js",
+        "modules/behavior.js",
+        "modules/child-view-container.js",
+        "modules/collection-view.js",
+        "modules/common/bind-events.js",
+        "modules/common/bind-requests.js",
+        "modules/common/get-option.js",
+        "modules/common/merge-options.js",
+        "modules/common/monitor-view-events.js",
+        "modules/common/normalize-methods.js",
+        "modules/common/radio.js",
+        "modules/common/trigger-method.js",
+        "modules/common/view.js",
+        "modules/object.js",
+        "modules/radio.js",
+        "modules/view-region.js",
+        "utils/build-event-args.js",
+        "utils/call-handler.js",
+        "utils/error.js",
+        "utils/extend.js",
+        "utils/make-callback.js",
+        "utils/once-wrap.js",
+        "utils/proxy.js",
+        "version.js"
+      ],
+      "baselineExternalImports": [
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./backbone",
+      "input": "backbone.js",
+      "output": "dist/backbone.js",
+      "baselineModules": [
+        "backbone.js"
+      ],
+      "baselineExternalImports": [
+        "backbone",
+        "marionette",
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./jquery-dom-api",
+      "input": "jquery-dom-api.js",
+      "output": "dist/jquery-dom-api.js",
+      "baselineModules": [
+        "jquery-dom-api.js"
+      ],
+      "baselineExternalImports": [
+        "jquery"
+      ]
+    }
+  ],
+  "forbiddenExternalImports": [
+    "underscore"
+  ],
+  "forbiddenProductionModulePrefixes": [
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "docs-site/",
+    "node_modules/",
+    "scripts/",
+    "test/",
+    "config/diagnostics/",
+    "config/release/"
+  ],
+  "forbiddenProductionModules": [
+    "config/performance.json",
+    "config/release-profile.json",
+    "config/release-promotion.json"
+  ],
+  "deterministicResources": {
+    "attachDetachCycles": 100,
+    "mountDestroyCycles": 1000,
+    "instanceShapes": {
+      "View": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_domEvents",
+        "_eventPrefix",
+        "_isAttached",
+        "_isRendered",
+        "_rdEvents",
+        "_regions",
+        "cid",
+        "el",
+        "options",
+        "regions"
+      ],
+      "Region": [
+        "_initEl",
+        "cid",
+        "el",
+        "options"
+      ],
+      "Behavior": [
+        "_domEvents",
+        "_rdListenId",
+        "_rdListeningTo",
+        "cid",
+        "el",
+        "options",
+        "ui",
+        "view"
+      ],
+      "CollectionView": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_children",
+        "_collectionEvents",
+        "_domEvents",
+        "_emptyRegion",
+        "_eventPrefix",
+        "_isAttached",
+        "_rdEvents",
+        "childView",
+        "children",
+        "cid",
+        "collection",
+        "el",
+        "options"
+      ]
+    },
+    "allocationShapes": {
+      "View": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "_regions",
+          "options",
+          "regions"
+        ],
+        "marionetteEventRegistrations": 6
+      },
+      "Behavior": {
+        "emptyArrays": [
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "options",
+          "ui"
+        ],
+        "listeningContainers": 1
+      },
+      "CollectionView": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyChildViewContainers": [
+          "_children",
+          "children"
+        ],
+        "eagerEmptyRegion": true,
+        "marionetteEventRegistrations": 6
+      }
+    },
+    "retentionShapes": {
+      "regionRegistrationsWhileShown": 1,
+      "collectionRegistrationsWhileMounted": 3,
+      "modelRegistrationsWhileMounted": 1,
+      "externalListenerOwnersWhileMounted": 1,
+      "collectionViewListeningToWhileMounted": 1,
+      "behaviorListeningToWhileMounted": 2,
+      "destroyedBehaviorRetainsHostReference": true,
+      "destroyedHostRetainsBehaviorCount": 1,
+      "externalRegistrationsAfterDestroy": 0,
+      "externalListenerOwnersAfterDestroy": 0,
+      "frameworkListeningToAfterDestroy": 0,
+      "childContainerEntriesAfterDestroy": 0,
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
+    }
+  },
+  "timing": {
+    "harnessSchemaVersion": 1,
+    "harnessRevision": "d6dc4c26b48c83ce4ecfd073c99f614f7e2974bd8be145e6859baaea4b540def",
+    "sampleCount": 20,
+    "warmupBatches": 5,
+    "cases": [
+      {
+        "id": "view-construct-destroy",
+        "iterationsPerSample": 200
+      },
+      {
+        "id": "view-render-rerender",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "behavior-view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "region-show-empty",
+        "iterationsPerSample": 50
+      },
+      {
+        "id": "collection-view-render-destroy",
+        "iterationsPerSample": 10
+      },
+      {
+        "id": "collection-view-add-remove",
+        "iterationsPerSample": 20
+      }
+    ],
+    "controlledRunner": {
+      "status": "pending-pr-b"
+    }
+  }
+}

--- a/evidence/performance-budget-amendments/BA0007/prototype.json
+++ b/evidence/performance-budget-amendments/BA0007/prototype.json
@@ -1,0 +1,686 @@
+{
+  "schemaVersion": 1,
+  "revision": "5714bee19c57d738e94bd724168bb28e9dec388b",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 20515,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 20585,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 20914,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 15470,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 644,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 656,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 79137,
+      "baselineSize": 49500,
+      "absoluteCeiling": 79084
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js",
+          "runtime/backbone-data-api.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [
+          "runtime/backbone-data-api.js"
+        ],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 15396,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15395,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 15442,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 13776,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 13783,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 13829,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 15643,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15640,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 15687,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15436,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15445,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15501,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15684,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15692,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15727,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 0,
+        "collectionViewListeningToWhileMounted": 0,
+        "behaviorListeningToWhileMounted": 1,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": [
+      "Cumulative Brotli-11 size 79137 exceeds the absolute ceiling 79084"
+    ]
+  }
+}


### PR DESCRIPTION
Related #127
Related #366

## What
- Records exact-base and exact-prototype bundle, graph, allocation, and retention evidence for the CollectionView constructor rollback fix.
- Proposes BA0007 as a no-headroom increase from 79,084 B to the measured 79,137 B prototype.
- Leaves the runtime implementation on its separate local feature branch until governance is authorized.

## Why
Merged #365 leaves 8 B of aggregate headroom. The smallest complete #366 prototype adds 61 B over the merged runtime and exceeds the current ceiling by 53 B while fixing child View, Region, DOM, and collection-observer leaks after render-then-throw construction failures.

## Scope
This is a governance-only prerequisite. The final authorization commit will change only the append-only performance ledger, BA0007 evidence, and performance-baseline documentation. It does not change runtime source, distribution artifacts, package entrypoints, repository settings, or release behavior.

## Deployment Impact
No deployment, publication, tag, or release is performed.

## Testing
- Exact base `1c38284d03f4ab0a00faef9209fd514d211904d7`: `npm ci --ignore-scripts`, `npm run build`, `node scripts/performance/bundle-size.mjs --json` (79,076 B; no violations)
- Exact prototype `5714bee19c57d738e94bd724168bb28e9dec388b`: `npm test -- test/unit/mixins/view.spec.js --reporter=dot` (46 passed), `npm run build`, `node scripts/performance/bundle-size.mjs --json` (79,137 B; expected current-ceiling violation)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorizes a performance budget ceiling increase for the CollectionView constructor rollback fix so the complete prototype can be consumed later. The merged runtime leaves 8 B of headroom; the smallest complete fix measures 79,137 B, exceeding the 79,084 B ceiling by 53 B.

**Evidence**
- Adds exact-base and exact-prototype bundle, graph, allocation, and retention reports to `evidence/performance-budget-amendments/BA0007/`.
- Proposes a no-headroom ceiling increase to 79,137 B.
- The fix stops child View, Region, DOM, and collection-observer leaks after render-then-throw construction failures.
- Runtime code stays on a separate feature branch until governance is approved.
- No deployment or release is performed.

<sup>Written for commit b60965309aca87285d64d13077f81728e6ac4537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

