### PR TITLE
fix(behaviors): preserve cleanup during initialization

### DIFF
--- a/src/mixins/behaviors.ts
+++ b/src/mixins/behaviors.ts
@@ -4,6 +4,7 @@ import disposeAll from '../utils/dispose-all.ts';
 import getValue from '../utils/get-value.ts';
 
 export interface BehaviorInstance {
+  _isDestroyed?: boolean;
   behaviors?: unknown;
   destroy(options?: unknown): unknown;
   _syncElement(): unknown;
@@ -59,29 +60,29 @@ function getBehaviorClass(options: BehaviorDefinition) {
   });
 }
 
-function addBehavior(view: BehaviorContainer, behaviorDefinition: BehaviorDefinition, allBehaviors: BehaviorInstance[]) {
+function addBehavior(view: BehaviorContainer, behaviorDefinition: BehaviorDefinition) {
   const { BehaviorClass, options } = getBehaviorClass(behaviorDefinition);
   const behavior = new (BehaviorClass as BehaviorConstruction)(options, view);
-  allBehaviors.push(behavior);
+  if (!behavior._isDestroyed) {
+    view._behaviors!.push(behavior);
+  }
 
-  parseBehaviors(view, getValue(behavior, 'behaviors'), allBehaviors);
+  parseBehaviors(view, getValue(behavior, 'behaviors'));
 }
 
 // Iterate over the behaviors object, for each behavior
 // instantiate it and get its grouped behaviors.
 // This accepts a list of behaviors in either an object or array form
-function parseBehaviors(view: BehaviorContainer, behaviors: unknown, allBehaviors: BehaviorInstance[]) {
+function parseBehaviors(view: BehaviorContainer, behaviors: unknown) {
   if (Array.isArray(behaviors)) {
     for (let index = 0, length = behaviors.length; index < length; index++) {
-      addBehavior(view, behaviors[index], allBehaviors);
+      addBehavior(view, behaviors[index]);
     }
   } else {
     eachOwn(behaviors, (behaviorDefinition: BehaviorDefinition) => {
-      addBehavior(view, behaviorDefinition, allBehaviors);
+      addBehavior(view, behaviorDefinition);
     });
   }
-
-  return allBehaviors;
 }
 
 function eachBehavior(behaviors: BehaviorInstance[] | undefined, iteratee: (behavior: BehaviorInstance) => unknown) {
@@ -113,7 +114,7 @@ export default {
     this._behaviors = [];
 
     try {
-      parseBehaviors(this, getValue(this, 'behaviors'), this._behaviors);
+      parseBehaviors(this, getValue(this, 'behaviors'));
     } catch (error) {
       this._rollbackBehaviors();
       throw error;

--- a/src/modules/behavior.ts
+++ b/src/modules/behavior.ts
@@ -160,6 +160,8 @@ const Behavior = function(this: BehaviorInternals, options: BehaviorOptions | un
     (this.initialize as Function).apply(this, arguments);
 
     this._initStateEvents();
+    if (this._isDestroyed) { return; }
+
     this._syncElement();
   } catch (error) {
     try {

--- a/test/unit/behavior-initialize-cleanup.spec.js
+++ b/test/unit/behavior-initialize-cleanup.spec.js
@@ -1,0 +1,156 @@
+import { Behavior, View } from 'marionette';
+
+// Observe real DOM handlers and public cleanup; do not inspect the parser's array.
+describe('Behavior initialization cleanup', function() {
+  let el;
+  let host;
+  let instances;
+  let clicks;
+  let destroyed;
+
+  beforeEach(function() {
+    el = document.createElement('section');
+    el.innerHTML = '<button>Run</button>';
+    document.body.appendChild(el);
+    instances = {};
+    clicks = [];
+    destroyed = [];
+  });
+
+  afterEach(function() {
+    if (host) { host.destroy(); }
+    // Also release any instance lost by a failing ownership regression.
+    Object.values(instances).forEach(behavior => behavior.destroy());
+    el.remove();
+    host = undefined;
+  });
+
+  function defineBehavior(name, properties = {}) {
+    const { initialize, ...rest } = properties;
+    return Behavior.extend({
+      ...rest,
+      events: {
+        'click button'() { clicks.push(name); }
+      },
+      initialize() {
+        instances[name] = this;
+        if (initialize) { initialize.call(this); }
+      },
+      destroy() {
+        destroyed.push(name);
+        return Behavior.prototype.destroy.call(this);
+      }
+    });
+  }
+
+  function showBehaviors(behaviors) {
+    host = new View({ el, behaviors });
+    el.firstElementChild.click();
+  }
+
+  function expectHostCleanup(expectedClicks, expectedDestroyed) {
+    host.destroy();
+    // A detached but retained root must not keep a Behavior's listener alive.
+    el.firstElementChild.click();
+    expect(clicks).to.deep.equal(expectedClicks);
+    expect(destroyed).to.have.members(expectedDestroyed);
+    expect(destroyed).to.have.lengthOf(expectedDestroyed.length);
+  }
+
+  it('does not rebind a self-destroyed Behavior and retains both live siblings', function() {
+    showBehaviors([
+      defineBehavior('first'),
+      defineBehavior('self', { initialize() { this.destroy(); } }),
+      defineBehavior('last')
+    ]);
+
+    expect(clicks).to.deep.equal(['first', 'last']);
+    expectHostCleanup(['first', 'last'], ['self', 'first', 'last']);
+  });
+
+  it('retains the later Behavior when its initializer destroys an earlier sibling', function() {
+    showBehaviors([
+      defineBehavior('first'),
+      defineBehavior('last', { initialize() { instances.first.destroy(); } })
+    ]);
+
+    expect(clicks).to.deep.equal(['last']);
+    expectHostCleanup(['last'], ['first', 'last']);
+  });
+
+  it('retains nested and outer siblings after a nested Behavior destroys itself', function() {
+    showBehaviors([
+      defineBehavior('outer', {
+        behaviors: [
+          defineBehavior('self', { initialize() { this.destroy(); } }),
+          defineBehavior('nested')
+        ]
+      }),
+      defineBehavior('last')
+    ]);
+
+    expect(clicks).to.deep.equal(['outer', 'nested', 'last']);
+    expectHostCleanup(['outer', 'nested', 'last'], ['self', 'outer', 'nested', 'last']);
+  });
+
+  it('still constructs and owns the nested definitions of a self-destroyed Behavior', function() {
+    showBehaviors([
+      defineBehavior('self', {
+        initialize() { this.destroy(); },
+        behaviors: [defineBehavior('nested')]
+      }),
+      defineBehavior('last')
+    ]);
+
+    expect(clicks).to.deep.equal(['nested', 'last']);
+    expectHostCleanup(['nested', 'last'], ['self', 'nested', 'last']);
+  });
+
+  it('cleans up live siblings when a later constructor throws after self-destruction', function() {
+    const failure = new Error('initialization failed');
+    expect(() => showBehaviors([
+      defineBehavior('first'),
+      defineBehavior('self', { initialize() { this.destroy(); } }),
+      defineBehavior('last'),
+      defineBehavior('throws', { initialize() { throw failure; } })
+    ])).to.throw(failure);
+
+    el.firstElementChild.click();
+    expect(clicks).to.deep.equal([]);
+    expect(destroyed).to.have.members(['self', 'throws', 'first', 'last']);
+    expect(destroyed).to.have.lengthOf(4);
+  });
+
+  it('does not rebind after a synchronous state callback destroys the Behavior', function() {
+    let releases = 0;
+    const Stateful = defineBehavior('state', {
+      state: {},
+      stateEvents: { ready: 'onReady' },
+      onReady() { this.destroy(); }
+    });
+    Stateful.setStateApi({
+      subscribe(source, name, callback, context) {
+        callback.call(context);
+        return () => { releases += 1; };
+      }
+    });
+
+    showBehaviors([Stateful, defineBehavior('last')]);
+
+    expect(clicks).to.deep.equal(['last']);
+    expect(releases).to.equal(1);
+    expectHostCleanup(['last'], ['state', 'last']);
+    expect(releases).to.equal(1);
+  });
+
+  it('preserves ordinary nested registration order and cleans each Behavior once', function() {
+    showBehaviors([
+      defineBehavior('first'),
+      defineBehavior('outer', { behaviors: [defineBehavior('nested')] }),
+      defineBehavior('last')
+    ]);
+
+    expect(clicks).to.deep.equal(['first', 'outer', 'nested', 'last']);
+    expectHostCleanup(['first', 'outer', 'nested', 'last'], ['first', 'outer', 'nested', 'last']);
+  });
+});


### PR DESCRIPTION
Related #429

## What

- Stop Behavior construction from attaching DOM callbacks after initialization or a synchronous state subscription destroys the Behavior.
- Register live Behaviors in the host's current collection so earlier destruction cannot lose later siblings or rollback cleanup.
- Add seven public regressions covering self-destruction, sibling and nested ownership, subscription cleanup, and constructor failure.

## Why

A Behavior could reacquire DOM listeners after destruction. Its destruction also replaced the host collection while parsing still used the old array, leaving live siblings unreachable during host cleanup. Clicking a retained root after host destruction could still call those handlers. This predates the typing conversion in #429.

## Scope

Two core Behavior construction files and one regression suite. Nested definitions remain part of the host's flat Behavior collection, even when their declaring Behavior destroys itself. The fix adds two checks per constructed Behavior, using the existing destroyed flag. Render, update and attachment loops are unchanged; this does not establish general cancellation semantics for lifecycle callbacks.

## Deployment Impact

No forms or application redeploy is required for this repository change. Package consumers receive it with a future library version. No release, tag, or publication is included.

## Testing

- `npm run check:types` and focused ESLint on the changed source and regression suite.
- `npm run build`.
- Focused Behavior tests: 102 tests passed.
- `npm run coverage`: 2,179 tests passed, with 100% statements, branches, functions and lines; 19 agent benchmark contract tests passed.
- Five new regressions fail against the unchanged base; the ordinary-order control already passes. The additional synchronous state regression fails before the constructor check is moved after state initialization. An independent public StateApi reproduction confirms the callback leak and its correction.
- Independent source/test review verified retained-root DOM cleanup and the nested ownership contract.

Fresh full-core output comparison against master: Brotli ESM -20 bytes, CJS -9 bytes, UMD -13 bytes, minified UMD +6 bytes. The earlier two-check prototype had overlapping construction timings within 1%; that is bounded prototype evidence, not an exact-final-commit speed claim.

Fresh CI will validate distributions, browsers, installed packages and deterministic size against the current master base.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Behavior cleanup during initialization so a destroyed Behavior can no longer rebind DOM listeners, and live siblings stay reachable when the host is destroyed.

- Checks the destroyed flag after initialization and state event setup, and only registers live Behaviors in the host's current collection.
- Adds regression tests covering self-destruction, sibling and nested ownership, constructor failure, and synchronous state subscription cleanup.
- Changes apply to Behavior construction and parsing only; render, update, and attachment loops are unchanged.

<sup>Written for commit 85b28d29058fd25841ad2178115003c8c9a92c98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Behaviors that destroy themselves during initialization are no longer rebound or synchronized.
  * Nested behaviors are handled correctly even when a parent behavior is destroyed during setup.
  * Remaining active behaviors continue to initialize and clean up reliably after a sibling is destroyed or fails during construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->