### PR TITLE
perf(collection-view): read source order once per sort

### DIFF
--- a/src/modules/collection-view.js
+++ b/src/modules/collection-view.js
@@ -766,6 +766,15 @@ assignOwn(CollectionView.prototype, ViewMixin, {
 
     this.triggerMethod('before:sort', this);
 
+    if (viewComparator === defaultViewComparator && this._children.length) {
+      const indexByModel = new Map();
+      const models = this.Data.models(this.collection);
+      for (let index = 0; index < models.length; index++) {
+        indexByModel.set(models[index], index);
+      }
+      viewComparator = view => indexByModel.get(view.model) ?? -1;
+    }
+
     this._children._sort(viewComparator, this);
 
     this.triggerMethod('sort', this);
@@ -1288,5 +1297,7 @@ assignOwn(CollectionView.prototype, ViewMixin, {
   }
 });
 
+// Prototype overrides must not be mistaken for the built-in comparator.
+const defaultViewComparator = CollectionView.prototype._viewComparator;
 
 export default CollectionView;

--- a/test/unit/collection-view/collection-view-sorting.spec.js
+++ b/test/unit/collection-view/collection-view-sorting.spec.js
@@ -311,6 +311,103 @@ describe('CollectionView - Sorting', function() {
     });
   });
 
+  describe('default source ordering', function() {
+    it('reads one source snapshot when sorting an existing list', function() {
+      const view = new MyCollectionView({ collection }).render();
+      const models = this.sinon.spy(view.Data, 'models');
+
+      view.sort();
+
+      expect(models).to.have.been.calledOnceWith(collection);
+      expect(view.el.textContent).to.equal(noSortText);
+      view.destroy();
+    });
+
+    it('reads one snapshot for validation and one for sorting a collection change', function() {
+      const view = new MyCollectionView({ collection }).render();
+      const models = this.sinon.spy(view.Data, 'models');
+      const added = collection.add({ index: 5, sort: 6, altSort: 0 }, { at: 2 });
+
+      expect(models).to.have.been.calledTwice;
+      expect(view.children.findByIndex(2).model).to.equal(added);
+      view.destroy();
+    });
+
+    it('reads the source after before:sort changes its order silently', function() {
+      const view = new MyCollectionView({ collection }).render();
+      view.once('before:sort', () => {
+        collection.comparator = 'sort';
+        collection.sort({ silent: true });
+      });
+
+      view.sort();
+
+      expect(view.el.textContent).to.equal(sortText);
+      view.destroy();
+    });
+
+    it('does not read the source when before:sort destroys the view', function() {
+      const view = new MyCollectionView({ collection }).render();
+      const models = this.sinon.spy(view.Data, 'models');
+      view.once('before:sort', () => view.destroy());
+
+      view.sort();
+
+      expect(models).to.not.have.been.called;
+      expect(view.isDestroyed()).to.be.true;
+    });
+
+    it('preserves an overridden source comparator', function() {
+      const comparator = this.sinon.spy(function(child) {
+        return -child.model.get('index');
+      });
+      const CustomList = MyCollectionView.extend({ _viewComparator: comparator });
+      const view = new CustomList({ collection }).render();
+
+      expect(view.children.map(child => child.model.get('index'))).to.deep.equal([4, 3, 2, 1, 0]);
+      expect(comparator).to.have.been.calledOn(view);
+      view.destroy();
+    });
+
+    it('preserves a replacement of the base prototype comparator', function() {
+      const comparator = this.sinon.stub(CollectionView.prototype, '_viewComparator')
+        .callsFake(function(child) { return -child.model.get('index'); });
+      const view = new MyCollectionView({ collection }).render();
+
+      expect(view.children.map(child => child.model.get('index'))).to.deep.equal([4, 3, 2, 1, 0]);
+      expect(comparator).to.have.been.calledOn(view);
+      view.destroy();
+    });
+
+    it('preserves a getComparator wrapper around the source comparator', function() {
+      const comparator = this.sinon.spy();
+      const CustomList = MyCollectionView.extend({
+        getComparator() {
+          return child => {
+            comparator(child);
+            return -this._viewComparator(child);
+          };
+        }
+      });
+      const view = new CustomList({ collection }).render();
+
+      expect(view.children.map(child => child.model.get('index'))).to.deep.equal([4, 3, 2, 1, 0]);
+      expect(comparator.callCount).to.equal(collection.length);
+      view.destroy();
+    });
+
+    it('keeps children without a source model before the source children', function() {
+      const view = new MyCollectionView({ collection }).render();
+      const child = new View({ template: false });
+
+      view.addChildView(child);
+
+      expect(view.children.first()).to.equal(child);
+      expect(view.children.rest().map(current => current.model)).to.deep.equal(collection.models);
+      view.destroy();
+    });
+  });
+
   describe('#setComparator', function() {
     it('should return the collectionView instance', function() {
       const myCollectionView = new CollectionView();


### PR DESCRIPTION
## What

- Read the collection's current source order once per default CollectionView sort and index it by model.
- Preserve custom comparator overrides, source changes in `before:sort`, and the existing comparator rank (-1) of manually added children whose model is absent from the source.
- Add regressions for source-read counts and those existing sorting contracts.

## Why

The built-in comparator currently calls `Data.models(collection).indexOf(view.model)` for every child. Providers that return snapshots repeatedly copy the full collection, and every provider incurs repeated linear searches. A one-row update in a 10,000-row native collection was observed to make 10,001 source reads and copy 100,010,000 references. The change reduces that operation to two source reads: validation and sorting.

The historical [decision in #3667](https://github.com/marionettejs/backbone.marionette/issues/3667#issuecomment-489456239) remains unchanged: an explicitly inserted child is still subject to later sorting. This optimization preserves comparator behavior; it does not preserve absolute insertion indexes.

## Scope

CollectionView's built-in source-order comparator and its sorting tests. Public/custom comparator behavior, lifecycle events, reconciliation validation, adapters, typing, dependencies, and distribution tracking remain unchanged. The new map is local to each sort; there is no persistent cache or new API.

## Deployment Impact

No release or deployment is included. Applications receive the optimization through a future library version; no separate form redeployment is required by this source change.

## Testing

Candidate `7e5783999e463a7bb0873625fa850022649159dd` includes current master `c7677122b488193a8b73e0821dcf75d8d1a5a7fc` through an ordinary merge:

- `npm run build` passed, including source and private consumer type checks.
- Before the comment/name-only master update, `npm exec -- vitest run test/unit/collection-view --reporter=dot`: 402 tests passed across 10 files. After the update, build/type checks and the 41 sorting tests pass again.
- Against the base implementation, the sorting spec's two source-read regressions fail and 39 controls pass. Candidate source was restored afterward and the worktree is clean.
- `npm run lint:ci`, `npm run test:source`, `npm run test:dist`, and `node scripts/performance/bundle-size.mjs` passed before the comment/name-only master update.
- Exact-base Brotli deltas: core ESM +75 B, CommonJS +77 B, UMD +60 B, minified UMD +46 B. All 14 optional-package executables are byte-identical.
- Earlier alternating same-machine Node 24/jsdom measurements of this algorithm, before unrelated base updates, reduced a 10,000-row one-view touch from 47.5 ms to 14.8 ms and an append/remove pair from 111.4 ms to 37.1 ms. At 100 rows, differences were noise-scale. These timings were not rerun on this PR head and are not browser or production guarantees; source-read regressions are verified on the fresh head.
- Full repository coverage, browser tests, and the package fixture matrix were not rerun locally for this focused source change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `CollectionView`'s default sort by reading the collection's source order once per sort instead of locating every child via `Data.models(collection).indexOf()`. A one-row update in a 10,000-row collection previously made 10,001 source reads and copied 100,010,000 references; that same sort now reads the source only for validation and sorting.

**Behavior preserved**
- Custom comparators and prototype overrides still take precedence over the built-in path.
- Source order changes made in `before:sort` are read after that event fires.
- Manually added children whose model is absent from the source retain comparator rank -1; an insertion index is not pinned across later sorts.
- The indexed order lives only for the duration of the sort; no cache or new API is introduced.

<sup>Written for commit 7e5783999e463a7bb0873625fa850022649159dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collection view sorting to preserve the source collection’s ordering more reliably.
  - Sorting now correctly reflects source collection changes, including silent reordering.
  - Custom sorting behavior remains supported, including comparator overrides and wrapped comparators.
  - Views removed during sorting are handled safely, and views without source models remain ordered consistently.

- **Tests**
  - Added coverage for source ordering, collection updates, custom comparators, and view lifecycle changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
