### PR TITLE
perf(build): scope size ceiling to core package

### DIFF
--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -414,7 +414,9 @@ adds zero artifact bytes. Conversely, a new runtime artifact without a correspon
 new production subpath is invalid rather than independently approvable. Approval binds
 the complete additive artifact set from the same exact head; conditional artifacts such
 as CommonJS outputs need not each be the selected production-graph output, but every
-artifact is named at full size and charged against the cumulative ceiling.
+artifact is named at full size. Separately published package artifacts remain measured,
+reported, and bound to exact-head approval, but they do not consume the core Marionette
+runtime ceiling.
 
 The full lowercase head SHA prevents an approval from surviving a code change. The
 approved path list must exactly match all existing artifacts above the strict
@@ -438,8 +440,13 @@ existing artifact or graph. The only permitted toolchain transition is a valid S
 revision at `toolchain.releaseProfile.sha256`; every other toolchain field remains
 exact-base, and the candidate report must prove that digest matches the actual
 candidate release-profile file. New artifact Phase 0 baselines remain zero, so
-their full size counts against the original absolute ceiling; after adoption, the exact
-merged artifact becomes the comparison base for later pull requests. Unmeasured graphs,
+their full size is reported and requires exact-head approval; after adoption, the exact
+merged artifact becomes the comparison base for later pull requests. The absolute ceiling
+applies only to artifacts shipped from the root `marionette` package. `@marionette/data`,
+`@marionette/adapters`, and future separately published packages retain their own artifact
+measurements and package-specific reports without consuming that core ceiling. Historical
+evidence reports that predate the explicit core totals retain their original aggregate
+interpretation and remain immutable. Unmeasured graphs,
 forbidden modules, removed or renamed base entries, non-integer sizes, report-contract
 drift, and cumulative growth above the ceiling fail closed.
 

--- a/scripts/performance/budget-amendments.mjs
+++ b/scripts/performance/budget-amendments.mjs
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { dirname, resolve } from 'node:path';
 import { isDeepStrictEqual, promisify } from 'node:util';
+import { isCoreRuntimeArtifact } from './runtime-scope.mjs';
 
 const ledgerFields = ['entries', 'schemaVersion'];
 const amendmentFields = [
@@ -429,6 +430,7 @@ function measuredReport(report, contract, label, expectedCeiling) {
   const expectedGraphs = mapBy(contract.productionGraphs, 'subpath', `${label} expected graphs`);
   violations.push(...expectedArtifacts.violations, ...expectedGraphs.violations);
   let total = 0;
+  let coreTotal = 0;
   for (const artifact of report.artifacts) {
     if (typeof artifact?.path !== 'string' || artifacts.has(artifact.path) ||
         artifact.status !== 'measured' || !Number.isSafeInteger(artifact.size) || artifact.size < 0) {
@@ -440,6 +442,9 @@ function measuredReport(report, contract, label, expectedCeiling) {
       violations.push(`${label} measured artifact total exceeds the safe integer range`);
     } else {
       total += artifact.size;
+      if (isCoreRuntimeArtifact(artifact.path)) {
+        coreTotal += artifact.size;
+      }
     }
     if (expectedArtifacts.map.get(artifact.path)?.name !== artifact.name) {
       violations.push(`${label} artifact ${artifact.path} does not match its contract name`);
@@ -455,8 +460,23 @@ function measuredReport(report, contract, label, expectedCeiling) {
   if (report?.cumulative?.size !== total) {
     violations.push(`${label} cumulative size does not equal all measured artifacts`);
   }
-  const expectedViolations = total > expectedCeiling ? [
-    `Cumulative Brotli-${contract.baseline.brotliQuality} size ${total} exceeds the absolute ceiling ${expectedCeiling}`,
+  const hasCoreSize = Object.hasOwn(report?.cumulative || {}, 'coreSize');
+  const hasCoreBaselineSize = Object.hasOwn(report?.cumulative || {}, 'coreBaselineSize');
+  const expectedCoreBaselineSize = [...expectedArtifacts.map.entries()]
+    .filter(([path]) => isCoreRuntimeArtifact(path))
+    .reduce((sum, [, artifact]) => sum + artifact.baselineBrotliBytes, 0);
+  if (hasCoreSize !== hasCoreBaselineSize) {
+    violations.push(`${label} core cumulative fields must either both be present or both be absent`);
+  } else if (hasCoreSize &&
+      (report.cumulative.coreSize !== coreTotal ||
+        report.cumulative.coreBaselineSize !== expectedCoreBaselineSize)) {
+    violations.push(`${label} core cumulative fields do not match the measured core artifact set`);
+  }
+  const budgetedTotal = hasCoreSize ? coreTotal : total;
+  const expectedViolations = budgetedTotal > expectedCeiling ? [
+    hasCoreSize ?
+      `Core package Brotli-${contract.baseline.brotliQuality} size ${budgetedTotal} exceeds the absolute ceiling ${expectedCeiling}` :
+      `Cumulative Brotli-${contract.baseline.brotliQuality} size ${budgetedTotal} exceeds the absolute ceiling ${expectedCeiling}`,
   ] : [];
   if (!isDeepStrictEqual(report?.violations, expectedViolations)) {
     violations.push(`${label} violations do not match its measured cumulative result`);
@@ -483,7 +503,7 @@ function measuredReport(report, contract, label, expectedCeiling) {
   if (missingGraphs.length || extraGraphs.length) {
     violations.push(`${label} graph set mismatch; missing: ${missingGraphs.join(', ') || 'none'}; extra: ${extraGraphs.join(', ') || 'none'}`);
   }
-  return { artifacts, subpaths, total, violations };
+  return { artifacts, subpaths, total: budgetedTotal, violations };
 }
 
 function measuredDelta(

--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -25,6 +25,7 @@ import {
   parseBudgetAmendmentLedger,
   validateBudgetAmendmentLedger,
 } from './budget-amendments.mjs';
+import { isCoreRuntimeArtifact } from './runtime-scope.mjs';
 
 const compress = promisify(brotliCompress);
 const consumerScenarioIds = [
@@ -254,7 +255,7 @@ export function validateCumulativeSize(contract, totalSize) {
     return [];
   }
 
-  return [`Cumulative Brotli-${contract.baseline.brotliQuality} size ${totalSize} exceeds the absolute ceiling ${contract.baseline.absoluteCeilingBytes}`];
+  return [`Core package Brotli-${contract.baseline.brotliQuality} size ${totalSize} exceeds the absolute ceiling ${contract.baseline.absoluteCeilingBytes}`];
 }
 
 export function findForbiddenModules(modules, contract) {
@@ -783,7 +784,13 @@ export async function measure({
     return measureArtifact(resolvedRoot, quality, artifact);
   }));
   const totalSize = artifacts.reduce((total, artifact) => total + (artifact.size || 0), 0);
-  violations.push(...validateCumulativeSize(contract, totalSize));
+  const coreSize = artifacts
+    .filter(artifact => isCoreRuntimeArtifact(artifact.path))
+    .reduce((total, artifact) => total + (artifact.size || 0), 0);
+  const coreBaselineSize = contract.runtimeArtifacts
+    .filter(artifact => isCoreRuntimeArtifact(artifact.path))
+    .reduce((total, artifact) => total + artifact.baselineBrotliBytes, 0);
+  violations.push(...validateCumulativeSize(contract, coreSize));
 
   let configurations;
   try {
@@ -891,6 +898,8 @@ export async function measure({
     cumulative: {
       size: totalSize,
       baselineSize: contract.baseline.totalBrotliBytes,
+      coreSize,
+      coreBaselineSize,
       absoluteCeiling: contract.baseline.absoluteCeilingBytes,
     },
     graphs,
@@ -1337,8 +1346,16 @@ async function buildReport(
         'Approved' : 'Required';
     return `| \`${graph.subpath}\` | ${moduleCount} | ${graph.externalImports.join(', ') || 'None'} | ${change} | ${approval} |`;
   });
-  const cumulativeGrowth = formatChange(base.cumulative.size, current.cumulative.size);
-  const phase0Growth = formatChange(current.cumulative.baselineSize, current.cumulative.size);
+  const hasCoreTotals = [base.cumulative, current.cumulative].every(cumulative =>
+    Object.hasOwn(cumulative, 'coreSize') &&
+    Object.hasOwn(cumulative, 'coreBaselineSize'));
+  const baseCoreSize = hasCoreTotals ? base.cumulative.coreSize : base.cumulative.size;
+  const currentCoreSize = hasCoreTotals ?
+    current.cumulative.coreSize : current.cumulative.size;
+  const coreBaselineSize = hasCoreTotals ?
+    current.cumulative.coreBaselineSize : current.cumulative.baselineSize;
+  const cumulativeGrowth = formatChange(baseCoreSize, currentCoreSize);
+  const phase0Growth = formatChange(coreBaselineSize, currentCoreSize);
   const resourceComparison = compareResourceReports(base, current);
   const consumerComparison = compareConsumerBundleReports(
     base.consumerBundles,
@@ -1382,7 +1399,9 @@ async function buildReport(
     '| --- | ---: | ---: | ---: | --- |',
     ...rows,
     '',
-    `Cumulative Brotli-${current.brotliQuality}: **${formatBytes(current.cumulative.size)}** / ${formatBytes(current.cumulative.absoluteCeiling)} authority-contract ceiling (${cumulativeGrowth} from PR base; ${phase0Growth} from Phase 0).`,
+    hasCoreTotals ?
+      `Core package Brotli-${current.brotliQuality}: **${formatBytes(currentCoreSize)}** / ${formatBytes(current.cumulative.absoluteCeiling)} authority-contract ceiling (${cumulativeGrowth} from PR base; ${phase0Growth} from Phase 0). Optional package artifacts are measured above but do not consume this ceiling.` :
+      `Cumulative Brotli-${current.brotliQuality}: **${formatBytes(currentCoreSize)}** / ${formatBytes(current.cumulative.absoluteCeiling)} authority-contract ceiling (${cumulativeGrowth} from PR base; ${phase0Growth} from Phase 0). Historical comparison uses aggregate scope because the base report has no core totals.`,
     '',
     '| Production subpath | Internal modules | External imports | PR graph change | Approval |',
     '| --- | ---: | --- | --- | --- |',
@@ -1424,7 +1443,7 @@ function writeMeasurement(result, json) {
   for (const artifact of result.artifacts) {
     console.log(`${artifact.name}: ${formatBytes(artifact.size)} (${formatChange(artifact.baselineSize, artifact.size)} from Phase 0)`);
   }
-  console.log(`Cumulative: ${formatBytes(result.cumulative.size)} / ${formatBytes(result.cumulative.absoluteCeiling)}`);
+  console.log(`Core package cumulative: ${formatBytes(result.cumulative.coreSize)} / ${formatBytes(result.cumulative.absoluteCeiling)}`);
   for (const graph of result.graphs) {
     console.log(`${graph.subpath}: ${graph.status === 'measured' ? `${graph.modules.length} internal modules, ${graph.externalImports.length} external imports` : graph.error}`);
   }

--- a/scripts/performance/growth-approval.mjs
+++ b/scripts/performance/growth-approval.mjs
@@ -9,6 +9,7 @@ import {
   evaluateBudgetAmendmentFromCheckouts,
   validateBudgetAmendmentScope,
 } from './budget-amendments.mjs';
+import { isCoreRuntimeArtifact } from './runtime-scope.mjs';
 
 const marker = '<!-- marionette-performance-growth-approval:v1 -->';
 const requiredRecordFields = ['approvedPaths', 'evidenceUrls', 'headSha', 'issueUrl', 'schemaVersion'];
@@ -657,6 +658,7 @@ function reportContractViolations(
     violations.push(`${label} report artifact set mismatch; missing: ${missingArtifacts.join(', ') || 'none'}; extra: ${extraArtifacts.join(', ') || 'none'}`);
   }
   let artifactTotal = 0;
+  let coreArtifactTotal = 0;
   for (const [path, artifact] of reportArtifacts) {
     const expected = expectedArtifacts.map.get(path);
     if (artifact.status !== 'measured' || !Number.isInteger(artifact.size) || artifact.size < 0) {
@@ -664,6 +666,9 @@ function reportContractViolations(
       continue;
     }
     artifactTotal += artifact.size;
+    if (isCoreRuntimeArtifact(path)) {
+      coreArtifactTotal += artifact.size;
+    }
     if (expected && artifact.name !== expected.name) {
       violations.push(`${label} runtime artifact ${path} name does not match its contract`);
     }
@@ -671,8 +676,24 @@ function reportContractViolations(
   if (!Number.isInteger(report?.cumulative?.size) || report.cumulative.size !== artifactTotal) {
     violations.push(`${label} cumulative size does not equal the complete measured artifact set`);
   }
-  if (artifactTotal > expectedCeiling) {
-    violations.push(`${label} cumulative size ${artifactTotal} exceeds the ${ceilingAuthority} cumulative ceiling ${expectedCeiling}`);
+  const hasCoreSize = Object.hasOwn(report?.cumulative || {}, 'coreSize');
+  const hasCoreBaselineSize = Object.hasOwn(report?.cumulative || {}, 'coreBaselineSize');
+  const expectedCoreBaselineSize = [...expectedArtifacts.map.entries()]
+    .filter(([path]) => isCoreRuntimeArtifact(path))
+    .reduce((total, [, artifact]) => total + artifact.baselineBrotliBytes, 0);
+  if (hasCoreSize !== hasCoreBaselineSize) {
+    violations.push(`${label} core cumulative fields must either both be present or both be absent`);
+  } else if (hasCoreSize &&
+      (!Number.isInteger(report.cumulative.coreSize) ||
+        report.cumulative.coreSize !== coreArtifactTotal ||
+        !Number.isInteger(report.cumulative.coreBaselineSize) ||
+        report.cumulative.coreBaselineSize !== expectedCoreBaselineSize)) {
+    violations.push(`${label} core cumulative fields do not match the measured core artifact set`);
+  }
+  const budgetedTotal = hasCoreSize ? coreArtifactTotal : artifactTotal;
+  if (budgetedTotal > expectedCeiling) {
+    const scope = hasCoreSize ? 'core package ' : '';
+    violations.push(`${label} ${scope}cumulative size ${budgetedTotal} exceeds the ${ceilingAuthority} cumulative ceiling ${expectedCeiling}`);
   }
 
   const missingGraphs = [...expectedGraphs.map.keys()]

--- a/scripts/performance/runtime-scope.mjs
+++ b/scripts/performance/runtime-scope.mjs
@@ -1,0 +1,3 @@
+export function isCoreRuntimeArtifact(path) {
+  return typeof path === 'string' && !path.startsWith('packages/');
+}

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -427,6 +427,86 @@ describe('two-stage performance budget amendments', () => {
     assert.equal(result.requiresExactHeadGrowthApproval, false);
   });
 
+  test('evaluates amendments against core bytes while retaining package measurements', () => {
+    const scopedContract = contract();
+    scopedContract.runtimeArtifacts.push({
+      name: 'Adapter',
+      path: 'packages/adapters/dist/adapter.js',
+      baselineBrotliBytes: 0,
+    });
+    scopedContract.productionGraphs.push({
+      subpath: '@marionette/adapters/adapter',
+      input: 'packages/adapters/src/adapter.js',
+      output: 'packages/adapters/dist/adapter.js',
+      baselineModules: [],
+      baselineExternalImports: [],
+    });
+    const scopedReport = (coreSize, violations = []) => ({
+      ...measuredReport(coreSize),
+      artifacts: [
+        { name: 'Main', path: 'dist/marionette.js', status: 'measured', size: coreSize },
+        {
+          name: 'Adapter',
+          path: 'packages/adapters/dist/adapter.js',
+          status: 'measured',
+          size: 10000,
+        },
+      ],
+      cumulative: {
+        size: coreSize + 10000,
+        baselineSize: 49500,
+        coreSize,
+        coreBaselineSize: 49500,
+        absoluteCeiling: initialCeiling,
+      },
+      graphs: [
+        ...measuredReport(coreSize).graphs,
+        {
+          subpath: '@marionette/adapters/adapter',
+          input: 'packages/adapters/src/adapter.js',
+          output: 'packages/adapters/dist/adapter.js',
+          status: 'measured',
+          modules: ['packages/adapters/src/adapter.js'],
+          externalImports: [],
+          forbiddenModules: [],
+        },
+      ],
+      violations,
+    });
+    const base = scopedReport(51000);
+    const prototype = scopedReport(52000, [
+      `Core package Brotli-11 size 52000 exceeds the absolute ceiling ${initialCeiling}`,
+    ]);
+    const record = amendment();
+    const result = transition({
+      authorityContract: scopedContract,
+      candidateContract: structuredClone(scopedContract),
+      candidateLedger: ledger([record]),
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        'docs/performance-baselines.md',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      evidence: {
+        [baseReportPath]: {
+          schemaVersion: 1,
+          revision: record.prototypeBaseCommit,
+          report: base,
+        },
+        [reportPath]: {
+          schemaVersion: 1,
+          revision: record.prototypeCommit,
+          report: prototype,
+        },
+        [prototypeContractPath]: scopedContract,
+      },
+    });
+
+    assert.equal(result.status, 'accepted', result.diagnostics.join('\n'));
+  });
+
   test('accepts later consumption only from a merged pending authority record', () => {
     const record = amendment();
     const result = transition({

--- a/test/performance/contract.test.mjs
+++ b/test/performance/contract.test.mjs
@@ -363,6 +363,10 @@ describe('performance contract validation', () => {
       'dist/index.mjs',
       'packages/adapters/dist/feature.js',
     ]);
+    contract.runtimeArtifacts[0].baselineBrotliBytes = 100;
+    contract.runtimeArtifacts[1].baselineBrotliBytes = 0;
+    contract.baseline.totalBrotliBytes = 100;
+    contract.baseline.absoluteCeilingBytes = 100;
     contract.productionGraphs = [
       {
         subpath: '.',
@@ -402,11 +406,13 @@ describe('performance contract validation', () => {
         writeFile(join(fixtureRoot, 'dist/index.mjs'), 'export const root = true;\n'),
         writeFile(
           join(fixtureRoot, 'packages/adapters/src/feature.js'),
-          'export const feature = true;\n',
+          `export const feature = '${Array.from({ length: 256 }, (_, index) =>
+            index.toString(36).padStart(2, '0')).join('-')}';\n`,
         ),
         writeFile(
           join(fixtureRoot, 'packages/adapters/dist/feature.js'),
-          'export const feature = true;\n',
+          `export const feature = '${Array.from({ length: 256 }, (_, index) =>
+            index.toString(36).padStart(2, '0')).join('-')}';\n`,
         ),
         writeFile(
           join(fixtureRoot, 'rollup.config.mjs'),
@@ -441,6 +447,11 @@ describe('performance contract validation', () => {
           path === 'packages/adapters/dist/feature.js').status,
         'measured',
       );
+      assert.ok(result.cumulative.size > result.cumulative.absoluteCeiling);
+      assert.ok(result.cumulative.coreSize <= result.cumulative.absoluteCeiling);
+      assert.equal(result.cumulative.coreBaselineSize, 100);
+      assert.equal(result.violations.some(violation =>
+        violation.includes('exceeds the absolute ceiling')), false);
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }
@@ -553,6 +564,30 @@ describe('performance contract validation', () => {
       const identical = await createReport(baseReport, baseReport);
       assert.match(identical, /\| Main .* \| Not required \|/);
       assert.match(identical, /Status: \*\*Not required\*\*\./);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('uses aggregate scope on both sides when the base report has no core totals', async() => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-performance-report-scope-'));
+    const baseReport = join(fixtureRoot, 'base.json');
+    const currentReport = join(fixtureRoot, 'current.json');
+    const base = bundleReport(100);
+    const current = bundleReport(110);
+    current.cumulative.coreSize = 100;
+    current.cumulative.coreBaselineSize = 90;
+
+    try {
+      await Promise.all([
+        writeFile(baseReport, JSON.stringify(base)),
+        writeFile(currentReport, JSON.stringify(current)),
+      ]);
+
+      const result = await createReport(baseReport, currentReport);
+      assert.match(result, /Cumulative Brotli-11: \*\*110 B\*\*.*\+10 B \(\+10\.00%\)/);
+      assert.match(result, /Historical comparison uses aggregate scope/);
+      assert.doesNotMatch(result, /Core package Brotli-11/);
     } finally {
       await rm(fixtureRoot, { recursive: true, force: true });
     }
@@ -1352,7 +1387,7 @@ describe('performance contract validation', () => {
 
     assert.deepEqual(validateCumulativeSize(contract, 10), []);
     assert.deepEqual(validateCumulativeSize(contract, 11), [
-      'Cumulative Brotli-11 size 11 exceeds the absolute ceiling 10'
+      'Core package Brotli-11 size 11 exceeds the absolute ceiling 10'
     ]);
   });
 

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -544,6 +544,55 @@ describe('exact-head performance growth approval contract', () => {
     assert.deepEqual(result.newSubpaths, ['./feature']);
   });
 
+  test('keeps optional package additions outside the core cumulative ceiling', () => {
+    const candidateContract = structuredClone(growthContract());
+    candidateContract.runtimeArtifacts.push({
+      name: 'Adapter feature',
+      path: 'packages/adapters/dist/feature.js',
+      baselineBrotliBytes: 0,
+    });
+    candidateContract.productionGraphs.push({
+      subpath: '@marionette/adapters/feature',
+      input: 'packages/adapters/src/feature.js',
+      output: 'packages/adapters/dist/feature.js',
+      baselineModules: [],
+      baselineExternalImports: [],
+    });
+    const currentReport = productionReport();
+    currentReport.artifacts.push({
+      name: 'Adapter feature',
+      path: 'packages/adapters/dist/feature.js',
+      status: 'measured',
+      size: 10,
+    });
+    currentReport.cumulative = {
+      ...currentReport.cumulative,
+      size: 110,
+      coreSize: 100,
+      coreBaselineSize: 100,
+    };
+    currentReport.graphs.push({
+      subpath: '@marionette/adapters/feature',
+      input: 'packages/adapters/src/feature.js',
+      output: 'packages/adapters/dist/feature.js',
+      status: 'measured',
+      modules: ['packages/adapters/src/feature.js'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+
+    assert.deepEqual(requiredNewProductionApproval({
+      authorityContract: growthContract(),
+      baseReport: productionReport(),
+      candidateContract,
+      currentReport,
+    }), {
+      artifacts: [{ path: 'packages/adapters/dist/feature.js', size: 10 }],
+      enforced: true,
+      subpaths: ['@marionette/adapters/feature'],
+    });
+  });
+
   test('blocks new production additions until candidate-contract activation', () => {
     const currentReport = productionReport({ includeFeature: true });
     currentReport.violations = [


### PR DESCRIPTION
Related #127

## What

- Record both all-artifact and core-package Brotli totals in bundle-size reports.
- Enforce the 100 KB ceiling against only the root `marionette` package while continuing to measure optional package artifacts and require exact-head approval for new artifacts and subpaths.
- Preserve the original aggregate interpretation for immutable historical reports that predate explicit core totals.

## Why

Separately published packages have independent installation and size decisions. Charging their bytes against the core Marionette runtime ceiling conflates those decisions and would require increasing the core budget to add an optional adapter.

## Scope

This changes performance reporting, growth approval validation, budget-amendment report validation, and the performance policy documentation. It does not change runtime code, package exports, the configured ceiling, the amendment ledger, or package-specific size reports.

## Deployment Impact

No deployment or package release is required beyond the normal repository workflow. No runtime artifact changes.

## Testing

- `npm run test:performance` — 123 tests passed.
- `npm test -- --reporter=dot` — 2,081 tests passed across 112 files.
- `npm run lint:ci`
- `npm run docs:check` — 55 pages built; 504 internal links validated.
- `npm run test:source`
- `npm run check:release-promotion`
- `npm run size` — core package measured at 89.06 KB / 100.00 KB; separate data and adapters reports passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Core runtime bundle budgets now apply only to artifacts shipped from the main package.
  * Separately published package artifacts retain independent measurements and reports without consuming the core runtime ceiling.
  * Performance reports and approval checks now distinguish core totals from optional package totals.
  * Historical aggregate performance evidence remains unchanged and valid.
* **Tests**
  * Added coverage confirming optional package artifacts are measured and approved separately from core runtime limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the 100 KB Brotli size ceiling to the core `marionette` package so separately published packages no longer consume the core runtime budget. Previously the ceiling applied to the aggregate of all artifacts, which would force a core budget increase to add an optional adapter (#127).

- `@marionette/data`, `@marionette/adapters`, and future optional packages remain measured, reported, and subject to exact-head approval, but no longer count against the core ceiling.
- Reports now record `coreSize` and `coreBaselineSize`; historical reports without these fields retain their original aggregate interpretation.

<sup>Written for commit a7c3af6b174d6a258214d21b9a104ed9a00e4003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

