### PR TITLE
fix(events): preserve registry during multi-event dispatch

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -76,6 +76,13 @@ emitter.trigger({
 });
 ```
 
+During a multi-name or mapped `trigger` call, calling `off()` from a handler
+removes subscriptions for subsequent calls but does not cancel the remaining
+event names in the current call. For example, `off()` inside a `start` handler
+still allows the existing `stop` handlers in `trigger('start stop')` to run.
+Calling `off('stop', handler)` inside `start` instead removes that handler before
+`stop` is dispatched. A nested `trigger` call uses the current subscriptions.
+
 `once` registers its generated callback through the object's overridable
 `on` method, and `listenToOnce` registers through overridable `listenTo`.
 This preserves the extension points used by event-lifecycle mixins. Likewise,

--- a/mixins/events.js
+++ b/mixins/events.js
@@ -286,14 +286,15 @@ const Events = {
   // (unless you're listening on `"all"`, which will cause your callback to
   // receive the true name of the event as the first argument).
   trigger(name, ...args) {
-    if (!this._rdEvents) { return this; }
+    const events = this._rdEvents;
+    if (!events) { return this; }
 
     if (name && typeof name === 'object') {
       const names = getKeys(name);
       for (let index = 0, length = names.length; index < length; index++) {
         const key = names[index];
         triggerApi({
-          events: this._rdEvents,
+          events,
           name: key,
           args: [name[key]],
         });
@@ -306,7 +307,7 @@ const Events = {
       for (let index = 0, length = names.length; index < length; index++) {
         const n = names[index];
         triggerApi({
-          events: this._rdEvents,
+          events,
           name: n,
           args,
         });
@@ -315,7 +316,7 @@ const Events = {
     }
 
     triggerApi({
-      events: this._rdEvents,
+      events,
       name,
       args,
     });

--- a/test/unit/events-parity.spec.js
+++ b/test/unit/events-parity.spec.js
@@ -51,6 +51,87 @@ describe('Events parity with Backbone.Events', function() {
     });
   });
 
+  const dispatchChanges = [
+    ['clears all handlers', emitter => emitter.off()],
+    ['removes the next event', emitter => emitter.off('beta')],
+    ['adds a handler to the next event', (emitter, calls) => {
+      emitter.on('beta', () => calls.push('added'));
+    }],
+    ['replaces the event registry', (emitter, calls) => {
+      emitter.off();
+      emitter.on('beta', () => calls.push('replacement'));
+    }],
+  ];
+
+  for (const [name, change] of dispatchChanges) {
+    it(`preserves multi-event dispatch when a handler ${name}`, function() {
+      expectParity(emitter => {
+        const calls = [];
+        emitter.on('alpha', () => {
+          calls.push('alpha');
+          change(emitter, calls);
+        });
+        emitter.on('beta', () => calls.push('beta'));
+
+        emitter.trigger('alpha beta');
+        emitter.trigger('beta');
+
+        return calls;
+      });
+    });
+  }
+
+  it('preserves once-map dispatch when the first handler clears all events', function() {
+    expectParity(emitter => {
+      const calls = [];
+      emitter.once({
+        alpha() {
+          calls.push('alpha');
+          emitter.off();
+        },
+        beta() { calls.push('beta'); },
+      });
+
+      emitter.trigger('alpha beta');
+      emitter.trigger('alpha beta');
+
+      return calls;
+    });
+  });
+
+  it('uses a replacement registry for nested dispatch without changing the outer dispatch', function() {
+    expectParity(emitter => {
+      const calls = [];
+      emitter.once('alpha', () => {
+        calls.push('alpha');
+        emitter.off();
+        emitter.on('beta', value => calls.push(['replacement', value]));
+        emitter.trigger('beta', 'nested');
+      });
+      emitter.on('beta', value => calls.push(['original', value]));
+
+      emitter.trigger('alpha beta', 'outer');
+      emitter.trigger('beta', 'later');
+
+      return calls;
+    });
+  });
+
+  it('keeps mapped trigger values when the first handler clears all events', function() {
+    const emitter = createEmitter(EventsMixin);
+    const calls = [];
+    emitter.on('alpha', value => {
+      calls.push(['alpha', value]);
+      emitter.off();
+    });
+    emitter.on('beta', value => calls.push(['beta', value]));
+
+    emitter.trigger({ alpha: 1, beta: 2 });
+    emitter.trigger('beta', 3);
+
+    expect(calls).to.deep.equal([['alpha', 1], ['beta', 2]]);
+  });
+
   it('removes a once handler before a reentrant trigger', function() {
     // Backbone once wrappers remove themselves before invoking the callback:
     // https://github.com/jashkenas/backbone/blob/1.4.0/backbone.js#L270-L299


### PR DESCRIPTION
## What

- Keep the current event registry for the duration of a multi-name or mapped `trigger` call.
- Cover clearing, removing, adding, and replacing subscriptions during dispatch, including once handlers and mapped values.
- Explain the effect of wholesale versus targeted removal during a multi-event call.

## Why

When an `alpha` handler calls `off()`, `trigger('alpha beta')` currently rereads an undefined registry and throws before dispatching `beta`. Capturing the existing registry reference restores supported Backbone-compatible dispatch behavior. Changes within that registry still take effect; a replacement registry is used by subsequent trigger calls. This is a longstanding mismatch, not claimed as a regression introduced this week.

## Scope

Only `mixins/events.js`, its public parity tests, and the events guide. One local reference replaces repeated property reads; there is no registry copy, allocation, additional guard, or new lifecycle-cancellation promise. Generated distributions are built and checked but are not committed.

## Deployment Impact

Library change only. No forms or app-frontend bundles need redeployment. Consumers receive the fix through a future package adoption; this PR publishes no package release.

## Testing

- On current master, the initial six added cases produce four failures and two passing controls. A subsequent nested-dispatch regression also passes with the fix.
- `npm test -- --reporter=dot test/unit/events-parity.spec.js test/unit/events-iteration.spec.js test/unit/mixins/events.spec.js test/unit/requests.spec.js test/unit/radio.spec.js test/unit/radio-composition.spec.js test/unit/mixins/radio.spec.js test/unit/common/bind-events.spec.js`: 163 tests pass in eight files.
- `npm run prepare`, `npm run test:source`, `node scripts/performance/bundle-size.mjs --json`, targeted ESLint and `git diff --check` pass.
- Full suite, browser/package checks and exact-base performance comparison run in CI.

Independent Claude review found no blocker. Added its nested-dispatch coverage suggestion; verified registry replacement directly. Mapped-value assertions follow Marionette's existing documented extension rather than incorrectly demanding Backbone parity.

`npm run docs:check` passes after the documentation follow-up (55 pages and 505 internal links).
