### PR TITLE
fix(diagnostics): inspect erased TypeScript error expressions

### DIFF
--- a/scripts/diagnostics/catalog.mjs
+++ b/scripts/diagnostics/catalog.mjs
@@ -174,6 +174,14 @@ function parseJavaScript(contents, path, errors) {
   return sourceCode.ast;
 }
 
+function unwrapTypeScriptExpression(node) {
+  while (node && ['TSAsExpression', 'TSTypeAssertion', 'TSNonNullExpression',
+    'TSSatisfiesExpression', 'TSInstantiationExpression'].includes(node.type)) {
+    node = node.expression;
+  }
+  return node;
+}
+
 function addRuntimeSourceErrors(runtimeSources, diagnosticsByCode, errors) {
   for (const { contents, path } of runtimeSources) {
     const ast = parseJavaScript(contents, path, errors);
@@ -197,15 +205,18 @@ function addRuntimeSourceErrors(runtimeSources, diagnosticsByCode, errors) {
     }
 
     visitNodes(ast, node => {
-      if (node.type === 'ThrowStatement' &&
-        ['CallExpression', 'NewExpression'].includes(node.argument?.type) &&
-        ['AggregateError', 'Error', 'EvalError', 'RangeError', 'ReferenceError',
-          'SyntaxError', 'TypeError', 'URIError'].includes(node.argument.callee?.name)) {
-        errors.push(`${path} must not throw a native ${node.argument.callee.name}; use MarionetteError with a catalog code`);
-        return;
+      if (node.type === 'ThrowStatement') {
+        const argument = unwrapTypeScriptExpression(node.argument);
+        const callee = unwrapTypeScriptExpression(argument?.callee);
+        if (['CallExpression', 'NewExpression'].includes(argument?.type) &&
+          ['AggregateError', 'Error', 'EvalError', 'RangeError', 'ReferenceError',
+            'SyntaxError', 'TypeError', 'URIError'].includes(callee?.name)) {
+          errors.push(`${path} must not throw a native ${callee.name}; use MarionetteError with a catalog code`);
+          return;
+        }
       }
 
-      if (node.type !== 'NewExpression' || !marionetteErrorBindings.has(node.callee.name)) {
+      if (node.type !== 'NewExpression' || !marionetteErrorBindings.has(unwrapTypeScriptExpression(node.callee)?.name)) {
         return;
       }
 

--- a/test/unit/config/diagnostic-catalog.spec.js
+++ b/test/unit/config/diagnostic-catalog.spec.js
@@ -258,6 +258,84 @@ describe('diagnostic catalog validation', function() {
     }
   });
 
+  const typedConstructors = [
+    '(FrameworkError as unknown as new (options: object) => Error)',
+    '(<new (options: object) => Error>FrameworkError)',
+    '(FrameworkError!)',
+    '(FrameworkError satisfies new (options: object) => Error)',
+    '(FrameworkError<object>)',
+  ];
+
+  it('requires diagnostic codes through erased TypeScript constructor expressions', function() {
+    for (const constructor of typedConstructors) {
+      expect(() => validate(createCatalog(), {
+        runtimeSources: [{
+          contents: `import FrameworkError from './error.js'; new ${constructor}({ message: 'Missing code' });`,
+          path: 'modules/example.ts',
+        }],
+      })).to.throw(
+        DiagnosticCatalogValidationError,
+        'modules/example.ts MarionetteError must declare one literal diagnostic code',
+      );
+    }
+  });
+
+  it('rejects uncataloged codes through erased TypeScript constructor expressions', function() {
+    for (const constructor of typedConstructors) {
+      expect(() => validate(createCatalog(), {
+        runtimeSources: [{
+          contents: `import FrameworkError from './error.js'; new ${constructor}({ code: 'MN9999' });`,
+          path: 'modules/example.ts',
+        }],
+      })).to.throw(
+        DiagnosticCatalogValidationError,
+        'modules/example.ts emits uncataloged diagnostic code MN9999',
+      );
+    }
+  });
+
+  it('accepts cataloged codes through erased TypeScript constructor expressions', function() {
+    for (const constructor of typedConstructors) {
+      const catalog = createCatalog();
+      expect(validate(catalog, {
+        runtimeSources: [{
+          contents: `import FrameworkError from './error.js'; new ${constructor}({ code: 'MN0001' });`,
+          path: 'modules/example.ts',
+        }],
+      })).to.equal(catalog);
+    }
+  });
+
+  it('rejects native errors through erased TypeScript callees', function() {
+    for (const constructor of typedConstructors) {
+      for (const prefix of ['', 'new ']) {
+        expect(() => validate(createCatalog(), {
+          runtimeSources: [{
+            contents: `throw ${prefix}${constructor.replaceAll('FrameworkError', 'TypeError')}('Uncataloged');`,
+            path: 'modules/example.ts',
+          }],
+        })).to.throw(
+          DiagnosticCatalogValidationError,
+          'modules/example.ts must not throw a native TypeError; use MarionetteError with a catalog code',
+        );
+      }
+    }
+  });
+
+  it('rejects native errors through erased TypeScript throw expressions', function() {
+    for (const expression of typedConstructors) {
+      expect(() => validate(createCatalog(), {
+        runtimeSources: [{
+          contents: `throw ${expression.replaceAll('FrameworkError', 'new Error(\'Uncataloged\')')};`,
+          path: 'modules/example.ts',
+        }],
+      })).to.throw(
+        DiagnosticCatalogValidationError,
+        'modules/example.ts must not throw a native Error; use MarionetteError with a catalog code',
+      );
+    }
+  });
+
   it('rejects deliberate native framework errors', function() {
     for (const errorName of ['Error', 'TypeError']) {
       expect(() => validate(createCatalog(), {


### PR DESCRIPTION
## What

- Inspect erased TypeScript wrappers around diagnostic error constructors and native throw expressions.
- Add regression coverage for missing and uncataloged codes, valid cataloged codes, and wrapped native errors.

## Why

A cast such as `new (FrameworkError as unknown as new (options: object) => Error)(...)` hid the constructor from diagnostic validation. The checker could accept missing or unknown diagnostic codes, and similarly miss deliberately thrown native errors. Type annotations do not change the executed error expression, so they should not bypass the existing rules.

## Scope

Only `scripts/diagnostics/catalog.mjs` and its unit tests. The checker unwraps `as`, angle-bracket assertions, non-null assertions, `satisfies`, and type instantiation at the existing constructor and throw boundaries. Runtime source, the diagnostic catalog, public APIs and build configuration are unchanged. Existing indirect/dynamic constructor detection limitations remain outside this fix.

## Deployment Impact

No forms, bundles or application deployment required. This affects repository validation only; it does not change shipped runtime code or require a library release.

## Testing

Freshly validated on base `7f7684fa` with candidate `7398f7e4`:

- Before-fix reproduction on previous base `bb369961`: 4 failing groups / 38 passing tests. The refreshed base leaves the checker unchanged.
- `node_modules/.bin/vitest run test/unit/config/diagnostic-catalog.spec.js --reporter=dot`: 42 passed after the fix.
- `npm run check:diagnostics`: validated all 39 production catalog entries.
- `npm run test:source`: passed.
- `node_modules/.bin/eslint scripts/diagnostics/catalog.mjs test/unit/config/diagnostic-catalog.spec.js --max-warnings=0`: passed.
- `git diff --check marionettejs/master HEAD`: passed.

Full runtime coverage and browser tests were not run for this validation-only change. The reviewed patch was transferred without functional changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, TypeScript casts and assertions around error constructors and throw expressions hid diagnostic errors from the catalog checker, so missing or unknown codes and native throws could pass. The checker now unwraps `as`, angle-bracket assertions, non-null assertions, `satisfies`, and type instantiation before validating constructors and throws. This is validation-only; no runtime code or catalog entries change.

- Adds regression tests for missing and uncataloged codes, valid cataloged codes, and wrapped native errors.
- Changes only `scripts/diagnostics/catalog.mjs` and its unit test.

<sup>Written for commit 7398f7e431ae42eaea19339f2c52736b2bcc7757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

