### PR TITLE
feat(performance): verify package artifact relocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
           node "${authority_script}" \
             --report "${PERFORMANCE_DIR}/bundle-size-base.json" "${PERFORMANCE_DIR}/bundle-size-authority.json" \
             --growth-approval "${PERFORMANCE_DIR}/growth-approval.json" \
+            --authority-contract "${base_contract}" \
+            --candidate-contract config/performance.json \
             > "${PERFORMANCE_DIR}/bundle-size-report.md" || report_status=$?
           cat "${PERFORMANCE_DIR}/bundle-size-report.md" >> "${GITHUB_STEP_SUMMARY}"
           if [ "${authority_status}" -ne 0 ] || [ "${candidate_status}" -ne 0 ] || \

--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -9,7 +9,10 @@ import terser from '@rollup/plugin-terser';
 import { rollup } from 'rollup';
 import {
   canonicalForbiddenExternalImports,
+  committedTimingHarnessRevision,
   newProductionReportDelta,
+  relocationTransition,
+  validateCandidateGrowthContract,
   validateGrowthApprovalPolicy,
 } from './growth-approval.mjs';
 import {
@@ -108,10 +111,18 @@ export function collectRuntimePaths(value, paths = new Set()) {
   return paths;
 }
 
-export function runtimeSubpaths(packageJson) {
+function publicSubpath(packageName, subpath) {
+  return subpath === '.' ? packageName : `${packageName}/${subpath.slice(2)}`;
+}
+
+function packageRuntimePath(directory, path) {
+  return normalizePath(directory ? `${directory}/${path}` : path);
+}
+
+export function runtimeSubpaths(packageJson, packageName = null) {
   return Object.entries(packageJson.exports || {})
     .filter(([, value]) => collectRuntimePaths(value).size)
-    .map(([subpath]) => subpath)
+    .map(([subpath]) => packageName ? publicSubpath(packageName, subpath) : subpath)
     .sort();
 }
 
@@ -136,7 +147,13 @@ function difference(left, right) {
   return left.filter(value => !rightSet.has(value));
 }
 
-export function validateContract(contract, packageJson, runtimeFiles, budgetAmendments = null) {
+export function validateContract(
+  contract,
+  packageJson,
+  runtimeFiles,
+  budgetAmendments = null,
+  runtimePackages = [{ directory: '', packageJson }],
+) {
   const violations = [];
   if (contract.schemaVersion !== 1) {
     violations.push(`Unsupported performance schemaVersion ${contract.schemaVersion}`);
@@ -165,12 +182,14 @@ export function validateContract(contract, packageJson, runtimeFiles, budgetAmen
     }
   }
 
-  const declaredPaths = collectRuntimePaths({
-    browser: packageJson.browser,
-    exports: packageJson.exports,
-    main: packageJson.main,
-    module: packageJson.module,
-  });
+  const declaredPaths = new Set(runtimePackages.flatMap(({ directory, packageJson: manifest }) => {
+    return [...collectRuntimePaths({
+      browser: manifest.browser,
+      exports: manifest.exports,
+      main: manifest.main,
+      module: manifest.module,
+    })].map(path => packageRuntimePath(directory, path));
+  }));
   for (const artifact of contract.runtimeArtifacts) {
     if (artifact.additionalShippedArtifact) {
       declaredPaths.add(artifact.path);
@@ -178,7 +197,11 @@ export function validateContract(contract, packageJson, runtimeFiles, budgetAmen
   }
 
   const configuredPaths = contract.runtimeArtifacts.map(({ path }) => path).sort();
-  const discoveredPaths = runtimeFiles.map(path => `dist/${path}`).sort();
+  const discoveredPaths = runtimeFiles.map(path => {
+    const normalized = normalizePath(path);
+    return normalized.startsWith('dist/') || normalized.startsWith('packages/') ?
+      normalized : `dist/${normalized}`;
+  }).sort();
   const missingConfiguration = difference([...declaredPaths].sort(), configuredPaths);
   const undeclaredConfiguration = difference(configuredPaths, [...declaredPaths].sort());
   const missingRuntimeFiles = difference(configuredPaths, discoveredPaths);
@@ -198,14 +221,24 @@ export function validateContract(contract, packageJson, runtimeFiles, budgetAmen
   }
 
   const configuredSubpaths = contract.productionGraphs.map(({ subpath }) => subpath).sort();
-  const exportedSubpaths = runtimeSubpaths(packageJson);
+  const exportedSubpaths = runtimePackages.flatMap(({ directory, packageJson: manifest }) => {
+    return runtimeSubpaths(manifest, directory ? manifest.name : null);
+  }).sort();
   const missingGraphs = difference(exportedSubpaths, configuredSubpaths);
   const extraGraphs = difference(configuredSubpaths, exportedSubpaths);
   if (missingGraphs.length || extraGraphs.length) {
     violations.push(`Production graph subpaths mismatch exports; missing: ${missingGraphs.join(', ') || 'none'}; extra: ${extraGraphs.join(', ') || 'none'}`);
   }
   for (const graph of contract.productionGraphs) {
-    const exportedPaths = collectRuntimePaths(packageJson.exports?.[graph.subpath]);
+    const owningPackage = runtimePackages.find(({ directory, packageJson: manifest }) => {
+      return runtimeSubpaths(manifest, directory ? manifest.name : null).includes(graph.subpath);
+    });
+    const localSubpath = owningPackage && !owningPackage.directory ?
+      graph.subpath : owningPackage ?
+        `./${graph.subpath.slice(owningPackage.packageJson.name.length + 1)}` : null;
+    const exportedPaths = localSubpath ? new Set([...collectRuntimePaths(
+      owningPackage.packageJson.exports?.[localSubpath]
+    )].map(path => packageRuntimePath(owningPackage.directory, path))) : new Set();
     if (!exportedPaths.has(graph.output)) {
       violations.push(
         `Production graph ${graph.subpath} output ${graph.output} is not exported by that subpath`
@@ -258,7 +291,8 @@ export function validateConsumerBundleContract(
   fixture,
   packageJson,
   brotliQuality,
-  fixtureRevision
+  fixtureRevision,
+  packageJsons = [packageJson],
 ) {
   const violations = [];
   if (!contract || !sameStringInventory(Object.keys(contract).sort(), [
@@ -306,12 +340,19 @@ export function validateConsumerBundleContract(
   if (!sameStringInventory(fixture?.expectedArtifacts, expectedArtifacts)) {
     violations.push(`Consumer bundle expected artifact set must be ${expectedArtifacts.join(', ')}`);
   }
-  if (fixture?.packageName !== packageJson.name) {
-    violations.push(`Consumer bundle fixture package ${fixture?.packageName || 'missing'} does not match ${packageJson.name}`);
+  const packageNames = packageJsons.map(manifest => manifest.name);
+  const legacySinglePackage = packageNames.length === 1 &&
+    fixture?.packageName === packageNames[0] && !Object.hasOwn(fixture, 'packageNames');
+  if (!legacySinglePackage && !sameStringInventory(fixture?.packageNames, packageNames)) {
+    violations.push(`Consumer bundle fixture packages must be ${packageNames.join(', ')}`);
   }
 
-  const runtimePeers = Object.keys(packageJson.peerDependencies || {})
+  const internalPackages = new Set(packageNames);
+  const runtimePeers = [...new Set(packageJsons.flatMap(manifest => {
+    return Object.keys(manifest.peerDependencies || {});
+  }))]
     .filter(peer => !peer.startsWith('@types/'))
+    .filter(peer => !internalPackages.has(peer))
     .sort();
   if (!sameStringInventory(contract.peerExternalImports, runtimePeers)) {
     violations.push(`Consumer bundle peer externals must be ${runtimePeers.join(', ')}`);
@@ -330,8 +371,8 @@ export function validateConsumerBundleContract(
     }
   }
 
-  const exportedImports = new Set(Object.keys(packageJson.exports || {}).map(subpath => {
-    return subpath === '.' ? packageJson.name : `${packageJson.name}/${subpath.slice(2)}`;
+  const exportedImports = new Set(packageJsons.flatMap(manifest => {
+    return Object.keys(manifest.exports || {}).map(subpath => publicSubpath(manifest.name, subpath));
   }));
   for (const scenario of fixture?.scenarios || []) {
     if (!Array.isArray(scenario.publicImports) || !scenario.publicImports.length ||
@@ -363,13 +404,14 @@ export function validateConsumerBundleContract(
   return violations;
 }
 
-function consumerPackageResolver(root, packageJson, peerExternalImports) {
-  const packageName = packageJson.name;
-  const importPaths = new Map(Object.entries(packageJson.exports || {}).map(([subpath, value]) => {
-    const publicImport = subpath === '.' ? packageName : `${packageName}/${subpath.slice(2)}`;
-    const paths = collectRuntimePaths(value);
-    const esmPath = [...paths].find(path => path.endsWith('.js') && !path.endsWith('.umd.js'));
-    return [publicImport, esmPath ? resolve(root, esmPath) : null];
+function consumerPackageResolver(root, runtimePackages, peerExternalImports) {
+  const importPaths = new Map(runtimePackages.flatMap(({ directory, packageJson }) => {
+    return Object.entries(packageJson.exports || {}).map(([subpath, value]) => {
+      const publicImport = publicSubpath(packageJson.name, subpath);
+      const paths = collectRuntimePaths(value);
+      const esmPath = [...paths].find(path => path.endsWith('.js') && !path.endsWith('.umd.js'));
+      return [publicImport, esmPath ? resolve(root, directory, esmPath) : null];
+    });
   }));
 
   return {
@@ -404,7 +446,7 @@ function consumerGraphViolations(scenario, modules, externalImports, peerExterna
     violations.push(`${scenario.id} contains non-peer external imports: ${undeclaredExternals.join(', ')}`);
   }
   if (scenario.id === 'root-only' && (externalImports.length !== 0 ||
-      modules.some(module => module === 'dist/backbone.js' || module === 'dist/jquery-dom-api.js'))) {
+      modules.some(module => module.startsWith('packages/adapters/dist/')))) {
     violations.push('root-only consumer bundle is not isolated from opt-in subpaths and peers');
   }
   return violations;
@@ -413,10 +455,19 @@ function consumerGraphViolations(scenario, modules, externalImports, peerExterna
 export async function measureConsumerBundles({ root = '.', contract, brotliQuality } = {}) {
   const resolvedRoot = resolve(root);
   const fixturePath = resolve(resolvedRoot, contract.fixture.path);
-  const [fixtureText, packageJson] = await Promise.all([
+  const [fixtureText, packageJson, adaptersPackageJson] = await Promise.all([
     readFile(fixturePath, 'utf8'),
     readJson(resolve(resolvedRoot, 'package.json')),
+    readJson(resolve(resolvedRoot, 'packages/adapters/package.json')).catch(error => {
+      if (error.code === 'ENOENT') { return null; }
+      throw error;
+    }),
   ]);
+  const runtimePackages = [
+    { directory: '', packageJson },
+    ...(adaptersPackageJson ? [{ directory: 'packages/adapters', packageJson: adaptersPackageJson }] : []),
+  ];
+  const packageJsons = runtimePackages.map(({ packageJson: manifest }) => manifest);
   const fixture = JSON.parse(fixtureText);
   const actualFixtureRevision = sha256Text(fixtureText);
   const violations = validateConsumerBundleContract(
@@ -424,7 +475,8 @@ export async function measureConsumerBundles({ root = '.', contract, brotliQuali
     fixture,
     packageJson,
     brotliQuality,
-    actualFixtureRevision
+    actualFixtureRevision,
+    packageJsons,
   );
   const fixtureRoot = dirname(fixturePath);
   const artifacts = [];
@@ -441,7 +493,7 @@ export async function measureConsumerBundles({ root = '.', contract, brotliQuali
       bundle = await rollup({
         input: entryPath,
         plugins: [
-          consumerPackageResolver(resolvedRoot, packageJson, contract.peerExternalImports),
+          consumerPackageResolver(resolvedRoot, runtimePackages, contract.peerExternalImports),
           terser(fixture.minify),
         ],
         treeshake: fixture.treeshake,
@@ -690,20 +742,40 @@ export async function measure({
     }
   }
   const packageJson = await readJson(resolve(resolvedRoot, 'package.json'));
-  const runtimeFiles = await listRuntimeFiles(resolve(resolvedRoot, 'dist')).catch(error => {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-    return [];
+  const adaptersPackageJson = await readJson(
+    resolve(resolvedRoot, 'packages/adapters/package.json')
+  ).catch(error => {
+    if (error.code === 'ENOENT') { return null; }
+    throw error;
   });
-  const violations = validateContract(contract, packageJson, runtimeFiles, budgetAmendments);
+  const runtimePackages = [
+    { directory: '', packageJson },
+    ...(adaptersPackageJson ? [{
+      directory: 'packages/adapters',
+      packageJson: adaptersPackageJson,
+    }] : []),
+  ];
+  const runtimeFiles = (await Promise.all(runtimePackages.map(async({ directory }) => {
+    const distDirectory = resolve(resolvedRoot, directory, 'dist');
+    const files = await listRuntimeFiles(distDirectory).catch(error => {
+      if (error.code !== 'ENOENT') { throw error; }
+      return [];
+    });
+    return files.map(path => packageRuntimePath(directory, `dist/${path}`));
+  }))).flat().sort();
+  const violations = validateContract(
+    contract,
+    packageJson,
+    runtimeFiles,
+    budgetAmendments,
+    runtimePackages,
+  );
   if (checkToolchain) {
     violations.push(...await validateToolchain(contract, resolvedRoot));
   }
   const quality = contract.baseline.brotliQuality;
   const configuredPaths = new Set(contract.runtimeArtifacts.map(artifact => artifact.path));
   const untrackedArtifacts = runtimeFiles
-    .map(path => `dist/${path}`)
     .filter(path => !configuredPaths.has(path))
     .map(path => ({ name: `Untracked ${path}`, path, untracked: true }));
   const artifactConfigurations = [...contract.runtimeArtifacts, ...untrackedArtifacts];
@@ -716,7 +788,22 @@ export async function measure({
   let configurations;
   try {
     const configUrl = pathToFileURL(resolve(resolvedRoot, 'rollup.config.mjs'));
-    ({ default: configurations } = await import(configUrl.href));
+    const { default: rootConfigurations } = await import(configUrl.href);
+    configurations = [...rootConfigurations];
+    if (adaptersPackageJson) {
+      const adaptersRoot = resolve(resolvedRoot, 'packages/adapters');
+      const adaptersConfigUrl = pathToFileURL(resolve(adaptersRoot, 'rollup.config.mjs'));
+      const { default: adapterConfigurations } = await import(adaptersConfigUrl.href);
+      configurations.push(...adapterConfigurations.map(configuration => ({
+        ...configuration,
+        input: resolveRollupInput(adaptersRoot, configuration.input),
+        output: (Array.isArray(configuration.output) ?
+          configuration.output : [configuration.output]).map(output => ({
+          ...output,
+          file: resolve(adaptersRoot, output.file),
+        })),
+      })));
+    }
   } catch (error) {
     violations.push(`Unable to load production Rollup configuration: ${error.message}`);
     configurations = [];
@@ -750,7 +837,9 @@ export async function measure({
   }
 
   const configuredSubpaths = new Set(contract.productionGraphs.map(graph => graph.subpath));
-  for (const subpath of runtimeSubpaths(packageJson)) {
+  for (const subpath of runtimePackages.flatMap(({ directory, packageJson: manifest }) => {
+    return runtimeSubpaths(manifest, directory ? manifest.name : null);
+  })) {
     if (!configuredSubpaths.has(subpath)) {
       graphs.push({
         subpath,
@@ -1038,7 +1127,7 @@ function sameNewArtifacts(supplied, expected) {
   });
 }
 
-function growthApprovalReport(base, current, supplied) {
+function growthApprovalReport(base, current, supplied, relocationOptions) {
   const thresholdPercent = current.thresholds.pullRequestApprovalPercent;
   const consumingBudget = supplied?.budgetAmendment?.status === 'accepted' &&
     supplied.budgetAmendment.mode === 'consume';
@@ -1052,7 +1141,7 @@ function growthApprovalReport(base, current, supplied) {
     ))
     .filter(Boolean)
     .sort((left, right) => left.path.localeCompare(right.path));
-  const newProduction = newProductionReportDelta(base, current);
+  const newProduction = newProductionReportDelta(base, current, relocationOptions);
   const newProductionPresent = newProduction.artifacts.length || newProduction.subpaths.length;
   const newProductionEnforced = supplied?.newProductionEnforced === true;
   const approvalRequired = required.length || newProductionPresent;
@@ -1178,11 +1267,47 @@ function growthApprovalSection(result) {
   return lines;
 }
 
-async function buildReport(baseFile, currentFile, growthApprovalFile) {
+async function buildReport(
+  baseFile,
+  currentFile,
+  growthApprovalFile,
+  authorityContractFile,
+  candidateContractFile,
+) {
   const base = await readJson(baseFile);
   const current = await readJson(currentFile);
   const suppliedGrowthApproval = growthApprovalFile ? await readJson(growthApprovalFile) : null;
-  const growthApproval = growthApprovalReport(base, current, suppliedGrowthApproval);
+  let relocationOptions;
+  if (suppliedGrowthApproval?.relocations) {
+    if (!authorityContractFile || !candidateContractFile) {
+      throw new Error('Relocation report rendering requires authority and candidate contracts');
+    }
+    const [authorityContract, candidateContract] = await Promise.all([
+      readJson(authorityContractFile),
+      readJson(candidateContractFile),
+    ]);
+    const contractViolations = validateCandidateGrowthContract(
+      authorityContract,
+      candidateContract,
+      {
+        timingHarnessRevision: Object.hasOwn(authorityContract, 'timing') ?
+          await committedTimingHarnessRevision() : undefined,
+      },
+    );
+    if (contractViolations.length) {
+      throw new Error(`Relocation report contract is invalid: ${contractViolations.join('; ')}`);
+    }
+    if (!isDeepStrictEqual(suppliedGrowthApproval.relocations, candidateContract.relocations)) {
+      throw new Error('Growth approval relocations do not match the candidate contract');
+    }
+    relocationOptions = relocationTransition(authorityContract, candidateContract);
+  }
+  const growthApproval = growthApprovalReport(
+    base,
+    current,
+    suppliedGrowthApproval,
+    relocationOptions,
+  );
   const baseByPath = new Map(base.artifacts.map(result => [result.path, result]));
   const approvalRequiredPaths = new Set(growthApproval.required.map(({ path }) => path));
   const newArtifactPaths = new Set(growthApproval.newArtifacts.map(({ path }) => path));
@@ -1274,8 +1399,20 @@ async function buildReport(baseFile, currentFile, growthApprovalFile) {
   return { consumerComparison, growthApproval, markdown, resourceComparison };
 }
 
-export async function createReport(baseFile, currentFile, growthApprovalFile) {
-  return (await buildReport(baseFile, currentFile, growthApprovalFile)).markdown;
+export async function createReport(
+  baseFile,
+  currentFile,
+  growthApprovalFile,
+  authorityContractFile,
+  candidateContractFile,
+) {
+  return (await buildReport(
+    baseFile,
+    currentFile,
+    growthApprovalFile,
+    authorityContractFile,
+    candidateContractFile,
+  )).markdown;
 }
 
 function writeMeasurement(result, json) {
@@ -1332,7 +1469,15 @@ export async function main(args = process.argv.slice(2)) {
   if (reportIndex !== -1) {
     const [baseFile, currentFile] = positionalPaths(args, reportIndex, 2, '--report');
     const growthApprovalFile = getArgument(args, '--growth-approval');
-    const report = await buildReport(baseFile, currentFile, growthApprovalFile);
+    const authorityContractFile = getArgument(args, '--authority-contract');
+    const candidateContractFile = getArgument(args, '--candidate-contract');
+    const report = await buildReport(
+      baseFile,
+      currentFile,
+      growthApprovalFile,
+      authorityContractFile,
+      candidateContractFile,
+    );
     console.log(report.markdown);
     if (report.resourceComparison.violations.length ||
         report.consumerComparison.violations.length ||

--- a/scripts/performance/growth-approval.mjs
+++ b/scripts/performance/growth-approval.mjs
@@ -47,7 +47,7 @@ export function canonicalForbiddenExternalImports(values) {
 }
 
 function validSubpath(subpath) {
-  return /^\.\/[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(subpath) &&
+  return /^(?:\.\/[A-Za-z0-9][A-Za-z0-9._/-]*|@[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._/-]*)$/.test(subpath) &&
     !subpath.includes('//') && !subpath.split('/').includes('..');
 }
 
@@ -68,8 +68,57 @@ function validNewArtifacts(artifacts) {
 }
 
 function validArtifactPath(path) {
-  return /^dist\/[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:c|m)?js$/.test(path) &&
+  return /^(?:dist|packages\/[A-Za-z0-9][A-Za-z0-9._/-]*\/dist)\/[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:c|m)?js$/.test(path) &&
     !path.includes('//') && !path.split('/').includes('..');
+}
+
+export function relocationTransition(authority, candidate) {
+  const empty = { artifactMoves: new Map(), graphMoves: new Map(), violations: [] };
+  if (Object.hasOwn(authority, 'relocations')) {
+    if (!isDeepStrictEqual(authority.relocations, candidate.relocations)) {
+      empty.violations.push('Candidate performance contract changes exact-base relocations');
+    }
+    return empty;
+  }
+  if (!Object.hasOwn(candidate, 'relocations')) {
+    return empty;
+  }
+
+  const relocations = candidate.relocations;
+  if (!exactObjectFields(relocations, ['productionGraphs', 'runtimeArtifacts']) ||
+      !Array.isArray(relocations.runtimeArtifacts) ||
+      !Array.isArray(relocations.productionGraphs)) {
+    return { ...empty, violations: ['Candidate performance relocations are malformed'] };
+  }
+
+  const artifactMoves = new Map();
+  const artifactTargets = new Set();
+  const graphMoves = new Map();
+  const graphTargets = new Set();
+  const violations = [];
+  for (const [index, move] of relocations.runtimeArtifacts.entries()) {
+    if (!exactObjectFields(move, ['from', 'to']) ||
+        !validArtifactPath(move?.from) || !validArtifactPath(move?.to) ||
+        artifactMoves.has(move.from) || artifactTargets.has(move.to) || move.from === move.to ||
+        index > 0 && relocations.runtimeArtifacts[index - 1]?.from >= move.from) {
+      violations.push('Candidate runtime artifact relocations must be unique safe from/to pairs');
+      continue;
+    }
+    artifactMoves.set(move.from, move.to);
+    artifactTargets.add(move.to);
+  }
+  for (const [index, move] of relocations.productionGraphs.entries()) {
+    if (!exactObjectFields(move, ['from', 'to']) ||
+        !(move?.from === '.' || validSubpath(move?.from)) || !validSubpath(move?.to) ||
+        graphMoves.has(move.from) || graphTargets.has(move.to) || move.from === move.to ||
+        index > 0 && relocations.productionGraphs[index - 1]?.from >= move.from) {
+      violations.push('Candidate production graph relocations must be unique safe from/to pairs');
+      continue;
+    }
+    graphMoves.set(move.from, move.to);
+    graphTargets.add(move.to);
+  }
+  return { artifactMoves, graphMoves, violations };
 }
 
 function escapeRegExp(value) {
@@ -415,16 +464,23 @@ export function validateCandidateGrowthContract(
   }
   const authorityKeys = Object.keys(authority).sort();
   const candidateKeys = Object.keys(candidate).sort();
-  const allowedCandidateKeys = Object.hasOwn(authority, 'forbiddenExternalImports') ?
-    authorityKeys : [...authorityKeys, 'forbiddenExternalImports'].sort();
+  const allowedCandidateKeys = new Set(authorityKeys);
+  if (!Object.hasOwn(authority, 'forbiddenExternalImports')) {
+    allowedCandidateKeys.add('forbiddenExternalImports');
+  }
+  if (!Object.hasOwn(authority, 'relocations')) {
+    allowedCandidateKeys.add('relocations');
+  }
   const missingAuthorityKeys = authorityKeys.filter(key => !Object.hasOwn(candidate, key));
-  const unrelatedCandidateKeys = candidateKeys.filter(key => !allowedCandidateKeys.includes(key));
+  const unrelatedCandidateKeys = candidateKeys.filter(key => !allowedCandidateKeys.has(key));
   if (missingAuthorityKeys.length || unrelatedCandidateKeys.length) {
     violations.push('Candidate performance contract top-level fields differ from the exact-base contract');
   }
   if (!validForbiddenExternalImportsTransition(authority, candidate)) {
     violations.push('Candidate performance contract forbiddenExternalImports must be a sorted, unique, non-empty string superset of the exact-base list');
   }
+  const relocation = relocationTransition(authority, candidate);
+  violations.push(...relocation.violations);
   for (const key of authorityKeys) {
     if (key === 'runtimeArtifacts' || key === 'productionGraphs') {
       continue;
@@ -465,8 +521,15 @@ export function validateCandidateGrowthContract(
   const authorityArtifacts = mapBy(authority.runtimeArtifacts, 'path', 'Exact-base runtimeArtifacts');
   const candidateArtifacts = mapBy(candidate.runtimeArtifacts, 'path', 'Candidate runtimeArtifacts');
   violations.push(...authorityArtifacts.violations, ...candidateArtifacts.violations);
+  for (const [from, to] of relocation.artifactMoves) {
+    if (!authorityArtifacts.map.has(from) || candidateArtifacts.map.has(from) ||
+        authorityArtifacts.map.has(to) || !candidateArtifacts.map.has(to)) {
+      violations.push(`Runtime artifact relocation ${from} to ${to} must replace one exact-base artifact`);
+    }
+  }
   for (const [path, artifact] of authorityArtifacts.map) {
-    if (!isDeepStrictEqual(candidateArtifacts.map.get(path), artifact)) {
+    if (!isDeepStrictEqual(candidateArtifacts.map.get(path), artifact) &&
+        !relocation.artifactMoves.has(path)) {
       violations.push(`Candidate performance contract removes or changes exact-base runtime artifact ${path}`);
     }
   }
@@ -474,11 +537,17 @@ export function validateCandidateGrowthContract(
     if (authorityArtifacts.map.has(path)) {
       continue;
     }
+    const movedFrom = [...relocation.artifactMoves]
+      .find(([, target]) => target === path)?.[0];
+    const movedArtifact = movedFrom ? authorityArtifacts.map.get(movedFrom) : null;
     if (!exactObjectFields(artifact, ['baselineBrotliBytes', 'name', 'path']) ||
         typeof artifact.name !== 'string' || !artifact.name || !validArtifactPath(path)) {
       violations.push(`New runtime artifact ${path} must contain only name, path, and baselineBrotliBytes`);
     }
-    if (artifact.baselineBrotliBytes !== 0) {
+    if (movedArtifact && (artifact.name !== movedArtifact.name ||
+        artifact.baselineBrotliBytes !== movedArtifact.baselineBrotliBytes)) {
+      violations.push(`Relocated runtime artifact ${path} must preserve its exact-base name and baseline`);
+    } else if (!movedArtifact && artifact.baselineBrotliBytes !== 0) {
       violations.push(`New runtime artifact ${path} baselineBrotliBytes must be 0`);
     }
   }
@@ -486,8 +555,15 @@ export function validateCandidateGrowthContract(
   const authorityGraphs = mapBy(authority.productionGraphs, 'subpath', 'Exact-base productionGraphs');
   const candidateGraphs = mapBy(candidate.productionGraphs, 'subpath', 'Candidate productionGraphs');
   violations.push(...authorityGraphs.violations, ...candidateGraphs.violations);
+  for (const [from, to] of relocation.graphMoves) {
+    if (!authorityGraphs.map.has(from) || candidateGraphs.map.has(from) ||
+        authorityGraphs.map.has(to) || !candidateGraphs.map.has(to)) {
+      violations.push(`Production graph relocation ${from} to ${to} must replace one exact-base graph`);
+    }
+  }
   for (const [subpath, graph] of authorityGraphs.map) {
-    if (!isDeepStrictEqual(candidateGraphs.map.get(subpath), graph)) {
+    if (!isDeepStrictEqual(candidateGraphs.map.get(subpath), graph) &&
+        !relocation.graphMoves.has(subpath)) {
       violations.push(`Candidate performance contract removes or changes exact-base production graph ${subpath}`);
     }
   }
@@ -495,6 +571,9 @@ export function validateCandidateGrowthContract(
     if (authorityGraphs.map.has(subpath)) {
       continue;
     }
+    const movedFrom = [...relocation.graphMoves]
+      .find(([, target]) => target === subpath)?.[0];
+    const movedGraph = movedFrom ? authorityGraphs.map.get(movedFrom) : null;
     if (!exactObjectFields(graph, [
       'baselineExternalImports',
       'baselineModules',
@@ -505,12 +584,19 @@ export function validateCandidateGrowthContract(
         !validArtifactPath(graph.output)) {
       violations.push(`New production graph ${subpath} has an invalid additive contract shape`);
     }
-    if (!Array.isArray(graph.baselineModules) || graph.baselineModules.length ||
-        !Array.isArray(graph.baselineExternalImports) || graph.baselineExternalImports.length) {
+    if (!Array.isArray(graph.baselineModules) || !Array.isArray(graph.baselineExternalImports) ||
+        (!movedGraph && (graph.baselineModules.length || graph.baselineExternalImports.length))) {
       violations.push(`New production graph ${subpath} Phase 0 module baselines must be empty`);
+    }
+    if (movedGraph &&
+        !isDeepStrictEqual(graph.baselineExternalImports, movedGraph.baselineExternalImports)) {
+      violations.push(`Relocated production graph ${subpath} must preserve its exact-base external-import baseline`);
     }
     if (!candidateArtifacts.map.has(graph.output)) {
       violations.push(`New production graph ${subpath} output must be a tracked runtime artifact`);
+    }
+    if (movedGraph && relocation.artifactMoves.get(movedGraph.output) !== graph.output) {
+      violations.push(`Relocated production graph ${subpath} must use the relocated exact-base output`);
     }
   }
 
@@ -613,16 +699,22 @@ function reportContractViolations(
   return violations;
 }
 
-export function newProductionReportDelta(baseReport, currentReport) {
+export function newProductionReportDelta(
+  baseReport,
+  currentReport,
+  { artifactMoves = new Map(), graphMoves = new Map() } = {},
+) {
   const baseArtifacts = artifactMap(baseReport, 'Exact-base');
   const currentArtifacts = artifactMap(currentReport, 'Pull request');
   const baseGraphs = graphMap(baseReport, 'Exact-base');
   const currentGraphs = graphMap(currentReport, 'Pull request');
-  const missingPaths = [...baseArtifacts.keys()].filter(path => !currentArtifacts.has(path)).sort();
+  const missingPaths = [...baseArtifacts.keys()]
+    .filter(path => !currentArtifacts.has(path) && !artifactMoves.has(path)).sort();
   if (missingPaths.length) {
     throw new Error(`Pull request report is missing exact-base artifacts: ${missingPaths.join(', ')}`);
   }
-  const missingSubpaths = [...baseGraphs.keys()].filter(subpath => !currentGraphs.has(subpath)).sort();
+  const missingSubpaths = [...baseGraphs.keys()]
+    .filter(subpath => !currentGraphs.has(subpath) && !graphMoves.has(subpath)).sort();
   if (missingSubpaths.length) {
     throw new Error(`Pull request report is missing exact-base production graphs: ${missingSubpaths.join(', ')}`);
   }
@@ -685,7 +777,8 @@ export function requiredNewProductionApproval({
   if (currentViolations.length) {
     throw new Error(currentViolations.join('; '));
   }
-  const delta = newProductionReportDelta(baseReport, currentReport);
+  const relocation = relocationTransition(authorityContract, effectiveContract);
+  const delta = newProductionReportDelta(baseReport, currentReport, relocation);
   if (delta.artifacts.length && !delta.subpaths.length) {
     throw new Error('A new runtime artifact cannot be adopted without a new production subpath');
   }
@@ -726,14 +819,19 @@ export function requiredNewProductionApproval({
   return { ...delta, enforced: true };
 }
 
-export function requiredArtifactGrowth(baseReport, currentReport, thresholdPercent) {
+export function requiredArtifactGrowth(
+  baseReport,
+  currentReport,
+  thresholdPercent,
+  { artifactMoves = new Map() } = {},
+) {
   if (!Number.isFinite(thresholdPercent) || thresholdPercent < 0) {
     throw new Error(`Growth approval threshold must be a non-negative number; received ${thresholdPercent}`);
   }
   const baseArtifacts = artifactMap(baseReport, 'Exact-base');
   const currentArtifacts = artifactMap(currentReport, 'Pull request');
   const missingPaths = [...baseArtifacts.keys()]
-    .filter(path => !currentArtifacts.has(path))
+    .filter(path => !currentArtifacts.has(path) && !artifactMoves.has(path))
     .sort();
   if (missingPaths.length) {
     throw new Error(`Pull request report is missing exact-base artifacts: ${missingPaths.join(', ')}`);
@@ -794,10 +892,13 @@ export function validateGrowthApproval({
     ));
   }
   try {
+    const relocation = authorityContract && candidateContract ?
+      relocationTransition(authorityContract, candidateContract) : undefined;
     required = requiredArtifactGrowth(
       baseReport,
       currentReport,
-      consumingBudget ? 0 : thresholdPercent
+      consumingBudget ? 0 : thresholdPercent,
+      relocation,
     );
     if (authorityContract) {
       if (candidateContract &&
@@ -847,6 +948,9 @@ export function validateGrowthApproval({
     status: 'required',
     thresholdPercent,
   };
+  if (candidateContract?.relocations) {
+    result.relocations = candidateContract.relocations;
+  }
   if (!/^[a-f\d]{40}$/.test(headSha || '')) {
     result.diagnostics.push(diagnostic(
       'GROWTH_APPROVAL_PULL_REQUEST_HEAD',

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -169,6 +169,36 @@ describe('performance contract validation', () => {
     assert.ok(violations.includes('Shipped runtime artifacts are untracked: dist/untracked.mjs'));
   });
 
+  test('tracks runtime artifacts and public graphs across separately published packages', () => {
+    const contract = contractFor([
+      'dist/index.mjs',
+      'packages/adapters/dist/backbone.js',
+    ]);
+    contract.productionGraphs.push({
+      subpath: '@marionette/adapters/backbone',
+      output: 'packages/adapters/dist/backbone.js',
+    });
+    const packageJson = {
+      name: 'marionette',
+      exports: { '.': { import: './dist/index.mjs' } },
+    };
+    const adaptersPackageJson = {
+      name: '@marionette/adapters',
+      exports: { './backbone': { import: './dist/backbone.js' } },
+    };
+
+    assert.deepEqual(validateContract(
+      contract,
+      packageJson,
+      ['dist/index.mjs', 'packages/adapters/dist/backbone.js'],
+      null,
+      [
+        { directory: '', packageJson },
+        { directory: 'packages/adapters', packageJson: adaptersPackageJson },
+      ],
+    ), []);
+  });
+
   test('surfaces malformed growth approval policy through contract validation', () => {
     const contract = contractFor();
     contract.pullRequestGrowthApproval.allowedLogins = ['zed', 'alpha'];
@@ -321,6 +351,95 @@ describe('performance contract validation', () => {
       assert.deepEqual(
         result.graphs.find(graph => graph.subpath === './feature').forbiddenExternalImports,
         []
+      );
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('discovers and measures a separately published adapters package', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-adapters-measurement-'));
+    const contract = contractFor([
+      'dist/index.mjs',
+      'packages/adapters/dist/feature.js',
+    ]);
+    contract.productionGraphs = [
+      {
+        subpath: '.',
+        input: 'index.js',
+        output: 'dist/index.mjs',
+        baselineModules: ['index.js'],
+        baselineExternalImports: [],
+      },
+      {
+        subpath: '@marionette/adapters/feature',
+        input: 'packages/adapters/src/feature.js',
+        output: 'packages/adapters/dist/feature.js',
+        baselineModules: ['packages/adapters/src/feature.js'],
+        baselineExternalImports: [],
+      },
+    ];
+
+    try {
+      await Promise.all([
+        mkdir(join(fixtureRoot, 'dist'), { recursive: true }),
+        mkdir(join(fixtureRoot, 'packages/adapters/dist'), { recursive: true }),
+        mkdir(join(fixtureRoot, 'packages/adapters/src'), { recursive: true }),
+      ]);
+      await Promise.all([
+        writeFile(join(fixtureRoot, 'package.json'), JSON.stringify({
+          name: 'marionette',
+          type: 'module',
+          exports: { '.': { import: './dist/index.mjs' } },
+        })),
+        writeFile(join(fixtureRoot, 'packages/adapters/package.json'), JSON.stringify({
+          name: '@marionette/adapters',
+          type: 'module',
+          exports: { './feature': { import: './dist/feature.js' } },
+        })),
+        writeFile(join(fixtureRoot, 'performance.json'), JSON.stringify(contract)),
+        writeFile(join(fixtureRoot, 'index.js'), 'export const root = true;\n'),
+        writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const root = true;\n'),
+        writeFile(
+          join(fixtureRoot, 'packages/adapters/src/feature.js'),
+          'export const feature = true;\n',
+        ),
+        writeFile(
+          join(fixtureRoot, 'packages/adapters/dist/feature.js'),
+          'export const feature = true;\n',
+        ),
+        writeFile(
+          join(fixtureRoot, 'rollup.config.mjs'),
+          'export default [{ input: \'index.js\', output: { file: \'dist/index.mjs\', format: \'es\' } }];\n',
+        ),
+        writeFile(
+          join(fixtureRoot, 'packages/adapters/rollup.config.mjs'),
+          'export default [{ input: \'src/feature.js\', output: { file: \'dist/feature.js\', format: \'es\' } }];\n',
+        ),
+      ]);
+
+      const result = await measure({
+        root: fixtureRoot,
+        configPath: join(fixtureRoot, 'performance.json'),
+        checkToolchain: false,
+      });
+      const repeated = await measure({
+        root: fixtureRoot,
+        configPath: join(fixtureRoot, 'performance.json'),
+        checkToolchain: false,
+      });
+      const adapterGraph = result.graphs.find(({ subpath }) =>
+        subpath === '@marionette/adapters/feature');
+      const repeatedAdapterGraph = repeated.graphs.find(({ subpath }) =>
+        subpath === '@marionette/adapters/feature');
+
+      assert.equal(adapterGraph.status, 'measured');
+      assert.equal(repeatedAdapterGraph.status, 'measured');
+      assert.deepEqual(adapterGraph.modules, ['packages/adapters/src/feature.js']);
+      assert.equal(
+        result.artifacts.find(({ path }) =>
+          path === 'packages/adapters/dist/feature.js').status,
+        'measured',
       );
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
@@ -511,6 +630,136 @@ describe('performance contract validation', () => {
     }
   });
 
+  test('derives report relocations from validated authority and candidate contracts', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-relocation-report-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const approvalReport = join(fixtureRoot, 'approval.json');
+    const authorityContractFile = join(fixtureRoot, 'authority-contract.json');
+    const candidateContractFile = join(fixtureRoot, 'candidate-contract.json');
+    const authorityContract = contractFor(['dist/main.js']);
+    authorityContract.runtimeArtifacts[0].name = 'Main';
+    authorityContract.runtimeArtifacts[0].baselineBrotliBytes = 100;
+    authorityContract.productionGraphs = [{
+      subpath: '.',
+      input: 'index.js',
+      output: 'dist/main.js',
+      baselineModules: ['index.js'],
+      baselineExternalImports: [],
+    }];
+    const candidateContract = structuredClone(authorityContract);
+    candidateContract.runtimeArtifacts = [{
+      name: 'Main',
+      path: 'packages/adapters/dist/main.js',
+      baselineBrotliBytes: 100,
+    }];
+    candidateContract.productionGraphs = [{
+      subpath: '@marionette/adapters/main',
+      input: 'packages/adapters/src/main.js',
+      output: 'packages/adapters/dist/main.js',
+      baselineModules: ['packages/adapters/src/main.js'],
+      baselineExternalImports: [],
+    }];
+    candidateContract.relocations = {
+      runtimeArtifacts: [{
+        from: 'dist/main.js',
+        to: 'packages/adapters/dist/main.js',
+      }],
+      productionGraphs: [{ from: '.', to: '@marionette/adapters/main' }],
+    };
+    const base = bundleReport(100);
+    base.artifacts[0].path = 'dist/main.js';
+    base.graphs = [{
+      subpath: '.',
+      status: 'measured',
+      modules: ['index.js'],
+      externalImports: [],
+    }];
+    const current = bundleReport(100);
+    current.artifacts[0].path = 'packages/adapters/dist/main.js';
+    current.artifacts[0].status = 'measured';
+    current.graphs = [{
+      subpath: '@marionette/adapters/main',
+      status: 'measured',
+      modules: ['packages/adapters/src/main.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    }];
+    const approval = newSubpathApproval();
+    approval.newSubpaths = ['@marionette/adapters/main'];
+    approval.newArtifacts = [{ path: 'packages/adapters/dist/main.js', size: 100 }];
+    approval.approval.approvedNewSubpaths = approval.newSubpaths;
+    approval.approval.approvedNewArtifacts = approval.newArtifacts;
+    approval.relocations = candidateContract.relocations;
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(base)),
+        writeFile(currentReport, JSON.stringify(current)),
+        writeFile(approvalReport, JSON.stringify(approval)),
+        writeFile(authorityContractFile, JSON.stringify(authorityContract)),
+        writeFile(candidateContractFile, JSON.stringify(candidateContract)),
+      ]);
+
+      const report = await createReport(
+        baseReport,
+        currentReport,
+        approvalReport,
+        authorityContractFile,
+        candidateContractFile,
+      );
+      assert.match(report, /New artifact \| Approved/);
+
+      const cli = spawnSync(process.execPath, [
+        join(root, 'scripts/performance/bundle-size.mjs'),
+        '--report', baseReport, currentReport,
+        '--growth-approval', approvalReport,
+        '--authority-contract', authorityContractFile,
+        '--candidate-contract', candidateContractFile,
+      ], { encoding: 'utf8' });
+      assert.equal(cli.status, 0);
+      assert.match(cli.stdout, /New artifact \| Approved/);
+
+      await assert.rejects(
+        createReport(baseReport, currentReport, approvalReport),
+        /requires authority and candidate contracts/,
+      );
+
+      approval.relocations.runtimeArtifacts[0].to = 'packages/adapters/dist/tampered.js';
+      await writeFile(approvalReport, JSON.stringify(approval));
+      await assert.rejects(
+        createReport(
+          baseReport,
+          currentReport,
+          approvalReport,
+          authorityContractFile,
+          candidateContractFile,
+        ),
+        /do not match the candidate contract/,
+      );
+
+      approval.relocations = candidateContract.relocations;
+      candidateContract.relocations.runtimeArtifacts[0].to = 'dist/main.js';
+      approval.relocations = candidateContract.relocations;
+      await Promise.all([
+        writeFile(approvalReport, JSON.stringify(approval)),
+        writeFile(candidateContractFile, JSON.stringify(candidateContract)),
+      ]);
+      await assert.rejects(
+        createReport(
+          baseReport,
+          currentReport,
+          approvalReport,
+          authorityContractFile,
+          candidateContractFile,
+        ),
+        /Relocation report contract is invalid/,
+      );
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   test('reports approval for a zero-byte new subpath aliasing an existing artifact', async() => {
     const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-new-subpath-alias-'));
     const baseReport = join(fixtureRoot, 'base.json');
@@ -679,6 +928,8 @@ describe('performance contract validation', () => {
       /^node "\$\{authority_script\}" --validate-resource-contract "\$\{base_contract\}" config\/performance\.json \|\| candidate_status=\$\?$/
     );
     assert.ok(commands[approvalIndex].includes('--candidate-contract config/performance.json'));
+    assert.match(authorityStep, /--authority-contract "\$\{base_contract\}"/);
+    assert.match(authorityStep, /--candidate-contract config\/performance\.json/);
     assert.ok(measurementIndex < approvalIndex);
     assert.ok(resourceValidationIndex < approvalIndex);
   });

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -135,6 +135,47 @@ function candidateAliasContract() {
   return contract;
 }
 
+function candidateRelocationContract() {
+  const contract = structuredClone(growthContract());
+  contract.runtimeArtifacts = [{
+    name: 'Main',
+    path: 'packages/adapters/dist/main.js',
+    baselineBrotliBytes: 100,
+  }];
+  contract.productionGraphs = [{
+    subpath: '@marionette/adapters/main',
+    input: 'packages/adapters/src/main.js',
+    output: 'packages/adapters/dist/main.js',
+    baselineModules: ['packages/adapters/src/main.js'],
+    baselineExternalImports: [],
+  }];
+  contract.relocations = {
+    runtimeArtifacts: [{ from: 'dist/main.js', to: 'packages/adapters/dist/main.js' }],
+    productionGraphs: [{ from: '.', to: '@marionette/adapters/main' }],
+  };
+  return contract;
+}
+
+function relocatedProductionReport() {
+  const current = productionReport();
+  current.artifacts = [{
+    name: 'Main',
+    path: 'packages/adapters/dist/main.js',
+    status: 'measured',
+    size: 100,
+  }];
+  current.graphs = [{
+    subpath: '@marionette/adapters/main',
+    input: 'packages/adapters/src/main.js',
+    output: 'packages/adapters/dist/main.js',
+    status: 'measured',
+    modules: ['packages/adapters/src/main.js'],
+    externalImports: [],
+    forbiddenModules: [],
+  }];
+  return current;
+}
+
 function timingContract(revision = authorityTimingRevision) {
   const contract = growthContract();
   contract.timing = {
@@ -329,6 +370,142 @@ describe('exact-head performance growth approval contract', () => {
       enforced: true,
       subpaths: ['./feature'],
     });
+  });
+
+  test('permits an explicit package relocation while requiring exact new-production approval', () => {
+    const authorityContract = growthContract();
+    const candidateContract = candidateRelocationContract();
+    const currentReport = relocatedProductionReport();
+
+    assert.deepEqual(validateCandidateGrowthContract(authorityContract, candidateContract), []);
+    assert.deepEqual(requiredNewProductionApproval({
+      authorityContract,
+      baseReport: productionReport(),
+      candidateContract,
+      currentReport,
+    }), {
+      artifacts: [{ path: 'packages/adapters/dist/main.js', size: 100 }],
+      enforced: true,
+      subpaths: ['@marionette/adapters/main'],
+    });
+
+    const renamed = structuredClone(candidateContract);
+    renamed.runtimeArtifacts[0].name = 'Replacement';
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, renamed).join('\n'),
+      /must preserve its exact-base name and baseline/,
+    );
+
+    const rewrittenExternalBaseline = structuredClone(candidateContract);
+    rewrittenExternalBaseline.productionGraphs[0].baselineExternalImports = ['jquery'];
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, rewrittenExternalBaseline).join('\n'),
+      /must preserve its exact-base external-import baseline/,
+    );
+
+    const missingTarget = structuredClone(candidateContract);
+    missingTarget.runtimeArtifacts = [];
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, missingTarget).join('\n'),
+      /must replace one exact-base artifact/,
+    );
+
+    const selfMove = structuredClone(candidateContract);
+    selfMove.relocations.runtimeArtifacts[0].to = 'dist/main.js';
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, selfMove).join('\n'),
+      /unique safe from\/to pairs/,
+    );
+
+    const duplicateTarget = structuredClone(candidateContract);
+    duplicateTarget.relocations.runtimeArtifacts.push({
+      from: 'dist/other.js',
+      to: 'packages/adapters/dist/main.js',
+    });
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, duplicateTarget).join('\n'),
+      /unique safe from\/to pairs/,
+    );
+
+    const unsorted = structuredClone(candidateContract);
+    unsorted.relocations.runtimeArtifacts = [
+      { from: 'dist/z.js', to: 'packages/adapters/dist/z.js' },
+      ...unsorted.relocations.runtimeArtifacts,
+    ];
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, unsorted).join('\n'),
+      /unique safe from\/to pairs/,
+    );
+
+    const extraneous = structuredClone(candidateContract);
+    extraneous.relocations.runtimeArtifacts.push({
+      from: 'dist/missing.js',
+      to: 'packages/adapters/dist/missing.js',
+    });
+    assert.match(
+      validateCandidateGrowthContract(authorityContract, extraneous).join('\n'),
+      /must replace one exact-base artifact/,
+    );
+
+    const collisionAuthority = structuredClone(authorityContract);
+    collisionAuthority.runtimeArtifacts.push({
+      name: 'Existing',
+      path: 'dist/existing.js',
+      baselineBrotliBytes: 0,
+    });
+    const collision = structuredClone(candidateContract);
+    collision.runtimeArtifacts = [collisionAuthority.runtimeArtifacts[1]];
+    collision.relocations.runtimeArtifacts[0].to = 'dist/existing.js';
+    assert.match(
+      validateCandidateGrowthContract(collisionAuthority, collision).join('\n'),
+      /must replace one exact-base artifact/,
+    );
+
+    const partialAuthority = structuredClone(authorityContract);
+    partialAuthority.runtimeArtifacts.push({
+      name: 'Other',
+      path: 'dist/other.js',
+      baselineBrotliBytes: 0,
+    });
+    assert.match(
+      validateCandidateGrowthContract(partialAuthority, candidateContract).join('\n'),
+      /removes or changes exact-base runtime artifact dist\/other\.js/,
+    );
+  });
+
+  test('does not change the approval output shape when no relocation is declared', () => {
+    const contract = growthContract();
+    const result = validateGrowthApproval({
+      authorityContract: contract,
+      baseReport: productionReport(),
+      candidateContract: structuredClone(contract),
+      comments: snapshot([]),
+      currentReport: productionReport(),
+      evidenceComments: evidenceSnapshot(),
+      headSha,
+      policy,
+      pullRequestNumber,
+      thresholdPercent: 1,
+    });
+
+    assert.equal(result.status, 'not-required');
+    assert.equal(Object.hasOwn(result, 'relocations'), false);
+  });
+
+  test('freezes merged relocation provenance in later candidate contracts', () => {
+    const authority = candidateRelocationContract();
+
+    assert.deepEqual(
+      validateCandidateGrowthContract(authority, structuredClone(authority)),
+      [],
+    );
+
+    const changed = structuredClone(authority);
+    changed.relocations.runtimeArtifacts[0].from = 'dist/other.js';
+    assert.match(
+      validateCandidateGrowthContract(authority, changed).join('\n'),
+      /changes exact-base relocations/,
+    );
   });
 
   test('requires approval when a new public subpath aliases an existing artifact at zero bytes', () => {


### PR DESCRIPTION
## Linked issue

- No linked issue; this is preparatory roadmap work for the adapter package extraction.

## What

- Discover and measure runtime artifacts and production graphs from the planned `@marionette/adapters` package alongside core.
- Add a canonical one-to-one relocation contract that preserves exact-base artifact and graph provenance.
- Revalidate relocation-bearing approval reports against exact-base and candidate contracts before rendering them.

## Agent-development failure addressed

- Exact-base performance checks previously treated a moved artifact as either a deletion or an unrelated new artifact, so the adapter extraction could not preserve measured provenance.
- The first implementation also allowed report rendering to consume relocation metadata without independently binding it to the candidate contract; this PR now fails closed on missing, invalid, or tampered contract evidence.

## Public behavior contract

- Canonical behavior after this PR: current exports and runtime behavior are unchanged; performance governance can verify an explicitly declared package relocation.
- Superseded behavior removed, if any: none for current consumers.
- Compatibility exception and removal condition, if any: none. Merged relocation records become immutable provenance.

## Runtime cost

- [ ] Static or documentation only
- [x] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: CI measured 0 B change for every current runtime artifact; aggregate remains 90,107 / 100,000 Brotli bytes.
- Startup/hot path: no production code changes; hosted timing remains reporting-only.
- Allocations/retention: deterministic resource comparison passed with no increase.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npm run test:performance  # 118 passed
npm run lint:ci           # passed
git diff --check          # passed
```

Coverage includes repeated temporary-package/Rollup measurement, malformed and conflicting relocation maps, uncovered removals, immutable merged provenance, tampered report metadata, and the exact report CLI arguments used by CI.

## Package and browser impact

- Entry points or install fixtures affected: no current entry point changes; the verifier can discover the future `packages/adapters` manifest and Rollup config.
- Browser contracts affected: none.
- Production/dev/test module-graph impact: performance tooling only; no production module graph changed.

## Rollback or deprecation

- This commit can be reverted before a dependent relocation lands. Once the adapter extraction uses the contract, its relocation record must remain as immutable provenance.

## Deployment Impact

- No deployment or package publication is required. This is repository CI governance only.

## Review notes

- Review feedback led to independent report-time contract validation, fail-closed relocation cases, preserved external-import baselines, copy-on-read Rollup configuration handling, and repeated-measurement coverage.