### PR TITLE
docs(roadmap): prioritize public proving grounds

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -629,6 +629,46 @@ is allowed. Resource ownership may allocate only after the first registration.
 The package backstop and every adopted consumer-scenario ceiling are independent hard
 gates; passing one does not compensate for failing another.
 
+## Public proving grounds
+
+External examples and benchmarks answer different questions and remain advisory
+unless a later roadmap decision explicitly promotes one into a release gate. Pursue
+them in this order:
+
+1. Finish the Marionette v5 [js-framework-benchmark][js-framework-benchmark]
+   implementation. It supplies the hot keyed-list and retained-memory signal, but its
+   benchmark-specific code does not define idiomatic application structure.
+2. Modernize the existing [Backbone.Marionette TodoMVC example][todomvc-marionette]
+   for v5 and submit it to the maintained [TodoMVC][todomvc] set. This is the highest
+   priority public normal-application artifact: it must demonstrate idiomatic
+   composition, routing and filtering, editable child Views, persistence, collection
+   changes, and lifecycle cleanup while passing TodoMVC's shared behavioral suite.
+3. Build a [RealWorld][realworld] implementation in a dedicated repository following
+   its starter-kit flow. Its shared API, CSS, and end-to-end suite give it the highest
+   architectural evidence value: API requests, authentication, routing, forms, nested
+   screens, error states, and asynchronous replacement exercise lifecycle races,
+   stale-request handling, Region replacement, teardown, and data-adapter ergonomics.
+   Its maintenance cost is accepted only after the smaller TodoMVC reference is current.
+4. Add Marionette to the [Framework Benchmarks weather application][framework-benchmarks]
+   if its maintainers are receptive. Its bundle, load, CPU, memory, build, and code
+   characteristics complement the list-operation focus above.
+5. Track [Speedometer][speedometer-3] rather than optimizing specifically for
+   admission. Maintaining a current, idiomatic TodoMVC implementation is useful
+   groundwork but does not imply inclusion in a browser-vendor-selected workload.
+
+[Builder.io framework-benchmarks][builder-framework-benchmarks] and
+[UIBench][uibench] remain lower-priority investigations. The former uses
+best-effort generated framework code, which makes idiomatic Marionette harder to
+defend; the latter offers useful rendering cases but less current ecosystem reach.
+Standalone bundle-size comparisons do not prove application-framework fitness and
+remain covered by Marionette's own release budgets.
+
+Together the selected proving grounds provide four distinct signals: peak list
+performance, understandable small-application code, realistic application
+architecture, and startup, bundle, and resource cost. Results follow the external
+benchmark evidence rules above and never justify a default API solely because a
+benchmark-specific implementation is fast.
+
 ## Work phases
 
 The phases describe dependency order, not separate releases. Work may overlap only
@@ -988,3 +1028,11 @@ block stable v5.
 [issue-190]: https://github.com/marionettejs/marionette/issues/190
 [issue-191]: https://github.com/marionettejs/marionette/issues/191
 [issue-104]: https://github.com/marionettejs/marionette/issues/104
+[js-framework-benchmark]: https://github.com/krausest/js-framework-benchmark
+[todomvc]: https://github.com/tastejs/todomvc
+[todomvc-marionette]: https://github.com/tastejs/todomvc/tree/master/examples/backbone_marionette
+[realworld]: https://github.com/realworld-apps/realworld
+[framework-benchmarks]: https://github.com/Lissy93/framework-benchmarks
+[speedometer-3]: https://webkit.org/blog/15131/speedometer-3-0-the-best-way-yet-to-measure-browser-performance/
+[builder-framework-benchmarks]: https://github.com/BuilderIO/framework-benchmarks
+[uibench]: https://github.com/localvoid/uibench


### PR DESCRIPTION
## What

- Add an ordered Public proving grounds roadmap section covering js-framework-benchmark, TodoMVC, RealWorld, the weather framework benchmark, and Speedometer tracking.
- Define the distinct evidence each project supplies and keep external results advisory unless explicitly promoted to a release gate.
- Record lower-priority Builder.io, UIBench, and standalone bundle-size work with direct source links.

## Why

The roadmap already governs external benchmark evidence but did not prioritize the public artifacts that should exercise normal application code, realistic architecture, and startup/resource cost alongside keyed-list performance. This makes that sequence explicit and keeps benchmark-specific optimizations from defining the default API.

## Scope

This changes only `ROADMAP.md`. It does not modify runtime code, package boundaries, tests, release gates, or any external benchmark repository.

## Deployment Impact

No deployment, package publication, or application redeploy is required.

## Testing

- `git diff --check`
- `npm ci`
- `npm run lint:ci`
- Verified all eight added external references return HTTP 200.
- Rechecked the current TodoMVC, RealWorld, Framework Benchmarks, Builder.io benchmark, and Speedometer primary documentation against the recorded claims.
- Runtime tests were not run because this is a roadmap-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes the public benchmarks and examples the roadmap will use as proving grounds, so benchmark-specific code doesn't define the default Marionette API.

- Orders js-framework-benchmark, TodoMVC, RealWorld, the Framework Benchmarks weather app, and Speedometer by the distinct evidence each provides.
- Keeps external results advisory unless a later roadmap decision promotes one to a release gate.
- Records Builder.io, UIBench, and standalone bundle-size work as lower priority with direct source links.
- Changes only `ROADMAP.md`; no runtime code, tests, or release gates are affected.

<sup>Written for commit 8b736d22240037b0c4bfb6a6a4d33db74e5c8fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

