### PR TITLE
fix(performance): accept typed production graph inputs

### DIFF
--- a/scripts/performance/budget-amendments.mjs
+++ b/scripts/performance/budget-amendments.mjs
@@ -63,7 +63,7 @@ function validArtifactPath(path) {
 function validSourcePath(path) {
   return typeof path === 'string' &&
     /^[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:js|ts)$/.test(path) &&
-    !path.endsWith('.d.ts') &&
+    !path.toLowerCase().endsWith('.d.ts') &&
     !path.includes('//') && !path.split('/').includes('..');
 }
 

--- a/scripts/performance/budget-amendments.mjs
+++ b/scripts/performance/budget-amendments.mjs
@@ -62,7 +62,8 @@ function validArtifactPath(path) {
 
 function validSourcePath(path) {
   return typeof path === 'string' &&
-    /^[A-Za-z0-9][A-Za-z0-9._/-]*\.js$/.test(path) &&
+    /^[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:js|ts)$/.test(path) &&
+    !path.endsWith('.d.ts') &&
     !path.includes('//') && !path.split('/').includes('..');
 }
 

--- a/scripts/performance/growth-approval.mjs
+++ b/scripts/performance/growth-approval.mjs
@@ -54,7 +54,8 @@ function validSubpath(subpath) {
 
 function validSourcePath(path) {
   return typeof path === 'string' &&
-    /^[A-Za-z0-9][A-Za-z0-9._/-]*\.js$/.test(path) &&
+    /^[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:js|ts)$/.test(path) &&
+    !path.endsWith('.d.ts') &&
     !path.includes('//') && !path.split('/').includes('..');
 }
 

--- a/scripts/performance/growth-approval.mjs
+++ b/scripts/performance/growth-approval.mjs
@@ -55,7 +55,7 @@ function validSubpath(subpath) {
 function validSourcePath(path) {
   return typeof path === 'string' &&
     /^[A-Za-z0-9][A-Za-z0-9._/-]*\.(?:js|ts)$/.test(path) &&
-    !path.endsWith('.d.ts') &&
+    !path.toLowerCase().endsWith('.d.ts') &&
     !path.includes('//') && !path.split('/').includes('..');
 }
 

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -958,6 +958,46 @@ describe('two-stage performance budget amendments', () => {
     }).diagnostics.join('\n'), /graph set mismatch/i);
   });
 
+  test('accepts a measured TypeScript graph in prototype evidence', () => {
+    const evidence = evidenceReports();
+    evidence[prototypeContractPath].productionGraphs.push({
+      subpath: './typed',
+      input: 'src/feature.ts',
+      output: 'dist/marionette.js',
+      baselineModules: [],
+      baselineExternalImports: [],
+    });
+    evidence[reportPath].report.graphs.push({
+      subpath: './typed',
+      input: 'src/feature.ts',
+      output: 'dist/marionette.js',
+      status: 'measured',
+      modules: ['src/feature.ts'],
+      externalImports: [],
+      forbiddenModules: [],
+    });
+    const record = amendment({ authorizedNewSubpaths: ['./typed'] });
+    const comments = trustedComments();
+    comments.approval.comments[0].body = formatBudgetAmendmentApproval(record, headSha);
+    const result = transition({
+      candidateLedger: ledger([record]),
+      comments,
+      changedFiles: [
+        'config/release/performance-budget-amendments.json',
+        baseReportPath,
+        prototypeContractPath,
+        reportPath,
+      ],
+      evidence,
+      reportHashes: {
+        [baseReportPath]: baseReportHash,
+        [prototypeContractPath]: prototypeContractHash,
+        [reportPath]: reportHash,
+      },
+    });
+    assert.equal(result.status, 'accepted', result.diagnostics.join('\n'));
+  });
+
   test('rejects unsafe prototype contract and source paths', () => {
     const unsafeContractPath = amendment({
       prototypeContract: {

--- a/test/performance/budget-amendment.test.mjs
+++ b/test/performance/budget-amendment.test.mjs
@@ -1009,33 +1009,35 @@ describe('two-stage performance budget amendments', () => {
       candidateLedger: ledger([unsafeContractPath]),
     }).diagnostics.join('\n'), /prototypeContract must use a safe immutable JSON path/i);
 
-    const unsafeSource = evidenceReports();
-    unsafeSource[prototypeContractPath].productionGraphs.push({
-      subpath: './unsafe',
-      input: 'modules/../unsafe.js',
-      output: 'dist/marionette.js',
-      baselineModules: [],
-      baselineExternalImports: [],
-    });
-    unsafeSource[reportPath].report.graphs.push({
-      subpath: './unsafe',
-      input: 'modules/../unsafe.js',
-      output: 'dist/marionette.js',
-      status: 'measured',
-      modules: ['unsafe.js'],
-      externalImports: [],
-      forbiddenModules: [],
-    });
-    assert.match(transition({
-      candidateLedger: ledger([amendment({ authorizedNewSubpaths: ['./unsafe'] })]),
-      changedFiles: [
-        'config/release/performance-budget-amendments.json',
-        baseReportPath,
-        prototypeContractPath,
-        reportPath,
-      ],
-      evidence: unsafeSource,
-    }).diagnostics.join('\n'), /new graph .* invalid additive contract/i);
+    for (const input of ['modules/../unsafe.js', 'src/index.d.ts', 'src/index.D.ts']) {
+      const unsafeSource = evidenceReports();
+      unsafeSource[prototypeContractPath].productionGraphs.push({
+        subpath: './unsafe',
+        input: input,
+        output: 'dist/marionette.js',
+        baselineModules: [],
+        baselineExternalImports: [],
+      });
+      unsafeSource[reportPath].report.graphs.push({
+        subpath: './unsafe',
+        input: input,
+        output: 'dist/marionette.js',
+        status: 'measured',
+        modules: ['unsafe.js'],
+        externalImports: [],
+        forbiddenModules: [],
+      });
+      assert.match(transition({
+        candidateLedger: ledger([amendment({ authorizedNewSubpaths: ['./unsafe'] })]),
+        changedFiles: [
+          'config/release/performance-budget-amendments.json',
+          baseReportPath,
+          prototypeContractPath,
+          reportPath,
+        ],
+        evidence: unsafeSource,
+      }).diagnostics.join('\n'), /new graph .* invalid additive contract/i);
+    }
   });
 
   test('requires a consuming implementation to use the authorized measured scope', () => {

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -372,35 +372,38 @@ describe('exact-head performance growth approval contract', () => {
     });
   });
 
-  test('permits an existing graph input move with a matching measured report', () => {
-    const authorityContract = growthContract();
-    const candidateContract = structuredClone(authorityContract);
-    candidateContract.productionGraphs[0].input = 'src/index.js';
-    const currentReport = productionReport();
-    currentReport.graphs[0].input = 'src/index.js';
-    currentReport.graphs[0].modules = ['src/index.js'];
+  for (const input of ['src/index.js', 'src/index.ts']) {
+    test(`permits a measured graph input move to ${input}`, () => {
+      const authorityContract = growthContract();
+      const candidateContract = structuredClone(authorityContract);
+      candidateContract.productionGraphs[0].input = input;
+      const currentReport = productionReport();
+      currentReport.graphs[0].input = input;
+      currentReport.graphs[0].modules = [input];
 
-    assert.deepEqual(validateCandidateGrowthContract(authorityContract, candidateContract), []);
-    assert.deepEqual(requiredNewProductionApproval({
-      authorityContract,
-      baseReport: productionReport(),
-      candidateContract,
-      currentReport,
-    }), { artifacts: [], subpaths: [], enforced: true });
+      assert.deepEqual(validateCandidateGrowthContract(authorityContract, candidateContract), []);
+      assert.deepEqual(requiredNewProductionApproval({
+        authorityContract,
+        baseReport: productionReport(),
+        candidateContract,
+        currentReport,
+      }), { artifacts: [], subpaths: [], enforced: true });
 
-    currentReport.graphs[0].input = 'index.js';
-    assert.throws(() => requiredNewProductionApproval({
-      authorityContract,
-      baseReport: productionReport(),
-      candidateContract,
-      currentReport,
-    }), /input or output does not match its contract/);
-  });
+      currentReport.graphs[0].input = 'index.js';
+      assert.throws(() => requiredNewProductionApproval({
+        authorityContract,
+        baseReport: productionReport(),
+        candidateContract,
+        currentReport,
+      }), /input or output does not match its contract/);
+    });
+  }
 
   test('rejects unsafe or missing replacement graph inputs', () => {
     const authorityContract = growthContract();
     for (const input of [undefined, null, '', '../index.js', '/src/index.js',
-      'src/../index.js', 'src//index.js', 'src/index.ts']) {
+      'src/../index.js', 'src//index.js', 'src/../index.ts', 'src//index.ts',
+      'src/index.d.ts', 'src/index.tsx']) {
       const candidateContract = structuredClone(authorityContract);
       if (input === undefined) {
         delete candidateContract.productionGraphs[0].input;

--- a/test/performance/growth-approval.test.mjs
+++ b/test/performance/growth-approval.test.mjs
@@ -403,7 +403,7 @@ describe('exact-head performance growth approval contract', () => {
     const authorityContract = growthContract();
     for (const input of [undefined, null, '', '../index.js', '/src/index.js',
       'src/../index.js', 'src//index.js', 'src/../index.ts', 'src//index.ts',
-      'src/index.d.ts', 'src/index.tsx']) {
+      'src/index.d.ts', 'src/index.D.ts', 'src/index.tsx']) {
       const candidateContract = structuredClone(authorityContract);
       if (input === undefined) {
         delete candidateContract.productionGraphs[0].input;


### PR DESCRIPTION
## What
- Accept `.ts` source inputs in production graph relocation and budget evidence validation.
- Continue rejecting declaration files, unsupported extensions and unsafe paths.

## Why
The checked public entry point will move from `src/index.js` to `src/index.ts`. CI reads the performance rules from the PR base, so this prerequisite lets the subsequent conversion use the normal measured-graph checks.

## Scope
Performance validation and its tests only. Runtime bundles, entry points, budgets, baselines, approval identities and required evidence are unchanged.

## Deployment Impact
No application or forms need redeployment. This change affects repository checks only and publishes no package or website.

## Testing
- `node --test --test-reporter=spec test/performance/growth-approval.test.mjs test/performance/budget-amendment.test.mjs` — 68 passed.
- Focused ESLint on the four changed files — passed.
- Cases cover matched JavaScript/TypeScript graph reports, mismatched reports, TypeScript prototype evidence, unsafe paths and declaration-file rejection. Existing exact-head approval and budget tests remain passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `.ts` source inputs in performance graph validation so the public entry point can move from `src/index.js` to `src/index.ts`. `growth-approval.mjs` and `budget-amendments.mjs` now allow `.ts` paths while still rejecting declaration files case-insensitively, unsafe paths, and unsupported extensions.

**Testing**
- `node --test --test-reporter=spec test/performance/growth-approval.test.mjs test/performance/budget-amendment.test.mjs` passes 68 tests.
- ESLint on the four changed files passes.

<sup>Written for commit f36d114a3dd736f82dc2ffa0bfd20e8a58ee5423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

