### PR TITLE
fix(app): release ownership after failed construction

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -38,6 +38,14 @@ import { Application } from 'marionette';
 const myApplication = new Application({ ... });
 ```
 
+If construction throws, Marionette attempts to release its State and Radio
+resources, its coordinated root View, and any Region it constructed. A borrowed
+Region and any unrelated replacement View remain owned by their caller.
+Child Applications registered during the failed construction are unregistered
+without being stopped or destroyed; their lifetime returns to the caller.
+Cleanup preserves the original construction error and does not undo other
+side effects of `initialize`.
+
 ## Application Lifecycle
 
 `start`, `stop`, `restart`, and `destroy` return a `Promise<boolean>`. The

--- a/src/modules/application.js
+++ b/src/modules/application.js
@@ -45,13 +45,18 @@ const Application = function(options) {
     this._initStateEvents();
   } catch (error) {
     const ownedRegion = this._ownedRegion;
-    delete this._region;
-    delete this._ownedRegion;
     disposeAll([
       () => this.stopListening(),
+      () => {
+        delete this._region;
+        delete this._ownedRegion;
+      },
       () => ownedRegion?.destroy(),
+      () => clearRootView(this),
+      () => emptyRootView(this),
       () => this._destroyRadio(),
-      () => this._destroyState()
+      () => this._destroyState(),
+      () => this._childApps?.forEach((child, name) => removeChildAppReference(this, name, child))
     ], error);
   }
 };

--- a/src/modules/application.js
+++ b/src/modules/application.js
@@ -53,9 +53,9 @@ const Application = function(options) {
       },
       () => ownedRegion?.destroy(),
       () => clearRootView(this),
-      () => emptyRootView(this),
       () => this._destroyRadio(),
       () => this._destroyState(),
+      () => emptyRootView(this),
       () => this._childApps?.forEach((child, name) => removeChildAppReference(this, name, child))
     ], error);
   }

--- a/test/unit/application-ownership.spec.js
+++ b/test/unit/application-ownership.spec.js
@@ -416,4 +416,39 @@ describe('Application ownership', function() {
     expect(third.isDestroyed()).to.be.true;
     expect(events).to.deep.equal(['first', 'second', 'third']);
   });
+  it('returns registered child instances to the caller when construction fails', async function() {
+    const failure = new Error('owner initialization failed');
+    const first = new Application();
+    const second = new Application();
+    await first.start();
+    const firstDestroy = this.sinon.spy(first, 'destroy');
+    const secondDestroy = this.sinon.spy(second, 'destroy');
+    let failedOwner;
+    const Owner = Application.extend({
+      initialize() {
+        failedOwner = this;
+        this.addChildApp('first', first);
+        this.addChildApp('second', second);
+        throw failure;
+      }
+    });
+    const nextOwner = new Application();
+
+    try {
+      expect(() => new Owner()).to.throw(failure);
+      expect(failedOwner.getChildApps()).to.deep.equal({});
+      expect(first.getName()).to.be.undefined;
+      expect(second.getName()).to.be.undefined;
+      expect(first.isRunning()).to.be.true;
+      expect(second.isRunning()).to.be.false;
+      expect(firstDestroy).not.to.have.been.called;
+      expect(secondDestroy).not.to.have.been.called;
+      expect(nextOwner.addChildApp('first', first)).to.equal(first);
+      expect(nextOwner.addChildApp('second', second)).to.equal(second);
+    } finally {
+      await failedOwner.destroy();
+      await nextOwner.destroy();
+    }
+  });
+
 });

--- a/test/unit/application-root-view.spec.js
+++ b/test/unit/application-root-view.spec.js
@@ -394,6 +394,55 @@ describe('Application root View ownership', function() {
     }
   });
 
+  it('keeps Application State and Radio available during failed-constructor root cleanup', function() {
+    const region = new Region({ el: '#application-root' });
+    const failure = new Error('owner initialization failed');
+    const state = { disposed: false };
+    const selection = { id: 42 };
+    const events = [];
+    let failedOwner;
+    const root = new (RootView.extend({
+      onBeforeDestroy() {
+        events.push({
+          event: 'root:destroy',
+          stateDisposed: failedOwner.getState().disposed,
+          selection: failedOwner.getChannel().request('selection')
+        });
+      }
+    }))();
+    const Owner = Application.extend({
+      channelName: 'constructor-root-cleanup',
+      radioRequests: { selection() { return selection; } },
+      createState() { return state; },
+      initialize() {
+        failedOwner = this;
+        this.getState();
+        this.showView(root);
+        throw failure;
+      }
+    });
+    Owner.setStateApi({
+      disposeOwned(source) {
+        source.disposed = true;
+        events.push({ event: 'state:dispose' });
+      }
+    });
+
+    try {
+      expect(() => new Owner({ region })).to.throw(failure);
+      expect(events).to.deep.equal([
+        { event: 'root:destroy', stateDisposed: false, selection },
+        { event: 'state:dispose' }
+      ]);
+      expect(root.isDestroyed()).to.be.true;
+      expect(state.disposed).to.be.true;
+      expect(failedOwner.getChannel().request('selection')).to.be.undefined;
+      expect(region.isDestroyed()).to.be.false;
+    } finally {
+      region.destroy();
+    }
+  });
+
   it('preserves an external replacement in a borrowed Region when construction fails', function() {
     const region = new Region({ el: '#application-root' });
     const root = new RootView();

--- a/test/unit/application-root-view.spec.js
+++ b/test/unit/application-root-view.spec.js
@@ -369,4 +369,91 @@ describe('Application root View ownership', function() {
     expect(app.isDestroyed()).to.be.true;
     expect(app.getView()).to.be.undefined;
   });
+  it('releases a coordinated root from a borrowed Region when construction fails', function() {
+    const region = new Region({ el: '#application-root' });
+    const root = new RootView();
+    const failure = new Error('owner initialization failed');
+    let failedOwner;
+    const Owner = Application.extend({
+      initialize() {
+        failedOwner = this;
+        this.showView(root);
+        throw failure;
+      }
+    });
+
+    try {
+      expect(() => new Owner({ region })).to.throw(failure);
+      expect(root.isDestroyed()).to.be.true;
+      expect(region.hasView()).to.be.false;
+      expect(region.isDestroyed()).to.be.false;
+      expect(failedOwner.getRegion()).to.be.undefined;
+      expect(failedOwner.getView()).to.be.undefined;
+    } finally {
+      region.destroy();
+    }
+  });
+
+  it('preserves an external replacement in a borrowed Region when construction fails', function() {
+    const region = new Region({ el: '#application-root' });
+    const root = new RootView();
+    const replacement = new RootView();
+    const failure = new Error('owner initialization failed');
+    const Owner = Application.extend({
+      initialize() {
+        this.showView(root);
+        region.show(replacement);
+        throw failure;
+      }
+    });
+
+    try {
+      expect(() => new Owner({ region })).to.throw(failure);
+      expect(root.isDestroyed()).to.be.true;
+      expect(region.currentView).to.equal(replacement);
+      expect(replacement.isDestroyed()).to.be.false;
+      expect(region.isDestroyed()).to.be.false;
+    } finally {
+      region.destroy();
+    }
+  });
+
+  it('preserves the constructor error and releases host observation when root cleanup fails', async function() {
+    const failure = new Error('owner initialization failed');
+    const cleanupFailure = new Error('root cleanup failed');
+    const child = new Application();
+    const region = new Region({ el: '#application-root' });
+    let failCleanup = true;
+    let failedOwner;
+    const root = new (RootView.extend({
+      onBeforeDestroy() {
+        if (failCleanup) { throw cleanupFailure; }
+      }
+    }))();
+    const Owner = Application.extend({
+      initialize() {
+        failedOwner = this;
+        this.addChildApp('child', child);
+        this.showView(root);
+        throw failure;
+      }
+    });
+    const empty = this.sinon.spy(Owner.prototype, '_onRootRegionEmpty');
+
+    try {
+      expect(() => new Owner({ region })).to.throw(failure);
+      expect(failedOwner.getRegion()).to.be.undefined;
+      expect(child.getName()).to.be.undefined;
+      expect(child.isDestroyed()).to.be.false;
+      failCleanup = false;
+      region.empty();
+      expect(empty).not.to.have.been.called;
+    } finally {
+      failCleanup = false;
+      region.destroy();
+      await failedOwner.destroy();
+      await child.destroy();
+    }
+  });
+
 });


### PR DESCRIPTION
Related #190
Related #375

## What

- Release a failed Application's coordinated root View and host observation before discarding its Region references.
- Unregister child Applications when construction throws, returning those instances to the caller without starting, stopping, or destroying them.
- Document the rollback boundary and cover borrowed Regions, replacement Views, and cleanup failures.

## Why

If `initialize()` calls `showView(root)` or `addChildApp(name, child)` and then throws, the caller never receives the Application. The old rollback leaves its root mounted in a borrowed Region and its children registered to that failed owner. It can also leave direct host observation behind. Failed setup now releases those ownership relationships while preserving the original exception.

## Scope

Application constructor rollback only. A borrowed Region and any unrelated replacement View remain with their caller; a Region constructed by the Application is destroyed. Cleanup uses the existing reverse-order, attempt-all helper and preserves the original construction error even when root cleanup throws. Root teardown runs before releasing still-available State and Radio resources so View cleanup can use them; resources already released by a failing subscription setup are not restored. This does not undo arbitrary user side effects or introduce asynchronous constructor cleanup. Normal lifecycle operations, exports, diagnostics, and package declarations are unchanged.

## Runtime cost

Only the construction-error path changes: four cleanup callbacks are added to its existing temporary array, with one traversal of registered children. Successful construction and render/event hot paths gain no work or retained fields. Exact-base Brotli changes: +17 B ESM, +36 B CJS, +30 B UMD, +15 B minified UMD. Optional artifacts and the production module graph are unchanged; size checks pass. No local timing claim is made for this error-only path.

## Deployment Impact

No forms or application bundles need redeployment for this library-source PR. Consumers receive the fix when they adopt a future library package; package publication is not part of this change.

## Testing

- Current-master regression run: 3 failures and 42 passing controls across the two ownership/root-View suites before the implementation change.
- `npm test -- --reporter=dot test/unit/application-ownership.spec.js test/unit/application-root-view.spec.js test/unit/application-state.spec.js test/unit/application.spec.js test/unit/object-application-composition.spec.js` — 63 tests pass.
- `npm run coverage` at the initial PR revision — 2,124 runtime tests plus 19 contract tests pass; configured statement, branch, function, and line coverage is 100%.
- The cleanup-order regression fails before the follow-up; all 143 tests across seven Application suites pass after it. The follow-up also passes build, focused lint, and diff checks.
- `npm run prepare`, `npm run lint:ci`, `npm run test:source`, and `npm run docs:check` pass.
- `node scripts/performance/bundle-size.mjs --json` and comparison with the exact base's equivalent relocation build pass.

Independent public probes additionally checked a replacement installed during State disposal, original-error identity, borrowed-host survival, and running children reused by a new owner. All initial-revision CI checks passed, including browser and package consumers; CI reruns for the cleanup-order follow-up. Reverting the PR restores the failed-construction ownership leaks.
