### PR TITLE
docs(roadmap): clarify Backbone adapter ownership

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -392,8 +392,8 @@ current-evidence findings:
 - **Selected:** V5 owns a neutral DataApi boundary for model identity, value reads,
   serialization, ordered collection items, entity subscriptions, and normalized
   structural collection changes. Core retains that contract, `setDataApi()`, and the
-  dependency-free plain-object and array default. The existing `backbone.js` installer
-  and `runtime/backbone-data-api.js` implementation move together into
+  dependency-free default for plain objects and arrays. The existing `backbone.js`
+  installer and `runtime/backbone-data-api.js` implementation move together into
   `@marionette/adapters/backbone` as one atomic optional integration, keeping `cid`,
   `attributes`, `models`, and Backbone event payloads out of core. This avoids making
   the temporary Backbone-shaped protocol a v5 public contract that would need removal
@@ -643,10 +643,10 @@ instructions, and every release blocker maps to this strategy.
 - Move first-party Backbone and jQuery runtime adapters into a separately published
   `@marionette/adapters` workspace package with only explicit `./backbone` and
   `./dom/jquery` exports. Move the current Backbone installer and Backbone DataApi
-  together behind `./backbone`; do not extract core's DataApi contract, setter, or
-  plain-data default. Remove the old core subpaths rather than forwarding them, keep
-  peers optional and isolated, and make build, package, performance, and release
-  verification require both distributions.
+  together behind `./backbone`; do not extract core's DataApi contract, `setDataApi()`,
+  or its default for plain objects and arrays. Remove the old core subpaths rather
+  than forwarding them, keep peers optional and isolated, and make build, package,
+  performance, and release verification require both distributions.
 - Remove the module-global feature registry as selected through the v3/v4
   compatibility audit. Preserve the canonical default behavior through existing
   local View and trigger options, migrate application-owned values to State or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -391,13 +391,15 @@ current-evidence findings:
   completion.
 - **Selected:** V5 owns a neutral DataApi boundary for model identity, value reads,
   serialization, ordered collection items, entity subscriptions, and normalized
-  structural collection changes. Plain objects and arrays are the default. The
-  optional `@marionette/adapters/backbone` integration installs the Backbone adapter,
-  keeping `cid`, `attributes`, `models`, and Backbone event payloads out of core. This
-  avoids making the temporary Backbone-shaped protocol a v5 public contract that would
-  need removal in v6. Do not add implicit Backbone detection, per-model wrappers, or a
-  parallel reconciliation path. State remains an owned local-state concern, not the
-  collection data source.
+  structural collection changes. Core retains that contract, `setDataApi()`, and the
+  dependency-free plain-object and array default. The existing `backbone.js` installer
+  and `runtime/backbone-data-api.js` implementation move together into
+  `@marionette/adapters/backbone` as one atomic optional integration, keeping `cid`,
+  `attributes`, `models`, and Backbone event payloads out of core. This avoids making
+  the temporary Backbone-shaped protocol a v5 public contract that would need removal
+  in v6. Do not add implicit Backbone detection, per-model wrappers, or a parallel
+  reconciliation path. State remains an owned local-state concern, not the collection
+  data source.
 - **Selected:** First-party Backbone and jQuery adapters ship only from explicit
   `@marionette/adapters/backbone` and `@marionette/adapters/dom/jquery` subpaths. The
   adapters package has no root barrel, and core does not retain forwarding modules or
@@ -640,8 +642,10 @@ instructions, and every release blocker maps to this strategy.
   package contracts. Keep Backbone-specific data shapes out of core.
 - Move first-party Backbone and jQuery runtime adapters into a separately published
   `@marionette/adapters` workspace package with only explicit `./backbone` and
-  `./dom/jquery` exports. Remove the old core subpaths rather than forwarding them,
-  keep peers optional and isolated, and make build, package, performance, and release
+  `./dom/jquery` exports. Move the current Backbone installer and Backbone DataApi
+  together behind `./backbone`; do not extract core's DataApi contract, setter, or
+  plain-data default. Remove the old core subpaths rather than forwarding them, keep
+  peers optional and isolated, and make build, package, performance, and release
   verification require both distributions.
 - Remove the module-global feature registry as selected through the v3/v4
   compatibility audit. Preserve the canonical default behavior through existing


### PR DESCRIPTION
## What

- State that core retains the DataApi contract, `setDataApi()`, and the dependency-free plain-data default.
- Require the existing Backbone installer and Backbone DataApi implementation to move together behind `@marionette/adapters/backbone`.
- Preserve the selected no-alias, explicit-subpath package boundary.

## Why

The Backbone installer and `BackboneDataApi` are one consumer integration that must be installed atomically. The roadmap already selected a separate adapters package, but did not explicitly prevent splitting those two pieces or extracting Marionette's native DataApi behavior from core.

## Scope

This is a `ROADMAP.md` clarification only. It does not move source, change package exports, alter runtime behavior, or publish an adapters package.

## Deployment Impact

None. No package or application deployment is required.

## Testing

- `npm run docs:check` — 7 documentation-contract tests passed; 22 executable examples validated; 50 pages built; 51 HTML files and 457 internal links validated.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the v5 roadmap so the existing Backbone installer and `runtime/backbone-data-api.js` move together into `@marionette/adapters/backbone` as one atomic optional integration. The previous wording left room to split those pieces or extract core's DataApi behavior; the update makes it explicit that core retains the DataApi contract, `setDataApi()`, and the dependency-free plain-object and array default. Docs-only change, so no source moves, export changes, runtime behavior shifts, or deployment impact.

<sup>Written for commit 849a14b18b7128669848f51a3dac17f1eed91fee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

