### PR TITLE
fix(app): complete adopted child stop lifecycles

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -95,6 +95,10 @@ resolves `false` even when a handler ignores it. When a start, restart, or
 destroy operation adopts an in-flight stop phase, it also adopts that phase's
 original options and context, and does not abort its signal.
 
+If a replacement start has already canceled the remaining child stops, that
+stop phase is no longer adopted. A later `stop()`, `restart()`, or `destroy()`
+begins a fresh stop phase with its own options and context.
+
 The context belongs to the readiness phase rather than to one caller's Promise.
 Completion methods and events receive only `(application, options)`.
 

--- a/src/modules/application.js
+++ b/src/modules/application.js
@@ -161,15 +161,29 @@ async function startChildApps(application, operation, options) {
   return true;
 }
 
+function canStopChildren(application, operation) {
+  if (isCurrentOperation(application, operation)) { return true; }
+
+  // A replacement stop, restart, or destroy continues the adopted stop phase.
+  const current = application._lifecycleOperation;
+  return current?.stopReadiness !== undefined && current.stopReadiness === operation.stopReadiness &&
+    current.kind !== 'start';
+}
+
+function cancelStopReadiness(operation) {
+  operation.stopReadiness.isCanceled = true;
+  return false;
+}
+
 async function stopChildApps(application, operation, options) {
   if (!application._childApps) { return true; }
 
   for (const child of application._childApps.values()) {
-    if (!isCurrentOperation(application, operation)) { return false; }
+    if (!canStopChildren(application, operation)) { return cancelStopReadiness(operation); }
     const stopped = await child.stop(options);
-    if (!isCurrentOperation(application, operation)) { return false; }
+    if (!canStopChildren(application, operation)) { return cancelStopReadiness(operation); }
     if (stopped && hasStableLifecycleState(child, STOPPED)) { continue; }
-    if (!isTerminal(application)) { return false; }
+    if (!isTerminal(application)) { return cancelStopReadiness(operation); }
     await child.destroy(options);
   }
 
@@ -301,7 +315,8 @@ function runOperation(application, operation, callback) {
 function beginOperation(application, kind, state, failureState, callback) {
   const superseded = supersedeOperation(application);
   const deferred = createDeferred();
-  const stopReadiness = superseded?.stopReadiness;
+  // A canceled child traversal cannot be continued by a later operation.
+  const stopReadiness = superseded?.stopReadiness?.isCanceled ? undefined : superseded?.stopReadiness;
 
   const operation = {
     ...deferred,
@@ -327,11 +342,11 @@ function beginOperation(application, kind, state, failureState, callback) {
 async function startApplication(application, operation, options) {
   if (operation.stopReadiness) {
     const readiness = operation.stopReadiness;
-    await readiness.promise;
+    const childrenStopped = await readiness.promise;
     if (!isCurrentOperation(application, operation)) { return; }
 
     completeReadiness(operation);
-    operation.failureState = STOPPED;
+    if (childrenStopped) { operation.failureState = STOPPED; }
     delete operation.stopReadiness;
   }
 

--- a/test/unit/application-child-lifecycle.spec.js
+++ b/test/unit/application-child-lifecycle.spec.js
@@ -259,6 +259,126 @@ describe('Application child lifecycle', function() {
     await owner.destroy();
   });
 
+  ['stop', 'restart', 'destroy'].forEach(method => {
+    it(`begins a new stop phase when ${method} replaces a start after child stops were canceled`, async function() {
+      const readiness = Promise.withResolvers();
+      const childStopping = Promise.withResolvers();
+      const events = [];
+      const firstOptions = { source: 'first' };
+      const latestOptions = { source: 'latest' };
+      const ChildApplication = Application.extend({
+        onBeforeStop() {
+          if (this.getName() === 'first') {
+            childStopping.resolve();
+            return readiness.promise;
+          }
+        },
+        onStop() { events.push(`${this.getName()}:stop`); }
+      });
+      const OwnerApplication = Application.extend({
+        onBeforeStop(application, options) { events.push(options); },
+        onStop() { events.push('owner:stop'); }
+      });
+      const owner = new OwnerApplication();
+      const first = owner.addChildApp('first', new ChildApplication());
+      const second = owner.addChildApp('second', new ChildApplication());
+      await owner.start();
+
+      const earlierStop = owner.stop(firstOptions);
+      await childStopping.promise;
+      const start = owner.start();
+      const childStop = first.stop();
+      readiness.resolve();
+      await childStop;
+      const latest = owner[method](latestOptions);
+
+      expect(await Promise.all([earlierStop, start, latest])).to.deep.equal([false, false, true]);
+      expect(events).to.deep.equal([firstOptions, 'first:stop', latestOptions, 'second:stop', 'owner:stop']);
+      expect(owner.isRunning()).to.equal(method === 'restart');
+      expect(first.isRunning()).to.equal(method === 'restart');
+      expect(second.isRunning()).to.equal(method === 'restart');
+      expect(owner.isDestroyed()).to.equal(method === 'destroy');
+      expect(first.isDestroyed()).to.equal(method === 'destroy');
+      expect(second.isDestroyed()).to.equal(method === 'destroy');
+
+      await owner.destroy();
+    });
+  });
+
+  ['owner', 'child'].forEach(failAt => {
+    it(`retains the prior owner state when ${failAt} startup fails after canceled child stops`, async function() {
+      const readiness = Promise.withResolvers();
+      const childStopping = Promise.withResolvers();
+      const failure = new Error('replacement startup failed');
+      const events = [];
+      let shouldFail = false;
+      const ChildApplication = Application.extend({
+        onBeforeStart() {
+          if (shouldFail && failAt === 'child' && this.getName() === 'first') { throw failure; }
+        },
+        onBeforeStop() {
+          if (this.getName() === 'first') {
+            childStopping.resolve();
+            return readiness.promise;
+          }
+        },
+        onStop() { events.push(`${this.getName()}:stop`); }
+      });
+      const OwnerApplication = Application.extend({
+        onBeforeStart() {
+          if (shouldFail && failAt === 'owner') { throw failure; }
+        },
+        onStop() { events.push('owner:stop'); }
+      });
+      const owner = new OwnerApplication();
+      const first = owner.addChildApp('first', new ChildApplication());
+      const second = owner.addChildApp('second', new ChildApplication());
+      await owner.start();
+
+      const stop = owner.stop();
+      await childStopping.promise;
+      shouldFail = true;
+      const start = expectRejection(owner.start(), failure);
+      readiness.resolve();
+
+      expect(await stop).to.be.false;
+      await start;
+      expect(owner.isRunning()).to.be.true;
+      expect(first.isRunning()).to.be.false;
+      expect(second.isRunning()).to.be.true;
+      expect(events).to.deep.equal(['first:stop']);
+
+      expect(await owner.stop()).to.be.true;
+      expect(owner.isRunning()).to.be.false;
+      expect(second.isRunning()).to.be.false;
+      expect(events).to.deep.equal(['first:stop', 'second:stop', 'owner:stop']);
+      await owner.destroy();
+    });
+  });
+
+  it('retains stopped state when startup fails after inherited stop readiness completes', async function() {
+    const readiness = Promise.withResolvers();
+    const failure = new Error('replacement startup failed');
+    let shouldFail = false;
+    const owner = new (Application.extend({
+      onBeforeStop() { return readiness.promise; },
+      onBeforeStart() {
+        if (shouldFail) { throw failure; }
+      }
+    }))();
+    await owner.start();
+
+    const stop = owner.stop();
+    shouldFail = true;
+    const start = expectRejection(owner.start(), failure);
+    readiness.resolve();
+
+    expect(await stop).to.be.false;
+    await start;
+    expect(owner.isRunning()).to.be.false;
+    await owner.destroy();
+  });
+
   it('cancels owner stop when child onStop directly starts', async function() {
     let childStart;
     let shouldRestart = false;
@@ -555,4 +675,118 @@ describe('Application child lifecycle', function() {
       'owner:destroy'
     ]);
   });
+  for (const pendingAt of ['owner', 'child']) {
+    for (const [earlier, later] of [['restart', 'stop'], ['stop', 'restart'], ['stop', 'destroy']]) {
+      it(`lets ${ later } adopt ${ earlier } while ${ pendingAt } stop readiness is pending`, async function() {
+        const stopping = Promise.withResolvers();
+        const entered = Promise.withResolvers();
+        const firstOptions = { source: 'first' };
+        const laterOptions = { source: 'later' };
+        const stopped = [];
+        const stopOptions = [];
+        let childrenStoppedBeforeDestroy;
+        const Owner = Application.extend({
+          onBeforeStop() {
+            if (pendingAt === 'owner') {
+              entered.resolve();
+              return stopping.promise;
+            }
+          },
+          onStop(app, options) {
+            stopped.push('owner');
+            stopOptions.push(options);
+          },
+          onBeforeDestroy() {
+            childrenStoppedBeforeDestroy = Object.values(this.getChildApps())
+              .every(child => !child.isRunning() && !child.isDestroyed());
+          }
+        });
+        const Child = Application.extend({
+          onBeforeStop() {
+            if (pendingAt === 'child' && this.getName() === 'first') {
+              entered.resolve();
+              return stopping.promise;
+            }
+          },
+          onStop(app, options) {
+            stopped.push(this.getName());
+            stopOptions.push(options);
+          }
+        });
+        const owner = new Owner();
+        const first = owner.addChildApp('first', new Child());
+        const second = owner.addChildApp('second', new Child());
+        await owner.start();
+
+        const previous = owner[earlier](firstOptions);
+        await entered.promise;
+        const current = owner[later](laterOptions);
+        const followingStop = [];
+        if (later === 'destroy') {
+          owner.stop().then(value => followingStop.push(value));
+        }
+        stopping.resolve();
+        const results = await Promise.all([previous, current]);
+        const outcome = {
+          results,
+          running: [owner, first, second].map(app => app.isRunning()),
+          destroyed: [owner, first, second].map(app => app.isDestroyed()),
+          stopped: [...stopped],
+          originalStopOptions: stopOptions.every(options => options === firstOptions),
+          followingStop,
+          childrenStoppedBeforeDestroy
+        };
+        await owner.destroy();
+
+        expect(outcome).to.deep.equal({
+          results: [false, true],
+          running: [later === 'restart', later === 'restart', later === 'restart'],
+          destroyed: [later === 'destroy', later === 'destroy', later === 'destroy'],
+          stopped: ['first', 'second', 'owner'],
+          originalStopOptions: true,
+          followingStop: later === 'destroy' ? [true] : [],
+          childrenStoppedBeforeDestroy: later === 'destroy' ? true : undefined
+        });
+      });
+    }
+  }
+
+  for (const later of ['stop', 'restart', 'destroy']) {
+    it(`preserves a stopped child prefix when adopted ${ later } readiness rejects`, async function() {
+      const stopping = Promise.withResolvers();
+      const entered = Promise.withResolvers();
+      const error = new Error('second child could not stop');
+      const stopped = [];
+      let attempts = 0;
+      const Child = Application.extend({
+        onBeforeStop() {
+          if (this.getName() === 'second' && !attempts++) {
+            entered.resolve();
+            return stopping.promise;
+          }
+        },
+        onStop() { stopped.push(this.getName()); }
+      });
+      const owner = new Application();
+      const children = ['first', 'second', 'third'].map(name => owner.addChildApp(name, new Child()));
+      await owner.start();
+
+      const previous = later === 'stop' ? owner.restart() : owner.stop();
+      await entered.promise;
+      const current = expectRejection(owner[later](), error);
+      const followingStop = later === 'destroy' ? expectRejection(owner.stop(), error) : undefined;
+      stopping.reject(error);
+      expect(await previous).to.be.false;
+      await current;
+      await followingStop;
+
+      expect(owner.isRunning()).to.be.true;
+      expect(children.map(child => child.isRunning())).to.deep.equal([false, true, true]);
+      expect(stopped).to.deep.equal(['first']);
+      expect(await owner.stop()).to.be.true;
+      expect(stopped).to.deep.equal(['first', 'second', 'third']);
+      await owner.destroy();
+    });
+  }
+
 });

--- a/test/unit/application-child-lifecycle.spec.js
+++ b/test/unit/application-child-lifecycle.spec.js
@@ -721,14 +721,14 @@ describe('Application child lifecycle', function() {
         const previous = owner[earlier](firstOptions);
         await entered.promise;
         const current = owner[later](laterOptions);
-        const followingStop = [];
+        const operations = [previous, current];
         if (later === 'destroy') {
-          owner.stop().then(value => followingStop.push(value));
+          operations.push(owner.stop());
         }
         stopping.resolve();
-        const results = await Promise.all([previous, current]);
+        const [previousResult, currentResult, ...followingStop] = await Promise.all(operations);
         const outcome = {
-          results,
+          results: [previousResult, currentResult],
           running: [owner, first, second].map(app => app.isRunning()),
           destroyed: [owner, first, second].map(app => app.isDestroyed()),
           stopped: [...stopped],


### PR DESCRIPTION
Related #190
Related #131

## What
- Continue pending child stops when another stop, restart, or destroy adopts the owner's stop phase.
- Begin a fresh stop phase if an intervening start already canceled the child traversal.
- Preserve the owner's prior stable state when replacement startup fails after canceled child stops, so a later stop still visits remaining children.

## Why
Previously, replacing an owner operation while a child stop was pending could cancel the winning operation and leave later children running. A failed replacement start could also incorrectly mark the owner stopped, causing a subsequent stop to skip those children. The fixes preserve sequential teardown and retry behavior while retaining adopted options and readiness signals.

## Scope
Application lifecycle source, focused child lifecycle regressions, and stop-phase adoption documentation. Constructor rollback, typing, generated distributions, and other source changes are excluded.

## Runtime Cost
The existing two ownership checks around each awaited child stop now recognize a live phase adopted by the current operation. Each remains a constant-time identity/kind check. Beginning a lifecycle operation adds one canceled-phase check; the cancellation marker is written only when traversal cancels. Child iteration remains sequential and linear, with no additional child snapshots or rendering work.

Fresh builds of master `6ef1a625` and implementation head `e2234de5`, compressed with Brotli quality 11. The test-only follow-up `b9175653` leaves runtime source unchanged:

| Artifact | Master | Candidate | Change |
| --- | ---: | ---: | ---: |
| ESM | 23,697 B | 23,778 B | +81 B |
| CommonJS | 23,803 B | 23,878 B | +75 B |
| UMD | 24,153 B | 24,211 B | +58 B |
| Minified UMD | 17,850 B | 17,927 B | +77 B |
| Core cumulative | 89,503 B | 89,794 B | +291 B |

## Deployment Impact
No deployment or package publication occurs in this PR. Consumers receive the fixes through a future library release.

## Testing
- Before implementation: the focused child lifecycle suite reproduced 11 failures with 24 passing controls on fresh master `6ef1a625`.
- At `e2234de5`, `vitest run` across the seven Application/composition suites: 158 passed, including live adoption, cancellation, original options, readiness signals, failure recovery, and completed-stop controls.
- After the test-only review follow-up `b9175653`: all 35 child-lifecycle tests and focused lint passed.
- On implementation head `e2234de5`: `npm run build`, `npm run lint:ci`, `npm run test:source`, and `npm run test:dist`.
- `npm run docs:build` and `node scripts/docs/check-links.mjs`: 55 documentation pages built; 56 HTML files and 505 internal links validated.
- `node scripts/performance/bundle-size.mjs` passed on the refreshed head; optional-package size checks passed before the base refresh (those packages are unchanged); core cumulative size 89,794 B within the 100,000 B budget.
