### PR TITLE
perf(build): authorize BA0010 development envelope

### DIFF
--- a/config/release/performance-budget-amendments.json
+++ b/config/release/performance-budget-amendments.json
@@ -371,6 +371,49 @@
       ],
       "rationale": "Authorize the exact measured distribution cost of explicit MnObject and Application owned cleanup tracked by #375. The prototype removes Radio and State cleanup from removable public destroy listeners, rolls back every established owned resource after construction failure, preserves the original error, and keeps public lifecycle timing. It grows only the four established main artifacts and adds no graph edge, external import, package subpath, allocation or retention proxy, or speculative headroom.",
       "rollbackCondition": "If the explicit owned-cleanup prototype is abandoned before consumption, append a governance-only BA0009 revocation. Never edit or delete this authorization. If the final implementation exceeds 79779 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
+    },
+    {
+      "kind": "authorization",
+      "id": "BA0010",
+      "target": "aggregate-shipped-package",
+      "previousCeilingBytes": 79779,
+      "proposedCeilingBytes": 100000,
+      "prototypeBaseCommit": "e89cb4acdaf16e8b7d962b2a14d6df95916c8520",
+      "prototypeCommit": "d091d7a2521b22a0fda109ede8c2d555d9f57a2b",
+      "implementationIssueUrl": "https://github.com/marionettejs/marionette/issues/191",
+      "authorizedArtifactPaths": [
+        "dist/backbone.cjs",
+        "dist/backbone.js",
+        "dist/marionette.cjs",
+        "dist/marionette.js",
+        "dist/marionette.min.js",
+        "dist/marionette.umd.js"
+      ],
+      "authorizedNewSubpaths": [],
+      "reports": [
+        {
+          "path": "evidence/performance-budget-amendments/BA0010/base.json",
+          "role": "base",
+          "sha256": "7592a2f6fbfecb756cae567355c2452400cac7fd9b9b55eb0896592c19923f85"
+        },
+        {
+          "path": "evidence/performance-budget-amendments/BA0010/prototype.json",
+          "role": "prototype",
+          "sha256": "d597426d0468267ff21ea8fde50b90e557dc50864610d8cfa1ca95621bbf8c54"
+        }
+      ],
+      "prototypeContract": {
+        "path": "evidence/performance-budget-amendments/BA0010/prototype-contract.json",
+        "sha256": "bf8ccea3760724d3d426b57b0a6778e34715479571fd973d581515e52bc38c22"
+      },
+      "approvalUrls": [
+        "https://github.com/marionettejs/marionette/pull/382#issuecomment-5514320166"
+      ],
+      "evidenceUrls": [
+        "https://github.com/marionettejs/marionette/issues/127#issuecomment-5514307943"
+      ],
+      "rationale": "Authorize a deliberate 100000-byte aggregate development envelope for the remaining v5 core runtime work. The StateApi and DataApi prototype proves the current ceiling is exhausted while adding about 1.4 kB to an individual root artifact; the aggregate reports 5351 bytes because it sums parallel delivery formats. The larger envelope restores this metric as a coarse runaway-growth backstop after nine authorization rounds, without approving new subpaths, external imports, eager allocations, retained resources, or bypassing exact-base artifact and consumer reporting.",
+      "rollbackCondition": "If the StateApi and DataApi architecture is abandoned before consumption, append a governance-only BA0010 revocation. Never edit or delete this authorization. Before beta promotion, review the envelope against the completed core and canonical consumer scenarios. If a final runtime implementation exceeds 100000 bytes or changes the authorized positive-delta artifact scope, require a new exact-base budget amendment."
     }
   ]
 }

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -203,9 +203,23 @@ preserves the original construction error, and keeps public lifecycle timing. It
 grows only the four existing main artifacts, adds no production graph edge, external
 import, package subpath, allocation or retention proxy, or speculative headroom, and
 leaves the optional adapter artifacts unchanged.
-[PR #378](https://github.com/marionettejs/marionette/pull/378) records the pending
-ceiling; a later runtime PR must consume it with independent exact-head artifact-growth
-approval.
+[PR #378](https://github.com/marionettejs/marionette/pull/378) recorded the
+authorization. [PR #379](https://github.com/marionettejs/marionette/pull/379)
+consumed it with independent exact-head artifact-growth approval.
+
+BA0010 authorizes an increase from 79,779 to 100,000 bytes as a deliberate
+development envelope for the remaining v5 core runtime work. The exact-base
+StateApi and DataApi prototype tracked by
+[#191](https://github.com/marionettejs/marionette/issues/191) proves that the
+previous ceiling is exhausted while adding about 1.4 kB to an individual root
+artifact. The aggregate reports 5,351 bytes because it sums parallel ESM, CommonJS,
+UMD, and minified UMD delivery formats. The proposal restores this metric as a coarse
+runaway-growth backstop after nine authorization rounds; it does not approve new
+subpaths, external imports, eager allocations, retained resources, or bypass
+exact-base artifact and consumer reporting. Before beta promotion, review the
+envelope against the completed core and canonical consumer scenarios.
+[PR #382](https://github.com/marionettejs/marionette/pull/382) records the pending
+ceiling; a later runtime PR must consume it independently.
 
 The approval must come from a different base-allowed maintainer whenever the exact-base
 allowlist contains an eligible alternative. If the pull-request author is the sole

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -212,8 +212,8 @@ development envelope for the remaining v5 core runtime work. The exact-base
 StateApi and DataApi prototype tracked by
 [#191](https://github.com/marionettejs/marionette/issues/191) proves that the
 previous ceiling is exhausted while adding about 1.4 kB to an individual root
-artifact. The aggregate reports 5,351 bytes because it sums parallel ESM, CommonJS,
-UMD, and minified UMD delivery formats. The proposal restores this metric as a coarse
+artifact. The aggregate grows by 5,351 bytes across parallel ESM, CommonJS, UMD, and
+minified UMD delivery formats. The proposal restores this metric as a coarse
 runaway-growth backstop after nine authorization rounds; it does not approve new
 subpaths, external imports, eager allocations, retained resources, or bypass
 exact-base artifact and consumer reporting. Before beta promotion, review the

--- a/evidence/performance-budget-amendments/BA0010/base.json
+++ b/evidence/performance-budget-amendments/BA0010/base.json
@@ -1,0 +1,684 @@
+{
+  "schemaVersion": 1,
+  "revision": "e89cb4acdaf16e8b7d962b2a14d6df95916c8520",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 20666,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 20751,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 21069,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 15583,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 644,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 656,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 79722,
+      "baselineSize": 49500,
+      "absoluteCeiling": 79779
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/state.js",
+          "modules/view-region.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "modules/state.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "utils/assign-in.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js",
+          "runtime/backbone-data-api.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [
+          "runtime/backbone-data-api.js"
+        ],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 15505,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15520,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 15562,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 13858,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 13863,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 13906,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 15745,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15751,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 15791,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15546,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15549,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15613,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 15806,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 15801,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 15846,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 0,
+        "collectionViewListeningToWhileMounted": 0,
+        "behaviorListeningToWhileMounted": 1,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": []
+  }
+}

--- a/evidence/performance-budget-amendments/BA0010/prototype-contract.json
+++ b/evidence/performance-budget-amendments/BA0010/prototype-contract.json
@@ -1,0 +1,343 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "sourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "totalBrotliBytes": 49500,
+    "absoluteCeilingBytes": 79779
+  },
+  "toolchain": {
+    "releaseProfile": {
+      "path": "config/release-profile.json",
+      "sha256": "405b0135261d44bc5c1cb7832f7bbdbcadfe8415704e40e14abee217ce2e5162",
+      "node": "24.19.0",
+      "npm": "11.17.0",
+      "lockfileVersion": 3,
+      "canonicalHost": {
+        "id": "linux-x64",
+        "runner": "ubuntu-24.04",
+        "platform": "linux",
+        "architecture": "x64"
+      }
+    },
+    "lockedDependencies": {
+      "backbone": "1.4.0",
+      "jsdom": "30.0.1",
+      "rollup": "4.63.0"
+    },
+    "commands": {
+      "deterministic": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run size"
+      ],
+      "hostedTiming": [
+        "npm run check:release-profile -- --host linux-x64 --runner ubuntu-24.04",
+        "npm ci",
+        "npm run performance:timing"
+      ]
+    }
+  },
+  "thresholds": {
+    "cumulativeGrowthPercent": 5,
+    "pullRequestApprovalPercent": 1,
+    "hostedTimingWarningPercent": 10,
+    "controlledMedianRegressionPercent": 5,
+    "controlledP95RegressionPercent": 10
+  },
+  "pullRequestGrowthApproval": {
+    "schemaVersion": 1,
+    "repository": "marionettejs/marionette",
+    "trackingIssueUrl": "https://github.com/marionettejs/marionette/issues/127",
+    "allowedLogins": [
+      "paulfalgout"
+    ]
+  },
+  "runtimeArtifacts": [
+    {
+      "name": "Main ES module",
+      "path": "dist/marionette.js",
+      "baselineBrotliBytes": 12776
+    },
+    {
+      "name": "Main CommonJS",
+      "path": "dist/marionette.cjs",
+      "baselineBrotliBytes": 12932
+    },
+    {
+      "name": "Main UMD",
+      "path": "dist/marionette.umd.js",
+      "baselineBrotliBytes": 13197
+    },
+    {
+      "name": "Main minified UMD",
+      "path": "dist/marionette.min.js",
+      "baselineBrotliBytes": 10001,
+      "additionalShippedArtifact": true
+    },
+    {
+      "name": "Backbone shim ES module",
+      "path": "dist/backbone.js",
+      "baselineBrotliBytes": 121
+    },
+    {
+      "name": "Backbone shim CommonJS",
+      "path": "dist/backbone.cjs",
+      "baselineBrotliBytes": 135
+    },
+    {
+      "name": "jQuery DomApi ES module",
+      "path": "dist/jquery-dom-api.js",
+      "baselineBrotliBytes": 169
+    },
+    {
+      "name": "jQuery DomApi CommonJS",
+      "path": "dist/jquery-dom-api.cjs",
+      "baselineBrotliBytes": 169
+    }
+  ],
+  "productionGraphs": [
+    {
+      "subpath": ".",
+      "input": "index.js",
+      "output": "dist/marionette.js",
+      "baselineModules": [
+        "config/dom.js",
+        "config/event-delegator.js",
+        "config/features.js",
+        "config/renderer.js",
+        "index.js",
+        "mixins/behaviors.js",
+        "mixins/common.js",
+        "mixins/delegate-entity-events.js",
+        "mixins/destroy.js",
+        "mixins/events.js",
+        "mixins/radio.js",
+        "mixins/requests.js",
+        "mixins/template-render.js",
+        "mixins/ui.js",
+        "mixins/view-events.js",
+        "mixins/view.js",
+        "modules/application.js",
+        "modules/behavior.js",
+        "modules/child-view-container.js",
+        "modules/collection-view.js",
+        "modules/common/bind-events.js",
+        "modules/common/bind-requests.js",
+        "modules/common/get-option.js",
+        "modules/common/merge-options.js",
+        "modules/common/monitor-view-events.js",
+        "modules/common/normalize-methods.js",
+        "modules/common/radio.js",
+        "modules/common/trigger-method.js",
+        "modules/common/view.js",
+        "modules/object.js",
+        "modules/radio.js",
+        "modules/view-region.js",
+        "utils/build-event-args.js",
+        "utils/call-handler.js",
+        "utils/error.js",
+        "utils/extend.js",
+        "utils/make-callback.js",
+        "utils/once-wrap.js",
+        "utils/proxy.js",
+        "version.js"
+      ],
+      "baselineExternalImports": [
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./backbone",
+      "input": "backbone.js",
+      "output": "dist/backbone.js",
+      "baselineModules": [
+        "backbone.js"
+      ],
+      "baselineExternalImports": [
+        "backbone",
+        "marionette",
+        "underscore"
+      ]
+    },
+    {
+      "subpath": "./jquery-dom-api",
+      "input": "jquery-dom-api.js",
+      "output": "dist/jquery-dom-api.js",
+      "baselineModules": [
+        "jquery-dom-api.js"
+      ],
+      "baselineExternalImports": [
+        "jquery"
+      ]
+    }
+  ],
+  "forbiddenExternalImports": [
+    "underscore"
+  ],
+  "forbiddenProductionModulePrefixes": [
+    ".github/",
+    "benchmarks/",
+    "docs/",
+    "docs-site/",
+    "node_modules/",
+    "scripts/",
+    "test/",
+    "config/diagnostics/",
+    "config/release/"
+  ],
+  "forbiddenProductionModules": [
+    "config/performance.json",
+    "config/release-profile.json",
+    "config/release-promotion.json"
+  ],
+  "deterministicResources": {
+    "attachDetachCycles": 100,
+    "mountDestroyCycles": 1000,
+    "instanceShapes": {
+      "View": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_domEvents",
+        "_eventPrefix",
+        "_isAttached",
+        "_isRendered",
+        "_rdEvents",
+        "_regions",
+        "cid",
+        "el",
+        "options",
+        "regions"
+      ],
+      "Region": [
+        "_initEl",
+        "cid",
+        "el",
+        "options"
+      ],
+      "Behavior": [
+        "_domEvents",
+        "_rdListenId",
+        "_rdListeningTo",
+        "cid",
+        "el",
+        "options",
+        "ui",
+        "view"
+      ],
+      "CollectionView": [
+        "_areViewEventsMonitored",
+        "_behaviors",
+        "_childViewEvents",
+        "_childViewTriggers",
+        "_children",
+        "_collectionEvents",
+        "_domEvents",
+        "_emptyRegion",
+        "_eventPrefix",
+        "_isAttached",
+        "_rdEvents",
+        "childView",
+        "children",
+        "cid",
+        "collection",
+        "el",
+        "options"
+      ]
+    },
+    "allocationShapes": {
+      "View": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "_regions",
+          "options",
+          "regions"
+        ],
+        "marionetteEventRegistrations": 6
+      },
+      "Behavior": {
+        "emptyArrays": [
+          "_domEvents"
+        ],
+        "emptyObjects": [
+          "options",
+          "ui"
+        ],
+        "listeningContainers": 1
+      },
+      "CollectionView": {
+        "emptyArrays": [
+          "_behaviors",
+          "_domEvents"
+        ],
+        "emptyChildViewContainers": [
+          "_children",
+          "children"
+        ],
+        "eagerEmptyRegion": true,
+        "marionetteEventRegistrations": 6
+      }
+    },
+    "retentionShapes": {
+      "regionRegistrationsWhileShown": 1,
+      "collectionRegistrationsWhileMounted": 3,
+      "modelRegistrationsWhileMounted": 1,
+      "externalListenerOwnersWhileMounted": 1,
+      "collectionViewListeningToWhileMounted": 1,
+      "behaviorListeningToWhileMounted": 2,
+      "destroyedBehaviorRetainsHostReference": true,
+      "destroyedHostRetainsBehaviorCount": 1,
+      "externalRegistrationsAfterDestroy": 0,
+      "externalListenerOwnersAfterDestroy": 0,
+      "frameworkListeningToAfterDestroy": 0,
+      "childContainerEntriesAfterDestroy": 0,
+      "managedDomChildrenAfterEmpty": 0,
+      "managedRootsConnectedAfterDestroy": 0,
+      "regionParentReferencesAfterDestroy": 0
+    }
+  },
+  "timing": {
+    "harnessSchemaVersion": 1,
+    "harnessRevision": "d6dc4c26b48c83ce4ecfd073c99f614f7e2974bd8be145e6859baaea4b540def",
+    "sampleCount": 20,
+    "warmupBatches": 5,
+    "cases": [
+      {
+        "id": "view-construct-destroy",
+        "iterationsPerSample": 200
+      },
+      {
+        "id": "view-render-rerender",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "behavior-view-set-element-destroy",
+        "iterationsPerSample": 100
+      },
+      {
+        "id": "region-show-empty",
+        "iterationsPerSample": 50
+      },
+      {
+        "id": "collection-view-render-destroy",
+        "iterationsPerSample": 10
+      },
+      {
+        "id": "collection-view-add-remove",
+        "iterationsPerSample": 20
+      }
+    ],
+    "controlledRunner": {
+      "status": "pending-pr-b"
+    }
+  }
+}

--- a/evidence/performance-budget-amendments/BA0010/prototype.json
+++ b/evidence/performance-budget-amendments/BA0010/prototype.json
@@ -1,0 +1,688 @@
+{
+  "schemaVersion": 1,
+  "revision": "d091d7a2521b22a0fda109ede8c2d555d9f57a2b",
+  "report": {
+    "schemaVersion": 1,
+    "contractPath": "config/performance.json",
+    "baselineSourceCommit": "31151c9cb5cb1e11d30da4332f58ca8b56cf2fe4",
+    "brotliQuality": 11,
+    "thresholds": {
+      "cumulativeGrowthPercent": 5,
+      "pullRequestApprovalPercent": 1,
+      "hostedTimingWarningPercent": 10,
+      "controlledMedianRegressionPercent": 5,
+      "controlledP95RegressionPercent": 10
+    },
+    "artifacts": [
+      {
+        "name": "Main ES module",
+        "path": "dist/marionette.js",
+        "status": "measured",
+        "size": 22070,
+        "baselineSize": 12776
+      },
+      {
+        "name": "Main CommonJS",
+        "path": "dist/marionette.cjs",
+        "status": "measured",
+        "size": 22151,
+        "baselineSize": 12932
+      },
+      {
+        "name": "Main UMD",
+        "path": "dist/marionette.umd.js",
+        "status": "measured",
+        "size": 22453,
+        "baselineSize": 13197
+      },
+      {
+        "name": "Main minified UMD",
+        "path": "dist/marionette.min.js",
+        "status": "measured",
+        "size": 16698,
+        "baselineSize": 10001
+      },
+      {
+        "name": "Backbone shim ES module",
+        "path": "dist/backbone.js",
+        "status": "measured",
+        "size": 672,
+        "baselineSize": 121
+      },
+      {
+        "name": "Backbone shim CommonJS",
+        "path": "dist/backbone.cjs",
+        "status": "measured",
+        "size": 676,
+        "baselineSize": 135
+      },
+      {
+        "name": "jQuery DomApi ES module",
+        "path": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "size": 175,
+        "baselineSize": 169
+      },
+      {
+        "name": "jQuery DomApi CommonJS",
+        "path": "dist/jquery-dom-api.cjs",
+        "status": "measured",
+        "size": 178,
+        "baselineSize": 169
+      }
+    ],
+    "cumulative": {
+      "size": 85073,
+      "baselineSize": 49500,
+      "absoluteCeiling": 79779
+    },
+    "graphs": [
+      {
+        "subpath": ".",
+        "input": "index.js",
+        "output": "dist/marionette.js",
+        "status": "measured",
+        "modules": [
+          "index.js",
+          "mixins/behaviors.js",
+          "mixins/common.js",
+          "mixins/delegate-entity-events.js",
+          "mixins/destroy.js",
+          "mixins/events.js",
+          "mixins/radio.js",
+          "mixins/requests.js",
+          "mixins/state.js",
+          "mixins/template-render.js",
+          "mixins/ui.js",
+          "mixins/view-events.js",
+          "mixins/view.js",
+          "modules/application.js",
+          "modules/behavior.js",
+          "modules/child-view-container.js",
+          "modules/collection-view.js",
+          "modules/common/bind-events.js",
+          "modules/common/bind-requests.js",
+          "modules/common/get-option.js",
+          "modules/common/merge-options.js",
+          "modules/common/monitor-view-events.js",
+          "modules/common/normalize-methods.js",
+          "modules/common/radio.js",
+          "modules/common/trigger-method.js",
+          "modules/common/view.js",
+          "modules/object.js",
+          "modules/radio.js",
+          "modules/view-region.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "runtime/state-api.js",
+          "utils/assign-in.js",
+          "utils/build-event-args.js",
+          "utils/call-handler.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/error.js",
+          "utils/extend.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/make-callback.js",
+          "utils/once-wrap.js",
+          "utils/subscribe-bindings.js",
+          "utils/unique-id.js",
+          "version.js"
+        ],
+        "externalImports": [],
+        "phase0AddedModules": [
+          "mixins/state.js",
+          "runtime/data-api.js",
+          "runtime/dom-api.js",
+          "runtime/event-delegator.js",
+          "runtime/renderer.js",
+          "runtime/state-api.js",
+          "utils/assign-in.js",
+          "utils/dispose-all.js",
+          "utils/each-own.js",
+          "utils/get-value.js",
+          "utils/is-string.js",
+          "utils/subscribe-bindings.js",
+          "utils/unique-id.js"
+        ],
+        "phase0RemovedModules": [
+          "config/dom.js",
+          "config/event-delegator.js",
+          "config/features.js",
+          "config/renderer.js",
+          "utils/proxy.js"
+        ],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./backbone",
+        "input": "backbone.js",
+        "output": "dist/backbone.js",
+        "status": "measured",
+        "modules": [
+          "backbone.js",
+          "runtime/backbone-data-api.js"
+        ],
+        "externalImports": [
+          "backbone",
+          "marionette"
+        ],
+        "phase0AddedModules": [
+          "runtime/backbone-data-api.js"
+        ],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [
+          "underscore"
+        ],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      },
+      {
+        "subpath": "./jquery-dom-api",
+        "input": "jquery-dom-api.js",
+        "output": "dist/jquery-dom-api.js",
+        "status": "measured",
+        "modules": [
+          "jquery-dom-api.js"
+        ],
+        "externalImports": [
+          "jquery"
+        ],
+        "phase0AddedModules": [],
+        "phase0RemovedModules": [],
+        "phase0AddedExternalImports": [],
+        "phase0RemovedExternalImports": [],
+        "forbiddenModules": [],
+        "forbiddenExternalImports": []
+      }
+    ],
+    "consumerBundles": {
+      "schemaVersion": 1,
+      "status": "reporting",
+      "fixtureVersion": "v1",
+      "fixtureRevision": "cbb5cf51f81b78c74238111372eb9b7148b081b3b0d30a91baf0ef613724b134",
+      "compression": {
+        "algorithm": "brotli",
+        "quality": 11
+      },
+      "toolchain": {
+        "rollup": "4.63.0",
+        "rollupPluginTerser": "1.0.0",
+        "terser": "5.48.0"
+      },
+      "peerExternalImports": [
+        "backbone",
+        "jquery"
+      ],
+      "artifacts": [
+        {
+          "id": "root-only:esm",
+          "scenario": "root-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 16610,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:cjs",
+          "scenario": "root-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 16614,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "root-only:umd",
+          "scenario": "root-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 16680,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-only.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": []
+        },
+        {
+          "id": "backbone-only:esm",
+          "scenario": "backbone-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 14949,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:cjs",
+          "scenario": "backbone-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 14953,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "backbone-only:umd",
+          "scenario": "backbone-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 15007,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/backbone-only.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:esm",
+          "scenario": "jquery-dom-api-only",
+          "format": "esm",
+          "status": "measured",
+          "size": 141,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:cjs",
+          "scenario": "jquery-dom-api-only",
+          "format": "cjs",
+          "status": "measured",
+          "size": 145,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "jquery-dom-api-only:umd",
+          "scenario": "jquery-dom-api-only",
+          "format": "umd",
+          "status": "measured",
+          "size": 251,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/jquery-dom-api-only.js",
+            "dist/jquery-dom-api.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:esm",
+          "scenario": "root-plus-backbone",
+          "format": "esm",
+          "status": "measured",
+          "size": 16857,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:cjs",
+          "scenario": "root-plus-backbone",
+          "format": "cjs",
+          "status": "measured",
+          "size": 16874,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-backbone:umd",
+          "scenario": "root-plus-backbone",
+          "format": "umd",
+          "status": "measured",
+          "size": 16930,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone.js",
+            "dist/backbone.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:esm",
+          "scenario": "root-plus-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 16667,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:cjs",
+          "scenario": "root-plus-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 16658,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-jquery:umd",
+          "scenario": "root-plus-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 16729,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-jquery.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:esm",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "esm",
+          "status": "measured",
+          "size": 16913,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:cjs",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "cjs",
+          "status": "measured",
+          "size": 16909,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        },
+        {
+          "id": "root-plus-backbone-jquery:umd",
+          "scenario": "root-plus-backbone-jquery",
+          "format": "umd",
+          "status": "measured",
+          "size": 16970,
+          "modules": [
+            "benchmarks/consumer-bundles/v1/root-plus-backbone-jquery.js",
+            "dist/backbone.js",
+            "dist/jquery-dom-api.js",
+            "dist/marionette.js"
+          ],
+          "externalImports": [
+            "backbone",
+            "jquery"
+          ]
+        }
+      ],
+      "violations": []
+    },
+    "resourcesRequired": true,
+    "resources": {
+      "schemaVersion": 1,
+      "workload": {
+        "attachDetachCycles": 100,
+        "mountDestroyCycles": 1000
+      },
+      "allocations": {
+        "View": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_domEvents",
+            "_eventPrefix",
+            "_isAttached",
+            "_isRendered",
+            "_rdEvents",
+            "_regions",
+            "cid",
+            "el",
+            "options",
+            "regions"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_domEvents",
+            "_rdEvents",
+            "_regions",
+            "el",
+            "options",
+            "regions"
+          ],
+          "uniqueOwnReferences": 7,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options",
+            "regions"
+          ],
+          "plainObjectEntries": 6,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        },
+        "Region": {
+          "ownProperties": [
+            "_initEl",
+            "cid",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_initEl",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 2,
+          "arrays": [],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "options"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 0
+        },
+        "Behavior": {
+          "ownProperties": [
+            "_domEvents",
+            "_rdListenId",
+            "_rdListeningTo",
+            "cid",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "ownReferences": [
+            "_domEvents",
+            "_rdListeningTo",
+            "el",
+            "options",
+            "ui",
+            "view"
+          ],
+          "uniqueOwnReferences": 6,
+          "arrays": [
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdListeningTo",
+            "options",
+            "ui"
+          ],
+          "plainObjectEntries": 1,
+          "childViewContainers": [],
+          "childViewContainerEntries": 0,
+          "regions": [],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 0,
+          "listeningContainers": 1
+        },
+        "CollectionView": {
+          "ownProperties": [
+            "_areViewEventsMonitored",
+            "_behaviors",
+            "_childViewEvents",
+            "_childViewTriggers",
+            "_children",
+            "_collectionEvents",
+            "_domEvents",
+            "_emptyRegion",
+            "_eventPrefix",
+            "_isAttached",
+            "_rdEvents",
+            "childView",
+            "children",
+            "cid",
+            "collection",
+            "el",
+            "options"
+          ],
+          "ownReferences": [
+            "_behaviors",
+            "_children",
+            "_domEvents",
+            "_emptyRegion",
+            "_rdEvents",
+            "childView",
+            "children",
+            "collection",
+            "el",
+            "options"
+          ],
+          "uniqueOwnReferences": 10,
+          "arrays": [
+            "_behaviors",
+            "_domEvents"
+          ],
+          "arrayEntries": 0,
+          "plainObjects": [
+            "_rdEvents",
+            "options"
+          ],
+          "plainObjectEntries": 8,
+          "childViewContainers": [
+            "_children",
+            "children"
+          ],
+          "childViewContainerEntries": 0,
+          "regions": [
+            "_emptyRegion"
+          ],
+          "regionsWithViews": 0,
+          "marionetteEventRegistrations": 6,
+          "listeningContainers": 0
+        }
+      },
+      "retention": {
+        "regionRegistrationsWhileShown": 1,
+        "collectionRegistrationsWhileMounted": 3,
+        "modelRegistrationsWhileMounted": 1,
+        "externalListenerOwnersWhileMounted": 0,
+        "collectionViewListeningToWhileMounted": 0,
+        "behaviorListeningToWhileMounted": 1,
+        "destroyedBehaviorRetainsHostReference": true,
+        "destroyedHostRetainsBehaviorCount": 1,
+        "externalRegistrationsAfterDestroy": 0,
+        "externalListenerOwnersAfterDestroy": 0,
+        "frameworkListeningToAfterDestroy": 0,
+        "childContainerEntriesAfterDestroy": 0,
+        "managedDomChildrenAfterEmpty": 0,
+        "managedRootsConnectedAfterDestroy": 0,
+        "regionParentReferencesAfterDestroy": 0
+      }
+    },
+    "violations": [
+      "Cumulative Brotli-11 size 85073 exceeds the absolute ceiling 79779"
+    ]
+  }
+}


### PR DESCRIPTION
Related #127
Related #191

## What

- Append BA0010 with exact-base and StateApi/DataApi prototype evidence.
- Raise the aggregate shipped-artifact development envelope from 79,779 to 100,000 bytes for later consumption by the runtime PR.
- Keep per-artifact growth reporting, production-graph validation, deterministic-resource checks, and exact-head approval independent.

## Why

The aggregate metric sums parallel ESM, CommonJS, UMD, and minified UMD delivery formats. Nine exact-size authorization and consumption rounds have left the active ceiling with no practical room for subsequent v5 runtime work. The StateApi/DataApi prototype is about 1.4 kB larger in an individual root artifact but appears as 5,351 aggregate bytes because equivalent runtime code is counted across formats. A deliberate 100,000-byte development envelope restores this check to its intended role as a coarse runaway-growth backstop.

## Scope

This governance-only PR changes the append-only performance-budget ledger, immutable BA0010 evidence, and performance-baseline documentation. It does not change runtime code, package exports, production graphs, the active ceiling, or any deployed artifact. The StateApi/DataApi PR must consume BA0010 separately after this authorization merges.

## Deployment Impact

None. No application, form, package, or deployment artifact changes in this PR.

## Testing

- Exact base `e89cb4acdaf16e8b7d962b2a14d6df95916c8520`: 79,722 cumulative Brotli-11 bytes; no contract violations.
- Prototype `d091d7a2521b22a0fda109ede8c2d555d9f57a2b`: 85,073 cumulative Brotli-11 bytes; only the expected current-ceiling violation.
- All 18 canonical consumer scenario/format combinations measured for both revisions.
- Evidence hashes and budget-amendment validation will be verified after the exact-head approval record is bound.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorizes BA0010 to raise the aggregate shipped-artifact development envelope from 79,779 to 100,000 Brotli-11 bytes for the StateApi/DataApi work tracked in #191. This governance-only change adds immutable evidence and does not modify runtime code, exports, production graphs, or deployed artifacts.

**Evidence**

- Measures all 18 canonical consumer scenario and format combinations for the exact base and prototype revisions.
- Confirms the base at 79,722 bytes and the prototype at 85,073 bytes, with only the expected current-ceiling violation.
- Keeps per-artifact growth, production-graph, deterministic-resource, and exact-head approval checks independent; the runtime PR must consume this authorization separately.

<sup>Written for commit e2d7f58167a89bd0d74853780d1b1e71b01579b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

