### PR TITLE
docs(guides): lead with application tasks and a consistent voice

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,8 +1,9 @@
 # Common Marionette Concepts
 
-This document covers the shared configuration patterns used by Marionette's
-classes. Class-specific pages remain the authority for when a particular value
-is read and whether it is read again.
+Learn the configuration patterns once, then use them across Marionette's classes.
+Each class's reference explains when it reads an option and whether it reads it
+again. For checked application options, see the
+[TypeScript example](./installation.md#typescript).
 
 ## Documentation Index
 
@@ -24,9 +25,9 @@ const view = new View();
 const app = new Application();
 ```
 
-V5 has no default namespace export. The package also exposes explicit optional
-integration subpaths; see [Installing Marionette](./installation.md) for the
-current entrypoints and peer-dependency boundaries.
+V5 has no default namespace export. The separate `@marionette/adapters` package
+provides optional integration subpaths; see [Installing Marionette](./installation.md)
+for the entrypoints and their dependencies.
 
 Existing no-bundler applications may serve the published
 `dist/marionette.umd.js` artifact. It exposes the named API on the global

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -1,19 +1,17 @@
 # Marionette Classes
 
-Marionette follows Backbone's [pseudo-class architecture](./basics.md#class-based-inheritance).
-This documentation is meant to provide a comprehensive listing of those classes so that
-the reader can have a high-level view and understand functional similarities between the classes.
-All of these classes share a [common set of functionality](./common.md).
+Each Marionette class has a job: render a piece of interface, manage where it goes,
+repeat it, share an interaction, or coordinate a feature. Start with the job you
+need, then follow the reference for its options and lifecycle.
+
+The classes share [configuration and inheritance patterns](./basics.md#class-based-inheritance)
+and a [common set of methods](./common.md).
 
 ### [Marionette.View](./marionette.view.md)
 
-A `View` is used for managing portions of the DOM via a single parent DOM element or `el`.
-It provides a consistent interface for managing the content of the `el` which is typically
-administered by serializing a `Backbone.Model` or `Backbone.Collection` and rendering
-a template with the serialized data into the `View`s `el`.
-
-The `View` provides event delegation for capturing and handling DOM interactions as well as
-the ability to separate concerns into smaller, managed child views.
+A `View` owns a piece of interface through its root element, `el`. It renders a
+template, handles DOM interactions, and can divide a screen into Regions for child
+Views. Plain objects and function templates work with the default configuration.
 
 `View` includes:
 - [The DOM API](./dom.api.md)
@@ -29,10 +27,10 @@ A `View` can have [`Region`s](#marionetteregion) and [`Behavior`s](#marionettebe
 
 ### [Marionette.CollectionView](./marionette.collectionview.md)
 
-A `CollectionView` like `View` manages a portion of the DOM via a single parent DOM element
-or `el`. This view manages an ordered set of child views that are shown within the view's `el`.
-These children are most often created to match the models of a `Backbone.Collection` though a
-`CollectionView` does not require a `collection` and can manage any set of views.
+A `CollectionView` manages an ordered set of child Views inside its root element.
+Use it for rows, cards, or other repeated content. A plain array supplies a static
+collection; an observable data integration can notify it of changes. You can also
+manage child Views directly without supplying a collection.
 
 `CollectionView` includes:
 - [The DOM API](./dom.api.md)
@@ -48,8 +46,8 @@ A `CollectionView` can have [`Behavior`s](#marionettebehavior).
 
 ### [Marionette.Region](./marionette.region.md)
 
-Regions provide consistent methods to manage, show and destroy views in your
-applications and views.
+A `Region` gives a View a place to appear. Showing a new View renders and attaches
+it; replacing or emptying the Region destroys its current View by default.
 
 `Region` includes:
 - [Class Events](./events.class.md#region-events)
@@ -57,8 +55,8 @@ applications and views.
 
 ### [Marionette.Behavior](marionette.behavior.md)
 
-A `Behavior` provides a clean separation of concerns to your view logic, allowing you to
-share common user-facing operations between your views.
+A `Behavior` shares interaction logic between Views, such as keyboard shortcuts or
+a reusable button action. The host View constructs and cleans up its Behaviors.
 
 `Behavior` includes:
 - [Class Events](./events.class.md#behavior-events)
@@ -67,18 +65,23 @@ share common user-facing operations between your views.
 
 ### [Marionette.Application](marionette.application.md)
 
-An `Application` provides hooks for organizing and initiating other elements and a view tree.
+An `Application` coordinates a feature's asynchronous start, stop, restart, and
+destruction. It can own child Applications and display a View through an optional
+Region. Use it for work that should start and stop together.
 
 `Application` includes:
 - [Class Events](./events.class.md#application-events)
 - [Radio API](./radio.md#marionette-integration)
-- [MnObject's API](./marionette.mnobject.md)
+- [Common Marionette Functionality](./common.md)
+- [State API](./marionette.state.md)
 
 An `Application` can have a single [region](./marionette.application.md#application-region).
 
 ### [Marionette.MnObject](marionette.mnobject.md)
 
-`MnObject` incorporates backbone conventions `initialize`, `cid` and `extend`.
+`MnObject` gives a nonvisual object initialization, events, options, and cleanup.
+Use it when those conventions are useful without an element or an Application's
+asynchronous lifecycle.
 
 `MnObject` includes:
 - [Class Events](./events.class.md#mnobject-events)
@@ -86,13 +89,12 @@ An `Application` can have a single [region](./marionette.application.md#applicat
 
 ### [State sources and StateApi](marionette.state.md)
 
-Eligible owners compose exact state sources and observe them through StateApi.
-It is independent from Backbone models and collections.
+Give a feature or View its own state, or pass in a source it should share.
+`StateApi` connects that source's notifications and cleanup to its owner.
 
 ## Routing in Marionette
 
-Users of versions of Marionette prior to v4 will notice that a router is no longer bundled.
-The [Marionette.AppRouter](https://github.com/marionettejs/marionette.approuter) was extracted
-and the core library will no longer hold an opinion on routing.
+Choose a router that fits your application. Route handlers can start an Application
+or show a View using ordinary application code.
 
 [Continue Reading](./routing.md) about routing in Marionette.

--- a/docs/data.api.md
+++ b/docs/data.api.md
@@ -1,8 +1,9 @@
 # Data API
 
-Marionette v5 reads models and collections through `DataApi`. Core does not
-require Backbone-shaped `cid`, `attributes`, `get`, `models`, or collection
-event payloads.
+Display plain objects and arrays directly, or connect your data library through
+`DataApi`. The adapter tells Marionette how to read models, obtain collection
+order, and observe changes. Core does not require Backbone-shaped `cid`,
+`attributes`, `get`, `models`, or collection event payloads.
 
 The default adapter treats models as plain objects and collections as ordered
 arrays. Plain arrays are static snapshots: mutating one does not notify
@@ -119,9 +120,11 @@ and `CollectionView`. `View.setDataApi()` and `CollectionView.setDataApi()` can
 configure a subclass independently. A CollectionView and its child View class
 must use compatible adapters.
 
-Behaviors use their owning View's adapter. The original model or collection is
-always passed to Views, Behaviors, callbacks, and templates; DataApi does not
-wrap application data.
+Behaviors use their owning View's adapter. Views and Behaviors work with the
+original model or collection, and event callbacks receive the source's native
+arguments. DataApi does not wrap application sources. Templates receive the
+data prepared by `serializeModel()` or `serializeCollection()`; see
+[Rendering](https://github.com/marionettejs/marionette/blob/master/docs/view.rendering.md).
 
 DataApi and [StateApi](./marionette.state.md#stateapi) are selected
 independently. One adapter object may implement both contracts, but configuring

--- a/docs/events.class.md
+++ b/docs/events.class.md
@@ -155,7 +155,7 @@ with its own destruction. A `destroy` event occurring on the `Behavior` will hav
 ## Region Events
 
 When you show a view inside a region - either using [`region.show(view)`](./marionette.region.md#showing-a-view) or
-[`showChildView('region', view)`](./marionette.view.md#showing-a-view) - the `Region` will emit events around the view
+[`showChildView('region', view)`](./marionette.view.md#showing-a-child-view) - the `Region` will emit events around the view
 events that you can hook into.
 
 The `Region` class also triggers [Destroy Events](#destroy-and-beforedestroy-events).

--- a/docs/events.class.md
+++ b/docs/events.class.md
@@ -256,16 +256,16 @@ The `CollectionView` triggers unique events specifically related to child manage
 ### `add:child` and `before:add:child` events
 
 These events fire before (`before:add:child`) and after (`add:child`) each child view
-is instantiated and added to the [`children`](./collectionview.md#collectionviews-children).
+is instantiated and added to the [`children`](./marionette.collectionview.md#accessing-a-child-view).
 These will fire once for each model in the attached collection or for any view added using
-[`addChildView`](./collectionview.md#adding-a-child-view).
+[`addChildView`](./marionette.collectionview.md#adding-a-child-view).
 
 ### `remove:child` and `before:remove:child` events
 
 These events fire before (`before:remove:child`) and after (`remove:child`) each child view
-is removed to the [`children`](./collectionview.md#collectionviews-children).
+is removed from the [`children`](./marionette.collectionview.md#accessing-a-child-view).
 A view may be removed from the `children` if it is destroyed, if it is removed
-from the `collection` or if it is removed with [`removeChildView`](./collectionview.md#removing-a-child-view).
+from the `collection` or if it is removed with [`removeChildView`](./marionette.collectionview.md#removing-a-child-view).
 
 **NOTE** A childview may or may not be destroyed by this point.
 
@@ -276,14 +276,14 @@ should happen in [`before:destroy:children`](#destroychildren-and-beforedestroyc
 ### `sort` and `before:sort` events
 
 These events fire before (`before:sort`) and after (`sort`) sorting the children in the `CollectionView`.
-These events will only fire if there are [`children`](./collectionview.md#collectionviews-children)
-and a [`viewComparator`](./collectionview.md#defining-the-viewcomparator)
+These events will only fire if there are [`children`](./marionette.collectionview.md#accessing-a-child-view)
+and a [`viewComparator`](./marionette.collectionview.md#defining-the-viewcomparator)
 
 ### `filter` and `before:filter` events
 
 These events fire before (`before:filter`) and after (`filter`) filtering the children in the `CollectionView`.
-This event will only fire if there are [`children`](./collectionview.md#collectionviews-children)
-and a [`viewFilter`](./collectionview.md#defining-the-viewfilter).
+This event will only fire if there are [`children`](./marionette.collectionview.md#accessing-a-child-view)
+and a [`viewFilter`](./marionette.collectionview.md#defining-the-viewfilter).
 
 When the `filter` event is fired the children filtered out will have already been
 detached from the view's `el`, but new children will not yet have been rendered.
@@ -315,12 +315,12 @@ but will be rendered and attached by `render:children`.
 If the `CollectionView` can determine that added views will only be appended to the end, only the appended views
 will be passed to the event. Otherwise all of the `children` views will be passed.
 
-**Note** if you consistently need all of the views within this event use [`children`](./marionette.collectionview.md#collectionviews-children)
+**Note** if you consistently need all of the views within this event use [`children`](./marionette.collectionview.md#accessing-a-child-view)
 
 ### `destroy:children` and `before:destroy:children` events
 
 These events fire before (`before:destroy:children`) and after (`destroy:children`) destroying the children
-in the `CollectionView`. These events will only fire if there are [`children`](./collectionview.md#collectionviews-children).
+in the `CollectionView`. These events will only fire if there are [`children`](./marionette.collectionview.md#accessing-a-child-view).
 
 ### CollectionView EmptyView Region Events
 

--- a/docs/events.class.md
+++ b/docs/events.class.md
@@ -1,9 +1,14 @@
 # Class Events
 
-Marionette uses [`triggerMethod`](./events.md#triggermethod) internally to trigger various
-events used within the [classes](./classes.md). This provides ['onEvent' binding](./events.md#onevent-binding)
-providing convenient hooks for handling class events. Notably all internally triggered events
-will pass the triggering class instance as the first argument of the event.
+Class events let you respond as a view renders, a Region shows a view, or an
+Application starts and stops. Marionette uses
+[`triggerMethod`](./events.md#triggermethod) to dispatch these events, so you can
+listen to an event or define its matching
+[`onEvent` method](./events.md#onevent-binding).
+
+Arguments depend on the event. Use the signatures below rather than assuming
+the first argument is the instance that triggered it; for example, a Behavior's
+proxied view events receive the host view.
 
 ## Documentation Index
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -282,8 +282,8 @@ For more information, see the [DOM interactions documentation](./dom.interaction
 
 ### View entity events
 
-Views can automatically bind to its model or collection with [`modelEvents`](./events.entity.md#model-events)
-and [`collectionEvents`](./events.entity.md#collection-events) respectively.
+Views can automatically bind to its model or collection with [`modelEvents`](./events.entity.md)
+and [`collectionEvents`](./events.entity.md) respectively.
 
 ```javascript
 import { View } from 'marionette';

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,25 +1,24 @@
 # Installing Marionette
 
-As with all JavaScript libraries, there are a number of ways to get started with
-a Marionette application. In this section we'll cover the most common ways.
-While some integrations are listed here, more resources are available in the integrations repo:
-[marionette-integrations](https://github.com/marionettejs/marionette-integrations)
+Install the core package, show a View, then add the integrations your application
+needs. Native DOM APIs, plain objects, and function templates work out of the box.
+
+This guide describes the current v5 source. Published alphas may lag behind it;
+see [contributor setup](https://github.com/marionettejs/marionette/blob/master/CONTRIBUTING.md#set-up-the-repository) to build and pack
+an unreleased checkout locally.
 
 ## Documentation Index
 
 * [Install](#install)
 * [Peer dependencies](#peer-dependencies)
 * [Quick start](#quick-start)
+* [TypeScript](#typescript)
 * [Independent runtimes](#independent-runtimes)
 * [Observable data sources](#observable-data-sources)
 * [Distribution formats](#distribution-formats)
 * [Backbone is optional](#backbone-is-optional)
 * [jQuery DOM adapter is optional](#jquery-dom-adapter-is-optional)
-* [NPM and Webpack](#quick-start-using-npm-and-webpack)
-* [NPM and Brunch](#quick-start-using-npm-and-brunch)
-* [NPM and Browserify](#quick-start-using-npm-and-browserify)
-* [Browserify and Grunt](#browserify-and-grunt)
-* [Browserify and Gulp](#browserify-and-gulp)
+* [Historical starter projects](#historical-starter-projects)
 * [Current v5 documentation](./readme.md)
 
 ## Install
@@ -90,7 +89,7 @@ Marionette v5 exposes its public API through named ESM imports. There is no
 default-namespace export; use named imports only.
 
 ```js
-import { Application, View, Region } from 'marionette';
+import { Application, View } from 'marionette';
 
 const RootView = View.extend({
   template: () => '<div>Hello, Marionette.</div>'
@@ -110,6 +109,38 @@ await app.start();
 selector strings — pass `document.querySelector('#root')` at the call site. See
 the [upgrade guide](../upgradeGuide.md) for the migration entry. `Region` continues
 to accept selector strings.
+
+## TypeScript
+
+The current v5 source includes declarations for TypeScript 6 and 7, with ESM and
+CommonJS entrypoints. Core needs no separate `@types` package. Annotate `initialize`
+to describe a View's application options; TypeScript uses that signature to check
+construction and `this.options`.
+
+```ts
+import { View } from 'marionette';
+
+const MessageView = View.extend({
+  template: false,
+  initialize(options: { message: string }) {
+    this.el.textContent = options.message;
+  },
+  message(): string {
+    return this.options.message;
+  }
+});
+
+const view = new MessageView({ message: 'Hello, Marionette.' });
+document.body.append(view.render().el);
+```
+
+This View requires a string `message`. Missing options or a numeric message are
+compile errors. `template: false` preserves the text set during initialization.
+
+Named imports work with `NodeNext` or bundler module resolution. The
+[typing guide](https://github.com/marionettejs/marionette/blob/master/CONTRIBUTING.md#typescript-source) covers custom constructors
+and the supported combinations of `.extend` and native classes. Optional
+integrations may need their own type packages, listed above.
 
 ## Independent runtimes
 
@@ -203,58 +234,33 @@ keeps the wrapper synchronized with the owning View's `setElement()` calls. See
 the [upgrade guide](../upgradeGuide.md) for the migration entries on jQuery DOM
 compatibility and the `detachContents` policy.
 
-## Quick start using NPM and Webpack
-[NPM](https://www.npmjs.com/) is the package manager for JavaScript.
+## Historical starter projects
 
-Installing with NPM through command-line interface
-```bash
-npm install marionette
-```
+The following projects target `backbone.marionette ~3.0.0`. They remain useful
+references for that generation of Marionette. For v5, start with the package and
+examples above; copying these projects also brings their older dependencies.
 
-[Webpack][webpack] is a build tool that makes it easy to pull your dependencies
-together into a single bundle to be delivered to your browser's `<script>` tag.
-It works particularly well with Marionette and jQuery.
+### Quick start using NPM and Webpack
 
-[Here](https://github.com/marionettejs/marionette-integrations/tree/master/webpack)
-we prepared simple marionettejs skeleton with Webpack.
+[Webpack starter for Marionette v3](https://github.com/marionettejs/marionette-integrations/tree/master/webpack).
 
+### Quick start using NPM and Brunch
 
-## Quick start using NPM and Brunch
+[Brunch starter for Marionette v3](https://github.com/marionettejs/marionette-integrations/tree/master/brunch).
 
-[Brunch][brunch] is fast front-end web app build tool with simple declarative config,
-seamless incremental compilation for rapid development, an opinionated pipeline
-and workflow, and core support for source maps.
+### Quick start using NPM and Browserify
 
-[Here](https://github.com/marionettejs/marionette-integrations/tree/master/brunch)
-we prepared simple marionettejs skeleton with Brunch.
-
-
-## Quick start using NPM and Browserify
-
-[Browserify][browserify] is a build tool that makes it easy to bundle NPM
-modules into your application, so you can `require` them as you would import
-dependencies in any other language.
-
-[Here](https://github.com/marionettejs/marionette-integrations/tree/master/browserify)
-we prepared simple marionettejs skeleton with Browserify.
+[Browserify starter for Marionette v3](https://github.com/marionettejs/marionette-integrations/tree/master/browserify).
 
 ### Browserify and Grunt
 
-[Grunt][grunt] is task runner. [Here](https://github.com/marionettejs/marionette-integrations/tree/master/browserify-grunt) is simple Browserify + Grunt skeleton.
+[Browserify and Grunt starter for Marionette v3](https://github.com/marionettejs/marionette-integrations/tree/master/browserify-grunt).
 
 ### Browserify and Gulp
 
-[Gulp][gulp] is streaming build system. [Here](https://github.com/marionettejs/marionette-integrations/tree/master/browserify-gulp) is simple Browserify + Gulp skeleton.
-
-
-[browserify]: http://browserify.org/
-[webpack]: https://webpack.github.io/
-[brunch]: http://brunch.io/
-[grunt]: http://gruntjs.com/
-[gulp]: http://gulpjs.com/
+[Browserify and Gulp starter for Marionette v3](https://github.com/marionettejs/marionette-integrations/tree/master/browserify-gulp).
 
 ## Getting Started
 
-After installing Marionette you might want to check out the basics.
-
-[Continue reading the current v5 documentation](./readme.md).
+[Choose a class for the job](https://github.com/marionettejs/marionette/blob/master/docs/classes.md), or learn the
+[shared configuration patterns](https://github.com/marionettejs/marionette/blob/master/docs/basics.md).

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -1,8 +1,8 @@
 # Marionette.Application
 
-The `Application` is Marionette's non-renderable lifecycle scope. It provides
-asynchronous start, stop, restart, and destroy coordination plus an optional
-Region for a view tree.
+An `Application` gives a feature a place to start, stop, restart, and clean up.
+It coordinates asynchronous work and child Applications, with an optional
+Region for the feature's view tree.
 
 `Application` includes:
 - [Common Marionette Functionality](./common.md)

--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -8,7 +8,7 @@ Region for the feature's view tree.
 - [Common Marionette Functionality](./common.md)
 - [Class Events](./events.class.md#application-events)
 - [Radio API](./radio.md#marionette-integration)
-- [State API](./marionette.state.md#owned-state)
+- [State API](./marionette.state.md#borrowed-and-owned-sources)
 
 `Application` is an independent class. It does not inherit from `MnObject` and
 does not add an element or render method.

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -362,8 +362,8 @@ including:
 
 * [`events`](./dom.interactions.md#view-events)
 * [`triggers`](./dom.interactions.md#view-triggers)
-* [`modelEvents`](./events.entity.md#model-events)
-* [`collectionEvents`](./events.entity.md#collection-events)
+* [`modelEvents`](./events.entity.md)
+* [`collectionEvents`](./events.entity.md)
 
 ```javascript
 import { Behavior } from 'marionette';

--- a/docs/marionette.behavior.md
+++ b/docs/marionette.behavior.md
@@ -1,7 +1,8 @@
 # Marionette.Behavior
 
-A `Behavior` provides a clean separation of concerns to your view logic,
-allowing you to share common user-facing operations between your views.
+A `Behavior` shares interaction logic across views. It uses its host view's
+DOM and can handle DOM, model, and collection events without giving each
+view another copy of the same handlers.
 
 `Behavior` includes:
 - [Common Marionette Functionality](./common.md)
@@ -9,11 +10,8 @@ allowing you to share common user-facing operations between your views.
 - [DOM Interactions](./dom.interactions.md)
 - [Entity Events](./events.entity.md)
 
-`Behavior`s are particularly good at factoring out the common user, model and
-collection interactions to be utilized across your application. Unlike the other
-Marionette classes, `Behavior`s are not meant to be instantiated directly.
-Instead a `Behavior` should be instantiated by the view it is related to by
-[attaching a behavior class definition to the view](#using-behaviors).
+[Attach a Behavior class to a view](#using-behaviors) through its `behaviors`
+definition. The view constructs the Behavior and manages its lifetime.
 
 ## Documentation Index
 
@@ -60,7 +58,7 @@ const MyView = View.extend({
   },
 
   warnBeforeDestroy() {
-    alert('You are about to destroy all your data!');
+    alert('This view will be removed.');
     this.destroy();
   },
 

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -1,9 +1,12 @@
 # Marionette.CollectionView
 
-A `CollectionView` like `View` manages a portion of the DOM via a single parent DOM element
-or `el`. This view manages an ordered set of child views that are shown within the view's `el`.
-These children are most often created to match the models of a `Backbone.Collection` though a
-`CollectionView` does not require a `collection` and can manage any set of views.
+A `CollectionView` manages repeated parts of a screen: rows, cards, or any
+ordered set of child views within a root element, `el`. It creates children
+from a `collection`, or lets you add and remove child views yourself.
+
+Plain arrays work with the default [Data API](./data.api.md). Use an adapter
+when your collection needs to notify the view about changes; mutating a plain
+array does not send those notifications.
 
 `CollectionView` includes:
 - [The DOM API](./dom.api.md)

--- a/docs/marionette.mnobject.md
+++ b/docs/marionette.mnobject.md
@@ -1,7 +1,9 @@
 # Marionette.MnObject
 
-`MnObject` is Marionette's lightweight base class. It provides `initialize`,
-the Events API, a `cid`, and `extend` without requiring Backbone at runtime.
+Use `MnObject` for objects that need Marionette events and cleanup without a
+DOM element. It provides `initialize`, options, the Events API, a unique `cid`,
+and `extend`, with no Backbone dependency.
+
 `MnObject` includes:
 - [Common Marionette Functionality](./common.md)
 - [Class Events](./events.class.md#mnobject-events)
@@ -74,7 +76,8 @@ Each receives the MnObject followed by the `options` passed to `destroy`.
 While a `destroy()` call is in progress, nested calls from either lifecycle
 event return the same MnObject without restarting teardown. Calls after
 destruction also return the same MnObject without repeating the lifecycle.
-[Applications](./marionette.application.md) share this destruction contract.
+`Application` has an asynchronous destruction lifecycle; see its
+[reference](./marionette.application.md#application-lifecycle).
 `isDestroyed()` is `false` during `before:destroy` and `true` during `destroy`.
 If a `before:destroy` handler throws, its error propagates without marking the
 instance destroyed. After that failed call ends, a later top-level `destroy()`

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -1,7 +1,9 @@
 # Marionette.Region
 
-Regions provide consistent methods to manage, show and destroy
-views in your applications and views.
+A `Region` gives a changing part of the screen a place to live. Show a view,
+replace it with another, or empty the Region when that part of the interface
+is no longer needed. By default, replacing or emptying a view destroys it;
+the Region remains available for the next view.
 
 `Region` includes:
 - [Common Marionette Functionality](./common.md)

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -553,7 +553,7 @@ resolving its element, changing the DOM, or emitting empty lifecycle events.
 
 **NOTE** If the region does _not_ currently contain a View it will detach
 any HTML inside the region when emptying. If the region _does_ contain a
-View [any HTML that doesn't belong to the View will remain](./upgrade.md#changes-to-regionshow).
+View, any HTML that doesn't belong to the View will remain.
 
 ### Preserving Existing Views
 

--- a/docs/marionette.state.md
+++ b/docs/marionette.state.md
@@ -1,8 +1,9 @@
 # State sources and StateApi
 
-`Application`, `MnObject`, `View`, `CollectionView`, and `Behavior` can compose
-one state source. Marionette owns the relationship and declarative observation;
-the source owns its values and mutation API. `Region` does not compose state.
+Keep state with the part of the application that uses it. `Application`,
+`MnObject`, `View`, `CollectionView`, and `Behavior` can each hold one state
+source. Marionette manages subscriptions and the cleanup described below; the
+source provides its own values and mutation API. `Region` does not compose state.
 
 `getState()` always returns the exact source. Core never converts a plain object
 into a model, record, Proxy, or observable object.
@@ -24,7 +25,7 @@ for state has no state-source property, subscription, or cleanup registration.
 
 ## Borrowed and owned sources
 
-There are two explicit composition forms:
+Choose how the state source is created and who disposes it:
 
 - `state` is an already-created, borrowed source. Several owners may borrow the
   same source. Destroying one owner releases only its subscriptions and never

--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -1,12 +1,12 @@
 # Marionette.View
 
-A `View` is used for managing portions of the DOM via a single parent DOM element or `el`.
-It provides a consistent interface for managing the content of the `el` which is typically
-administered by serializing attached model or collection data and rendering a template
-with that data into the `View`'s `el`.
+A `View` manages one part of a screen: its content, DOM interactions, and child
+views. Give it a template and data, and it renders into a root element, `el`.
+Plain objects and native DOM methods work by default.
 
-The `View` provides event delegation for capturing and handling DOM interactions as well as
-the ability to separate concerns into smaller, managed child views.
+Use named [Regions](./marionette.region.md) to give child views a place within
+that element, and [Behaviors](./marionette.behavior.md) to share interaction
+logic across views.
 
 `View` includes:
 - [The DOM API](./dom.api.md)
@@ -317,9 +317,9 @@ render the parent first, when showing a child into a declared selector Region.
 returns `undefined` or `false`, respectively. Operations that require a Region —
 `showChildView`, `detachChildView`, `getChildView`, and `removeRegion` — throw a
 `RegionError` with code [`MN0020`](/errors/MN0020/) when the named Region does not
-exist. A value that cannot be converted to a property key is treated as an
-unknown name.
-Object-valued names are not coerced a second time while formatting the error.
+exist. Region names must be non-empty strings. Other values throw a
+`RegionError` with code [`MN0032`](/errors/MN0032/) without coercion. Child View
+operations reject invalid names before rendering the parent.
 
 ## Efficient Nested View Structures
 

--- a/docs/optional-backbone.md
+++ b/docs/optional-backbone.md
@@ -1,8 +1,9 @@
 # Optional Backbone
 
-Marionette v5 core does not import Backbone. Plain objects and arrays use the
-default [Data API](./data.api.md), while applications that use Backbone install
-the separate adapters package and select its integration explicitly:
+Use Backbone models and collections with Marionette by installing the separate
+adapters package and selecting its Backbone integration. Marionette core does
+not import Backbone; plain objects and arrays use the default
+[Data API](./data.api.md).
 
 ```sh
 npm install @marionette/adapters backbone

--- a/docs/radio.md
+++ b/docs/radio.md
@@ -1,15 +1,15 @@
 # Radio
 
-Marionette includes `Radio`, a namespaced message bus for
-communication between otherwise unrelated parts of an application. Import it
-directly from Marionette:
+Use `Radio` to send events or request values between parts of an application
+that do not need a direct reference to each other. Channels keep those messages
+organized by name. Import Radio directly from Marionette:
 
 ```javascript
 import { Radio } from 'marionette';
 ```
 
-`Backbone.Radio` is no longer a required external dependency. Do not install
-`backbone.radio` for Marionette's Radio API.
+Radio is included in `marionette`; it does not require a separate
+`backbone.radio` installation.
 
 The built-in singleton does not share channels with `backbone.radio`. Migrate
 all application imports atomically, including code that publishes or requests

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,17 +1,53 @@
 # Marionette v5 documentation
 
-Use these repository guides for the v5 pre-release:
+Start with the part of the interface you want to build. The same classes work
+together as the application grows; you do not need to learn every integration
+before showing your first View.
 
-- [Installation and package entrypoints](installation.md)
-- [Runtime isolation](runtime-isolation.md)
-- [Marionette v5 terminology](terminology.md)
+These repository guides describe the current v5 source. Published alphas may lag
+behind it.
+
+## Build something
+
+- [Install Marionette](installation.md) and show a first View.
+- [Choose a class for the job](https://github.com/marionettejs/marionette/blob/master/docs/classes.md).
+- [Build a screen with a View](https://github.com/marionettejs/marionette/blob/master/docs/marionette.view.md).
+- [Show and replace a View in a Region](https://github.com/marionettejs/marionette/blob/master/docs/marionette.region.md).
+- [Render a list with CollectionView](https://github.com/marionettejs/marionette/blob/master/docs/marionette.collectionview.md).
+- [Share interactions with Behaviors](https://github.com/marionettejs/marionette/blob/master/docs/marionette.behavior.md).
+- [Start and stop a feature with Application](https://github.com/marionettejs/marionette/blob/master/docs/marionette.application.md).
+
+## Connect the parts
+
+- [Configuration and inheritance](https://github.com/marionettejs/marionette/blob/master/docs/basics.md)
+- [Templates and rendering](https://github.com/marionettejs/marionette/blob/master/docs/view.rendering.md)
+- [DOM interactions](https://github.com/marionettejs/marionette/blob/master/docs/dom.interactions.md)
+- [Lifecycle and cleanup](https://github.com/marionettejs/marionette/blob/master/docs/view.lifecycle.md)
+- [Events](https://github.com/marionettejs/marionette/blob/master/docs/events.md) and [Radio channels](https://github.com/marionettejs/marionette/blob/master/docs/radio.md)
+- [State sources and observation](marionette.state.md)
+- [Data and observable collections](data.api.md)
+- [Routing](https://github.com/marionettejs/marionette/blob/master/docs/routing.md)
+
+## Choose your integrations
+
 - [Optional Backbone integration](optional-backbone.md)
-- [Data API](data.api.md)
-- [State sources and StateApi](marionette.state.md)
+- [The DOM API](https://github.com/marionettejs/marionette/blob/master/docs/dom.api.md)
 - [Pre-rendered DOM](dom.prerendered.md)
-- [Phase 0 performance baselines](performance-baselines.md)
+- [Runtime isolation](runtime-isolation.md)
+
+## Look up the details
+
+Some references open in GitHub while the v5 documentation site is being completed.
+
+- [Common class methods](https://github.com/marionettejs/marionette/blob/master/docs/common.md) and [utility exports](https://github.com/marionettejs/marionette/blob/master/docs/utils.md)
+- [Class events](https://github.com/marionettejs/marionette/blob/master/docs/events.class.md) and [model and collection events](https://github.com/marionettejs/marionette/blob/master/docs/events.entity.md)
+- [MnObject](https://github.com/marionettejs/marionette/blob/master/docs/marionette.mnobject.md)
+- [Terminology](terminology.md)
+- [Diagnostics](diagnostic-catalog.md)
 - [v4-to-v5 compatibility ledger](migration-from-v4.md)
 - [Upgrade guide](../upgradeGuide.md)
+- [Contributing](https://github.com/marionettejs/marionette/blob/master/CONTRIBUTING.md), [performance baselines](performance-baselines.md),
+  and the [release profile](https://github.com/marionettejs/marionette/blob/master/docs/release-profile.md)
 
 The API reference is being reconciled for stable v5 in
 [issue #147](https://github.com/marionettejs/marionette/issues/147). Until that

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,14 +1,14 @@
 # Routing in Marionette
 
-Marionette does not export a router, depend on a routing library, or require a
-routing integration protocol. Route handlers are ordinary application code and
-can coordinate Marionette objects without a Marionette-specific adapter.
+Connect your chosen router to the application's ordinary Marionette APIs. Route
+handlers can show a View or start a feature's Application. Marionette does not
+export a router, depend on a routing library, or require a routing adapter.
 
 ## Using `Backbone.Router`
 
-Applications that choose Backbone can load the
-[optional Backbone adapter](./optional-backbone.md)
-before constructing routers:
+Import Backbone directly to use `Backbone.Router`. When the application also
+uses Backbone models, collections, or state, configure the
+[optional Backbone adapter](./optional-backbone.md) as shown here:
 
 ```javascript
 import BackboneApi from '@marionette/adapters/backbone';

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -1,7 +1,7 @@
 # Runtime isolation
 
-Named imports from `marionette` belong to one default runtime. Existing applications
-can continue importing and configuring those exports directly:
+Use named imports from `marionette` when the application shares one configuration.
+These exports belong to the default runtime:
 
 ```javascript
 import { View, Radio, setRenderer } from 'marionette';

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,27 +1,81 @@
-# Marionette v5 terminology
+# Terms used in these guides
 
-Use these names consistently in public APIs, documentation, diagnostics, tests, and
-new source. Historical migration material may quote an older name when the distinction
-is necessary to explain a real migration.
+These names describe what a value does, where it belongs, and who cleans it up.
+The distinctions matter when connecting data, composing Views, or waiting for an
+Application to finish starting.
 
-| Canonical term | Permitted context | Rejected synonyms | Justified distinction |
-| --- | --- | --- | --- |
-| model, models, ordered model snapshot | Collection data and CollectionView change records | item, items | Added, removed, previous, current, identity, key, and same-key replacement all qualify model. |
-| `DataApi`; Data API | Object identifier; document or conceptual area | DataAPI, data api | `models(collection)` returns the current ordered model snapshot. |
-| `StateApi`; State API | Object identifier; document or conceptual area | StateAPI, state api | State sources are separate from model and collection data. |
-| `DomApi`; DOM API | Object identifier; document or conceptual area | DOMApi in code, Dom API in prose | Use the exact exported identifier only when naming the object. |
-| default runtime, isolated runtime, runtime classes, selected runtime | Default exports; `createMarionette()` result; classes owned by a runtime; consumer selection | root runtime, independent runtime, class family, factory result | An owner-local `createState()` result is an owned state source, not an isolated runtime. |
-| lifecycle operation, readiness hook, readiness phase, before event, completion hook | Application start, stop, restart, and destroy | readiness method, readiness handler, stop-readiness hook, destroy-readiness handler | Only readiness hooks are awaited; completion hooks and `before:*` event listeners are synchronous notifications. |
-| child View, host View, owning View | View ownership and lifecycle responsibility | item view | Name a concrete role such as row only when the example domain supplies it. |
-| child Application, parent Application, root Application, hierarchy | Application ownership | topology, composition tree | Ownership is one-way: parents locate and control children; children receive collaborators explicitly. |
-| adapter contract, default adapter, adapter override, adapter replacement, integration | Runtime customization | interchangeable API, adapter, integration, provider, mixin, or overlay labels | Selection, partial override, complete replacement, and installation are distinct operations. |
-| idempotent cleanup function | Function returned by adapter registration | disposer, unsubscribe as a noun | Internal helpers such as `disposeAll` may retain implementation-oriented names. |
-| `marionette` | Current package imports | `backbone.marionette` | The old package name is valid only in historical migration material. |
+## Models, template data, and state
 
-Public API names override prose preferences when documenting a retained contract.
-The shared `models` vocabulary does not erase shape distinctions: `DataApi.models()`
-returns the source's raw ordered model snapshot, while the default
-`serializeCollection()` result contains each model's serialized value. An override
-may return another shape; when no model is present, the template receives that result
-as `models`.
-Code that must prove a removed API may name it in a negative assertion.
+A **model** is one value displayed by a View or represented by a CollectionView's
+child View. It may be a plain object or a value from your chosen data library.
+An **ordered model snapshot** is the current sequence returned by
+`DataApi.models(collection)`. Collection change records refer to those original
+models through `added`, `removed`, `previous`, and `current`.
+
+**Serialized data** is the value prepared for a template. The default
+`serializeCollection()` returns each model's serialized value; it does not return
+the raw model snapshot. An override may return another shape. When the View has
+no model, its template receives that collection serialization result as `models`.
+See [Rendering](https://github.com/marionettejs/marionette/blob/master/docs/view.rendering.md).
+
+A **state source** holds state for an Application, MnObject, View, CollectionView,
+or Behavior. `getState()` returns the source itself, with its own values and
+methods. State is configured separately from the model or collection a View
+displays. See [State sources](./marionette.state.md).
+
+| API | What it connects |
+| --- | --- |
+| [`DataApi`](./data.api.md) | Model reads, template serialization, collection order, and data events. |
+| [`StateApi`](./marionette.state.md#stateapi) | State events and cleanup of owned state. |
+| [`DomApi`](https://github.com/marionettejs/marionette/blob/master/docs/dom.api.md) | Element creation, selection, content, and attachment. |
+
+An **adapter** implements the methods for one or more of these APIs using your
+chosen tools. Installing an integration package makes its adapter available;
+configure it on the runtime or class that will use it. A partial adapter override
+changes the supplied methods and keeps the inherited methods it omits.
+
+## Ownership and cleanup
+
+A Behavior's **host View** is the View it is attached to. A **child View** is shown
+by a Region or managed by a CollectionView. These names describe relationships;
+a particular child might be a row, a card, or another item in your interface.
+
+A **parent Application** owns its registered child Applications. Parents locate
+and control children; children receive the collaborators they need explicitly.
+The Application at the top of that hierarchy is its **root Application**.
+
+For state, **borrowed** and **owned** describe who is responsible for disposal:
+
+- A supplied or declared `state` is borrowed. Destroying an owner releases that
+  owner's subscriptions and leaves the source available to other users.
+- A `createState()` result is owned. Destroying the owner releases its
+  subscriptions, then calls the selected StateApi's optional `disposeOwned()`.
+
+A **cleanup function** releases a subscription or other resource. **Idempotent**
+means repeated calls have the same effect as one call. Marionette wraps adapter
+subscription cleanup functions to make them idempotent.
+
+## Default and isolated runtimes
+
+The named exports from `marionette` belong to the **default runtime**.
+`createMarionette()` returns an **isolated runtime** with its own classes,
+adapter and renderer configuration, and Radio channels. Choose one runtime's
+classes and setters when composing that part of the application. See
+[Runtime isolation](./runtime-isolation.md).
+
+A state source created for one owner is still an owned state source; it does not
+create another runtime. Current package imports use `marionette`; historical
+migration guides may refer to the old `backbone.marionette` package name.
+
+## Application lifecycle and readiness
+
+`start()`, `stop()`, `restart()`, and `destroy()` are Application **lifecycle
+operations**. A **readiness hook** is one of `onBeforeStart`, `onBeforeStop`, or
+`onBeforeDestroy`. Marionette awaits a Promise returned by one of those hooks
+before completing that phase.
+
+The corresponding `before:*` event listeners are synchronous notifications;
+their return values are not awaited. `onStart`, `onStop`, `onDestroy`, and their
+matching events are **completion notifications** and are not awaited either.
+See [Application lifecycle](https://github.com/marionettejs/marionette/blob/master/docs/marionette.application.md) for ordering,
+cancellation, and the readiness `AbortSignal`.

--- a/docs/view.lifecycle.md
+++ b/docs/view.lifecycle.md
@@ -177,7 +177,7 @@ rendered, child Views are best managed in the View's [`initialize`](./common.md#
 
 ### `View` Children
 
-In general the best method for adding a child view to a `View` is to use [`showChildView`](./marionette.view.md#showing-a-view)
+In general the best method for adding a child view to a `View` is to use [`showChildView`](./marionette.view.md#showing-a-child-view)
 in the [`render` event](./events.class.md#render-and-beforerender-events).
 
 View Regions are emptied on each render, so Views shown outside of the `render` event still need to be shown again

--- a/docs/view.rendering.md
+++ b/docs/view.rendering.md
@@ -1,26 +1,22 @@
 # View Template Rendering
 
-Unlike [`Backbone.View`](http://backbonejs.org/#View-template), [Marionette views](./classes.md)
-provide a customizable solution for rendering a template with data and placing the
-results in the DOM.
+Give a view a template function, then call `render()` to put its result in the
+view's element. A plain function is enough to get started; template engines
+and custom renderers can fit the same workflow.
 
 ```javascript
-import _ from 'underscore';
 import { View } from 'marionette';
 
 const MyView = View.extend({
   tagName: 'h1',
-  template: _.template('Contents')
+  template: () => 'Contents'
 });
 
 const myView = new MyView();
 myView.render();
 ```
 
-In the above example the contents of the `template` attribute will be rendered inside
-a `<h1>` tag available at `myView.el`.
-
-[Live example](https://jsfiddle.net/marionettejs/h762zjua/)
+This renders `<h1>Contents</h1>`, available at `myView.el`.
 
 ## Documentation Index
 
@@ -42,8 +38,10 @@ a `<h1>` tag available at `myView.el`.
 
 A template is a function that given data returns either an HTML string or DOM.
 [The default renderer](#rendering-the-template) in Marionette expects the template to
-return an HTML string. Marionette's dependency Underscore comes with an HTML string
-[template compiler](http://underscorejs.org/#template).
+return an HTML string. If your application uses Underscore, its
+[template compiler](http://underscorejs.org/#template) can create that function.
+Install Underscore as an application dependency to use the following example;
+Marionette does not include it.
 
 ```javascript
 import _ from 'underscore';

--- a/readme.md
+++ b/readme.md
@@ -2,18 +2,41 @@
 <p align="center">
   <img title="Marionette" alt="Marionette logo" src="https://github.com/marionettejs/marionette/raw/master/marionette-logo.png" />
 </p>
-<p align="center">Explicit Views, Regions, lifecycle, and application structure.</p>
+<p align="center">Pull a few strings. Give your interface some structure.</p>
 <p align="center">
   <a href="https://github.com/marionettejs/marionette/actions/workflows/ci.yml"><img src="https://github.com/marionettejs/marionette/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI status" /></a>
   <a href="https://www.npmjs.com/package/marionette"><img src="https://img.shields.io/npm/v/marionette.svg" alt="npm version" /></a>
 </p>
 
-Marionette is a lightweight application framework for building structured interfaces
-with deterministic lifecycle, named composition boundaries, and explicit ownership.
-It works with native DOM APIs by default. Backbone models and collections and a jQuery
-DOM adapter are available as optional integrations.
+Marionette is a JavaScript library for building interfaces whose parts have clear
+jobs. Views render content and handle interactions. Regions give those Views a place
+to appear, change, and leave. Applications bring features together and coordinate
+the work that starts and stops with them.
 
-The current v5 pre-release is under active development. Stable v5 will ship only after
+Start with native DOM APIs, plain objects, and function templates. Choose other data,
+state, and rendering tools as your application needs them.
+
+## A place for the next change
+
+Adding a detail panel, updating a list, or stopping a feature should have a
+recognizable approach:
+
+- **Build a screen** with a [View](docs/marionette.view.md).
+- **Replace part of it** through a named [Region](docs/marionette.region.md).
+- **Repeat rows or cards** with a [CollectionView](docs/marionette.collectionview.md).
+- **Share an interaction** through a [Behavior](docs/marionette.behavior.md).
+- **Start and stop a feature** with an [Application](docs/marionette.application.md).
+
+Those same patterns give an agent a place to make a change and give you something
+specific to review. Marionette v5 is being developed with agent-led work in mind:
+consistent APIs, public types, and guidance that connects a task to the code it needs.
+
+We're optimistic about agents. We've also read the diffs.
+
+## Trying v5
+
+The v5 pre-release is under active development. These guides describe the current
+source; published alphas can lag behind it. Stable v5 will ship only after
 the public correctness, agent-development, packaging, browser, and performance gates
 in the [project roadmap](ROADMAP.md) pass.
 
@@ -52,13 +75,11 @@ See [installation](docs/installation.md) for package entrypoints and supported s
 
 - [Documentation index](docs/readme.md)
 - [Installation and package entrypoints](docs/installation.md)
-- [Runtime isolation](docs/runtime-isolation.md)
-- [Optional Backbone integration](docs/optional-backbone.md)
-- [Data API](docs/data.api.md)
-- [State sources and StateApi](docs/marionette.state.md)
-- [Pre-rendered DOM](docs/dom.prerendered.md)
-- [Phase 0 performance baselines](docs/performance-baselines.md)
-- [v4-to-v5 compatibility ledger](docs/migration-from-v4.md)
+- [Classes and their jobs](docs/classes.md)
+- [Rendering and templates](docs/view.rendering.md)
+- [State and observation](docs/marionette.state.md)
+- [Data and integrations](docs/data.api.md)
+- [Lifecycle and cleanup](docs/view.lifecycle.md)
 - [Upgrade guide](upgradeGuide.md)
 
 The API reference is being reconciled for stable v5 in
@@ -68,9 +89,10 @@ work is complete, the repository's v5 guides above are canonical; the hosted
 
 ## Development
 
-Contributions should start from a focused public issue with an explicit behavior and
-runtime-cost boundary. See [CONTRIBUTING.md](CONTRIBUTING.md) and the
-[agent-ready v5 roadmap](ROADMAP.md).
+Found an awkward API, a missing example, or a bug that survives a convincing test
+suite? Bring a small reproduction. Contributions should start from a focused public
+issue that describes the intended behavior and its runtime cost. See
+[CONTRIBUTING.md](CONTRIBUTING.md) and the [v5 roadmap](ROADMAP.md).
 
 ```sh
 npm ci


### PR DESCRIPTION
Related #147

## What

- Give the main README the marketing site's purpose-first voice and restrained humor, with direct routes from application tasks to Marionette classes.
- Refresh current guide introductions and replace the terminology rules table with a practical glossary. Add a checked TypeScript installation example.
- Correct stale package, Application, Region-name, template-data and Underscore claims; identify the existing v3 starter projects as historical references.

## Why

The documentation should help readers find an approach and understand the code they are about to write. It currently foregrounds integration vocabulary and release machinery before ordinary application work. This pass brings its tone closer to the approved marketing copy while keeping API contracts precise and agent-development claims limited to the project's direction.

## Scope

README and 19 current Markdown guides, plus link corrections in the Events and View lifecycle guides. Historical upgrade guides and precise release, performance and diagnostic references remain unchanged. API references outside the existing generated-docs set link to their canonical GitHub source, so navigation works both in the repository and in the rendered guides. No library source, package configuration, website implementation or deployment setting changes.

## Deployment Impact

No forms or application redeploy is required. This changes repository and generated documentation plus the README included in a future package. No package release or site deployment is included; the existing documentation publication gate remains disabled.

## Testing

- `npm run docs:check`: 7 example-contract tests passed; 23 marked examples mapped to 13 fixture validators; 55 pages built; 56 HTML files and 506 internal links validated.
- Executed the two changed introductory JavaScript examples with Node 24/JSDOM: rendering produces `<h1>Contents</h1>`; the Behavior example shows the revised message and removes its host View.
- The installation TypeScript snippet exactly matches the example verified against the installed package with TypeScript 6.0.3 and 7.0.2 under ESM, CommonJS and bundler resolution. This checks `this.el` inside `initialize` and `this.options` inside the View method. Invalid options produce the expected errors; its rendered greeting was verified.
- Existing marked executable examples are unchanged. No runtime suite was rerun locally for prose-only changes; normal PR CI remains enabled.
- Independently reviewed the 20-file voice pass and its reference-link follow-ups for contract accuracy and unsupported claims; verified all five historical starter manifests target `backbone.marionette ~3.0.0`.
- `git diff --check` passed.
