### PR TITLE
docs(rendering): document incremental renderer contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -471,11 +471,11 @@ current-evidence findings:
   Morphdom or Idiomorph, Lit, and a retained VDOM fixture should prove the category.
   The existing callable contract already supports incremental commits: Marionette
   invokes the renderer with the View as `this`, and a renderer that updates `this.el`
-  may return `undefined` to suppress `attachElContent()`. Before beta, document that
-  first-render/update contract explicitly. First test Morphdom's `isEqualNode`
-  subtree bailout and update the Lit experiment to use `className()` plus
-  `renderAttributes()`; those results determine whether any renderer capability is
-  actually missing.
+  may return `undefined` to suppress `attachElContent()`. The first-render/update
+  contract and Morphdom's `isEqualNode` subtree bailout are documented explicitly.
+  Before beta, measure that bailout and update the Lit experiment to use
+  `className()` plus `renderAttributes()`; those results determine whether any
+  renderer capability is actually missing.
   Autonomous component runtimes such as React, Vue, Svelte, Solid, and Preact own an
   exclusive hosted subtree inside a Marionette host View; Marionette does not coordinate
   their internal scheduling, lifecycle, refs, effects, or child ownership.

--- a/docs/view.rendering.md
+++ b/docs/view.rendering.md
@@ -149,7 +149,15 @@ to a separate library: https://github.com/marionettejs/marionette.templatecache 
 
 You can set the renderer for a view class by using the class method `setRenderer`.
 The renderer accepts two arguments. The first is the template passed to the view,
-and the second argument is the data to be rendered into the template.
+and the second argument is the data to be rendered into the template. Marionette
+invokes the renderer with the View as `this`, so use a regular function when the
+renderer needs access to the View instance.
+
+When the renderer returns anything other than `undefined`, Marionette passes it to
+[`attachElContent`](#customizing-attachelcontent). Returning `undefined` tells
+Marionette that the renderer committed the update itself, so
+`attachElContent` is not called. This supports renderers that retain bindings or
+patch the existing `view.el` without requiring a separate View API.
 
 Here's an example that allows for the `template` of a view to be an underscore template string.
 
@@ -201,13 +209,13 @@ for bundling tools such as [Browserify or Webpack](./installation.md).
 
 ### Rendering to HTML
 
-The default Marionette renders return the HTML as a string. This string is passed to the view's
-`attachElContents` method which in turn uses the DOM API's [`setContents`](./dom.api.md#setcontentsel-html).
+The default Marionette renderer returns the HTML as a string. This string is passed to the view's
+`attachElContent` method which in turn uses the DOM API's [`setContents`](./dom.api.md#setcontentsel-html)
 to set the contents of the view's `el` with DOM from the string.
 
-#### Customizing `attachElContents`
+#### Customizing `attachElContent`
 
-You can modify the way any particular view attaches a compiled template to the `el` by overriding `attachElContents`.
+You can modify the way any particular view attaches a compiled template to the `el` by overriding `attachElContent`.
 This method receives only the results of the view's renderer and is only called if the renderer returned a value.
 
 For instance, perhaps for one particular view you need to bypass the [DOM API](./dom.api.md) and set the html directly:
@@ -220,36 +228,45 @@ attachElContent(html) {
 
 ### Rendering to DOM
 
-Marionette also supports templates that render to DOM instead of html strings by using a custom render.
-
-In the following example the `template` method passed to the renderer will return a DOM element, and then
-if the view is already rendered utilize [morphdom](https://github.com/patrick-steele-idem/morphdom) to patch
-the DOM or otherwise it will set the view's `el` to the result of the template. (Note in this case the view's
-`el` created at instantiation would be overridden).
+Marionette also supports renderers that update DOM directly. The following
+example returns HTML for the first render, then uses
+[morphdom](https://github.com/patrick-steele-idem/morphdom) to patch the
+existing root on later renders. The equality check lets Morphdom skip unchanged
+subtrees.
 
 ```javascript
 import morphdom from 'morphdom';
 import { View } from 'marionette';
 
-const VDomView = View.extend();
+const MorphdomView = View.extend();
 
-VDomView.setRenderer(function(template, data) {
-  const el = template(data);
+MorphdomView.setRenderer(function(template, data) {
+  const html = template(data);
 
-  if (this.isRendered()) {
-    // Patch the view's el contents in the DOM
-    morphdom(this.el, el, { childrenOnly: true });
-    return;
+  if (!this.isRendered()) {
+    return html;
   }
 
-  this.setElement(el.cloneNode(true));
+  const nextEl = this.el.cloneNode();
+  nextEl.innerHTML = html;
+
+  morphdom(this.el, nextEl, {
+    childrenOnly: true,
+    onBeforeElUpdated(fromEl, toEl) {
+      return !fromEl.isEqualNode(toEl);
+    }
+  });
+
+  // The update is already committed, so skip attachElContent().
+  return undefined;
 });
 ```
 
-In this case because the renderer is modifying the `el` directly, there is no need to return the result
-of the template rendering for the view to handle in [`attachElContents`](#customizing-attachelcontents).
-It is certainly an option to return the compiled DOM and modify [`attachElContents`](#customizing-attachelcontents)
-to handle a DOM object instead of a string literal, but in many cases it may be overcomplicated to do so.
+The root element remains owned by the View. Other incremental renderers, such
+as Lit, can use the same contract: commit within `this.el` and return
+`undefined`. Root-level declarations remain separate; reevaluate a dynamic
+`className`, `id`, or `attributes` definition with
+[`renderAttributes()`](./marionette.view.md#refreshing-root-attributes).
 
 There are a variety of possibilities for rendering with Marionette. If you are looking into alternatives
 from the default this may be a useful resource: https://github.com/blikblum/marionette.renderers#renderers

--- a/test/unit/view.renderer.spec.js
+++ b/test/unit/view.renderer.spec.js
@@ -83,4 +83,25 @@ describe('View.setRenderer', function() {
       });
     });
   });
+
+  it('should invoke the renderer with the View and allow a direct DOM commit', function() {
+    let rendererContext;
+    const RendererView = View.extend({
+      template: _.constant('ignored')
+    });
+
+    RendererView.setRenderer(function(viewTemplate, renderedData) {
+      rendererContext = this;
+      this.el.textContent = `${ viewTemplate() }:${ renderedData.foo }`;
+    });
+
+    const view = new RendererView({ model });
+    const attachElContentSpy = this.sinon.spy(view, 'attachElContent');
+
+    view.render();
+
+    expect(rendererContext).to.equal(view);
+    expect(view.el.textContent).to.equal(`ignored:${ data.foo }`);
+    expect(attachElContentSpy).to.not.have.been.called;
+  });
 });


### PR DESCRIPTION
## Linked issue

- No linked issue. This completes the pre-beta renderer-contract documentation item in `ROADMAP.md`.

## What

- Document that custom renderers run with the View as `this` and may return `undefined` after committing directly to `view.el`.
- Update the Morphdom example to preserve the View root and skip identical subtrees with `isEqualNode`.
- Add an integration regression for renderer context and the direct-commit path.

## Why

The existing renderer already supports incremental DOM libraries, but the guide only implied the relevant contract. Making first-render versus update behavior explicit lets applications evaluate Morphdom, Lit, and similar optional renderers without adding a new core API before v5 beta.

## Agent-development failure addressed

- The prior guide described the renderer arguments but did not state its `this` binding or the exact `undefined` sentinel.
- Its Morphdom example replaced the View root on first render and traversed identical subtrees on updates.

## Public behavior contract

- Canonical behavior after this PR: a renderer receives `(template, data)` as a View method; any result other than `undefined` is passed to `attachElContent`, while `undefined` means the renderer already committed the update.
- Superseded behavior removed, if any: the stale root-replacing Morphdom example and pluralized `attachElContents` documentation are removed.
- Compatibility exception and removal condition, if any: none. Production behavior is unchanged.

## Runtime cost

- [x] Static or documentation only
- [ ] Development or test only; excluded from production entrypoints
- [ ] Changes an existing production path
- [ ] Adds an explicitly opt-in runtime path

Measured impact or explanation:

- Bundle: no production source or distribution changes.
- Startup/hot path: unchanged.
- Allocations/retention: unchanged.

## Scope

- Affects the View rendering guide, its roadmap status, and one View renderer integration test.
- Does not add a renderer argument, renderer package, Lit dependency, automatic attribute refresh, or production runtime behavior.
- Benchmark implementations and measurements remain outside this PR.

## Deployment Impact

- No runtime package or application redeploy is required.
- The documentation site will publish through the normal post-merge documentation workflow.

## Validation

- [x] Tests cover the acceptance criteria and relevant edge cases.
- [x] Docs, examples, declarations, diagnostics, and rule metadata agree where relevant.
- [x] No private consumer, private fixture, or undocumented context is required.
- [x] I ran the commands listed below and am reporting their actual results.

Commands:

```sh
npm run lint:ci
npm run coverage
npm run docs:check
npm run test:source
git diff --check
```

## Package and browser impact

- Entry points or install fixtures affected: none.
- Browser contracts affected: none; the existing renderer contract is newly explicit and regression-covered in JSDOM.
- Production/dev/test module-graph impact: production and development graphs are unchanged; one existing unit suite gains a test.

## Rollback or deprecation

- Revert this documentation/test commit. There is no runtime state or compatibility migration.

## Testing

- Full lint passed.
- 111 test files and 2,056 tests passed with 100% statements, branches, functions, and lines.
- All 19 agent benchmark contract tests passed.
- 23 executable documentation examples, 56 generated HTML files, and 503 internal links passed validation.
- Source validation and `git diff --check` passed.

## Review notes

- The example deliberately returns HTML on first render and directly patches on later renders.
- The `isEqualNode` bailout is documented for measurement; this PR does not claim benchmark improvement.
- Lit is identified only as a consumer of the existing contract, not as a core dependency or official package commitment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the renderer contract for incremental DOM libraries like `morphdom` and `Lit`. Production behavior is unchanged; previously the guide only implied the contract and its `morphdom` example replaced the View root on first render.

**Docs**
- Renderers run with the View as `this`; returning `undefined` skips `attachElContent` and signals a direct commit.
- Updated the `morphdom` example to preserve the View root and skip identical subtrees with `isEqualNode`.
- Marked the renderer-contract roadmap item as done.

**Testing**
- Added a regression test for renderer context and the direct-commit path.

<sup>Written for commit a4c3ec9499f4e277192ce8ea4cca63d4f82fdfde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

