### PR TITLE
fix(perf): scope consumer peers to measured scenarios

### DIFF
--- a/scripts/performance/bundle-size.mjs
+++ b/scripts/performance/bundle-size.mjs
@@ -356,8 +356,22 @@ export function validateConsumerBundleContract(
     .filter(peer => !peer.startsWith('@types/'))
     .filter(peer => !internalPackages.has(peer))
     .sort();
-  if (!sameStringInventory(contract.peerExternalImports, runtimePeers)) {
-    violations.push(`Consumer bundle peer externals must be ${runtimePeers.join(', ')}`);
+  if (!sameStringInventory(contract.peerExternalImports, consumerPeerExternalImports)) {
+    violations.push(`Consumer bundle peer externals must be ${consumerPeerExternalImports.join(', ')}`);
+  }
+  const missingPeers = difference(consumerPeerExternalImports, runtimePeers);
+  if (missingPeers.length) {
+    violations.push(`Consumer bundle peers are not declared runtime peers: ${missingPeers.join(', ')}`);
+  }
+  // Other integrations may add optional peers without changing the frozen v1
+  // scenarios. Exact measured graph checks still reject their runtime imports.
+  const additionalRequiredPeers = [...new Set(packageJsons.flatMap(manifest => {
+    return Object.keys(manifest.peerDependencies || {}).filter(peer =>
+      runtimePeers.includes(peer) && !consumerPeerExternalImports.includes(peer) &&
+      manifest.peerDependenciesMeta?.[peer]?.optional !== true);
+  }))].sort();
+  if (additionalRequiredPeers.length) {
+    violations.push(`Runtime peers outside consumer bundle v1 must be optional: ${additionalRequiredPeers.join(', ')}`);
   }
   if (!isDeepStrictEqual(contract.toolchain, consumerToolchain)) {
     violations.push('Consumer bundle toolchain metadata is not canonical');

--- a/test/performance/consumer-bundles.test.mjs
+++ b/test/performance/consumer-bundles.test.mjs
@@ -162,6 +162,74 @@ describe('consumer bundle measurements', () => {
     }
   });
 
+  test('keeps canonical peers declared and rejects required peers outside v1', async() => {
+    const { brotliQuality, contract, fixture, fixtureRevision, packageJson, packageJsons } = await canonicalInputs();
+    const adapters = packageJsons[1];
+    delete adapters.peerDependencies.backbone;
+    assert.match(validateConsumerBundleContract(
+      contract, fixture, packageJson, brotliQuality, fixtureRevision, packageJsons,
+    ).join('\n'), /not declared runtime peers: backbone/);
+
+    adapters.peerDependencies.backbone = '^1.4.0';
+    adapters.peerDependencies.morphdom = '^2.7.8';
+    delete adapters.peerDependenciesMeta.morphdom;
+    assert.match(validateConsumerBundleContract(
+      contract, fixture, packageJson, brotliQuality, fixtureRevision, packageJsons,
+    ).join('\n'), /outside consumer bundle v1 must be optional: morphdom/);
+
+    adapters.peerDependenciesMeta.morphdom = { optional: true };
+    packageJson.peerDependencies = { ...packageJson.peerDependencies, morphdom: '^2.7.8' };
+    assert.match(validateConsumerBundleContract(
+      contract, fixture, packageJson, brotliQuality, fixtureRevision, packageJsons,
+    ).join('\n'), /outside consumer bundle v1 must be optional: morphdom/);
+  });
+
+  test('rejects expanding frozen peer authority even for a declared optional peer', async() => {
+    const { brotliQuality, contract, fixture, fixtureRevision, packageJson, packageJsons } = await canonicalInputs();
+    packageJsons[1].peerDependencies.morphdom = '^2.7.8';
+    packageJsons[1].peerDependenciesMeta.morphdom = { optional: true };
+    contract.peerExternalImports.push('morphdom');
+
+    assert.match(validateConsumerBundleContract(
+      contract, fixture, packageJson, brotliQuality, fixtureRevision, packageJsons,
+    ).join('\n'), /peer externals must be backbone, jquery/);
+  });
+
+  test('allows unrelated optional peers only while frozen scenarios do not import them', async() => {
+    const inputs = await canonicalInputs();
+    inputs.packageJsons[1].peerDependencies.morphdom = '^2.7.8';
+    inputs.packageJsons[1].peerDependenciesMeta.morphdom = { optional: true };
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'marionette-consumer-peer-'));
+    try {
+      await Promise.all([
+        mkdir(join(fixtureRoot, 'benchmarks/consumer-bundles'), { recursive: true }),
+        mkdir(join(fixtureRoot, 'packages/adapters'), { recursive: true }),
+        cp(join(root, 'dist'), join(fixtureRoot, 'dist'), { recursive: true }),
+        writeFile(join(fixtureRoot, 'package.json'), JSON.stringify(inputs.packageJson)),
+      ]);
+      await Promise.all([
+        cp(join(root, 'packages/adapters/dist'), join(fixtureRoot, 'packages/adapters/dist'), { recursive: true }),
+        cp(join(root, 'benchmarks/consumer-bundles/v1'), join(fixtureRoot, 'benchmarks/consumer-bundles/v1'), { recursive: true }),
+        writeFile(join(fixtureRoot, 'packages/adapters/package.json'), JSON.stringify(inputs.packageJsons[1])),
+      ]);
+
+      const options = { root: fixtureRoot, ...measurementOptions(inputs) };
+      const unusedPeer = await measureConsumerBundles(options);
+      assert.equal(unusedPeer.artifacts.length, 18);
+      assert.deepEqual(unusedPeer.peerExternalImports, ['backbone', 'jquery']);
+      assert.deepEqual(unusedPeer.violations, []);
+
+      const jqueryPath = join(fixtureRoot, 'packages/adapters/dist/dom/jquery.js');
+      await writeFile(jqueryPath, `import 'morphdom';\n${await readFile(jqueryPath, 'utf8')}`);
+      const importedPeer = await measureConsumerBundles(options);
+      assert.ok(importedPeer.artifacts.some(({ externalImports }) => externalImports.includes('morphdom')));
+      assert.match(importedPeer.violations.join('\n'), /external imports differ from fixture metadata/);
+      assert.match(importedPeer.violations.join('\n'), /non-peer external imports: morphdom/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   test('reports deterministic exact-base deltas without enforcing a ceiling', async() => {
     const inputs = await canonicalInputs();
     const base = consumerReport(inputs);


### PR DESCRIPTION
Related #127

## What
- Keep the frozen v1 consumer benchmark external allowlist at Backbone and jQuery while permitting unrelated optional peers in package manifests.
- Reject missing canonical peers, extra required peers, modified v1 authority, and renderer imports leaking into existing benchmark scenarios.

## Why
Adding a separately imported optional renderer currently invalidates all 18 existing consumer measurements solely because its peer is declared. Unused optional integrations must not change the measured scenarios or their authority.

## Scope
The consumer benchmark validation and its regression tests. No production runtime, frozen fixture, baseline, ceiling, compiler, or reporting format changes.

## Deployment Impact
No application or form redeployment. No package publication or release tags. This prepares validation for optional renderer subpaths.

## Testing
- `node --test test/performance/consumer-bundles.test.mjs`: 11 passing tests, including a real injected Morphdom import rejected by measured graph checks.
- Targeted ESLint and `git diff --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes consumer peer validation to the frozen v1 benchmark scenarios so unused optional integrations no longer invalidate all 18 measurements. Previously, declaring any additional peer dependency failed every consumer bundle check; now only the canonical `backbone` and `jquery` peers are enforced, while unrelated optional peers are allowed as long as they aren't imported into measured scenarios.

**Validation**
- Rejects missing canonical peers, extra required peers, modified v1 peer authority, and renderer imports in benchmark scenarios.
- Adds regression tests covering optional peer declarations and rejected imports.

<sup>Written for commit a503d2d22cb51e2783f172dd50be42098fc4a29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consumer bundle validation to consistently enforce the supported peer-dependency contract.
  - Optional peer dependencies can now be added without affecting established bundle scenarios.
  - Required dependencies outside the supported contract are now flagged, including undeclared or unexpectedly imported dependencies.

- **Tests**
  - Added coverage for missing required dependencies, unsupported dependencies, optional peers, metadata mismatches, and unexpected external imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->