### PR TITLE
fix(collection-view): accept concise child view factories

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -363,7 +363,7 @@ const FooView = View.extend({
 });
 
 const BarView = View.extend({
-  bar
+  template: _.template('bar')
 });
 
 const MyCollectionView = CollectionView.extend({

--- a/modules/common/view.js
+++ b/modules/common/view.js
@@ -4,7 +4,7 @@ export function isView(view) {
 }
 
 export function isViewClass(ViewClass) {
-  return ViewClass.prototype.render && (ViewClass.prototype.destroy || ViewClass.prototype.remove);
+  return ViewClass.prototype?.render && (ViewClass.prototype.destroy || ViewClass.prototype.remove);
 }
 
 export function renderView(view) {

--- a/test/unit/collection-view/collection-view.spec.js
+++ b/test/unit/collection-view/collection-view.spec.js
@@ -201,6 +201,44 @@ describe('CollectionView', function() {
       });
     });
 
+    it('resolves a concise childView method for each model', function() {
+      const ChildList = CollectionView.extend({
+        childView(child) {
+          expect(this.collection).to.equal(collection);
+          expect(child).to.equal(model);
+          return MyChildView;
+        }
+      });
+      const view = new ChildList({ collection }).render();
+
+      expect(view.children.first()).to.be.instanceOf(MyChildView);
+      view.destroy();
+    });
+
+    it('resolves an arrow childView factory', function() {
+      const view = new CollectionView({
+        collection,
+        childView: child => child === model ? MyChildView : MyBbChildView
+      }).render();
+
+      expect(view.children.first()).to.be.instanceOf(MyChildView);
+      view.destroy();
+    });
+
+    it('resolves a native class childView method', function() {
+      class ChildList extends CollectionView {
+        childView(child) {
+          expect(this.collection).to.equal(collection);
+          expect(child).to.equal(model);
+          return MyChildView;
+        }
+      }
+      const view = new ChildList({ collection }).render();
+
+      expect(view.children.first()).to.be.instanceOf(MyChildView);
+      view.destroy();
+    });
+
     describe('when childView is not a valid view', function() {
       it('should throw InvalidChildViewError', function() {
         const myCollectionView = new CollectionView({


### PR DESCRIPTION
## What

- Accept concise methods, arrow functions, and native class methods as `CollectionView.childView` factories.
- Add three public rendering regressions and fix the invalid `BarView` documentation example.

## Why

A documented factory can be written as `childView(model) { return RowView; }`, but these functions have no `prototype`. The constructor check currently dereferences that missing property and throws before invoking the factory. Checking for a prototype's render method allows the existing factory path to run.

## Scope

The shared view-class check and CollectionView factory coverage/documentation. Existing view constructors and factory invocation/context behavior are preserved. `emptyView` keeps its separate existing class predicate. No new API or lifecycle guard is introduced.

## Deployment Impact

No forms or application bundles need redeployment for this library-source change. Consumers receive the fix when they choose a future package version; no package publication is part of this PR.

## Runtime cost

The existing constructor check gains one nullish property check per view-class resolution. It adds no allocation, retained state, imports, or module-graph entries. Against the exact base build, Brotli changes are +7 B ESM, +5 B CJS, +3 B UMD and +6 B minified UMD; optional artifacts are unchanged. All size and graph checks pass. Timing will be reported by CI; no local timing result is claimed.

## Testing

- Before the fix: all three new factory cases throw `Cannot read properties of undefined (reading 'render')`; 44 existing cases pass.
- Independent public runtime probe — 12 constructor/factory cases pass, including bound factories and corresponding empty-view controls.
- `npm run prepare` — build and distribution validation pass.
- `npm test -- --reporter=dot test/unit/collection-view test/unit/utils/is-view-class.spec.js` — 394 tests in 10 files pass.
- `npm test -- --reporter=dot test/unit/common/view.spec.js` — 23 shared view-helper tests pass.
- `npm run lint:ci` and `npm run test:source` pass.
- `npm run docs:check` — executable examples and 55-page documentation build pass; 505 internal links validated.
- `node scripts/performance/bundle-size.mjs --json` and exact-base report comparison pass.

CI owns the fresh full coverage, browser, package-consumer, and timing runs. The root package entrypoints, public exports, diagnostics, and optional-package declarations are unchanged. Reverting this focused change would restore the factory syntax defect.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `CollectionView` so concise methods, arrow functions, and native class methods work as `childView` factories. These factory forms previously threw `Cannot read properties of undefined (reading 'render')` because the shared class check dereferenced `prototype` on functions that lack it; optional chaining now lets the existing factory path run.

- The shared `isViewClass` check gains one nullish property check; `emptyView` keeps its separate predicate.
- The `BarView` docs example now defines a valid `template`.

<sup>Written for commit 3e589e061a2eec34c2b53456fe9618dfa266c5ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved view validation so missing prototypes no longer cause errors.
  - Confirmed support for defining collection child views using concise methods, arrow functions, and native class methods.

- **Documentation**
  - Corrected the collection view example to properly render the intended text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->