### PR TITLE
feat(application): configure instances in preinitialize

### DIFF
--- a/docs/marionette.application.md
+++ b/docs/marionette.application.md
@@ -38,6 +38,30 @@ import { Application } from 'marionette';
 const myApplication = new Application({ ... });
 ```
 
+### Initialization hooks
+
+`preinitialize(options)` runs after `options` and `cid` are assigned, before
+Marionette sets up the Region, Radio, and State. Use it to prepare instance
+configuration those steps depend on. `initialize(options)` runs after that
+setup, before State event subscriptions are connected. Owned State is still
+created lazily when `getState()` is first called.
+
+```javascript
+const FeatureApplication = Application.extend({
+  preinitialize(options) {
+    this.channelName = options.featureName;
+    this.region = { el: options.element };
+  },
+  initialize() {
+    // The configured Region and Radio channel are now available.
+  }
+});
+```
+
+Both hooks receive the original constructor arguments and run synchronously;
+returned Promises are not awaited. Use `onBeforeStart` for asynchronous startup
+readiness.
+
 Constructor errors propagate to the caller. Marionette does not undo partially
 completed initialization or automatically release resources from a constructor
 that throws. Application's asynchronous lifecycle has its own cancellation and

--- a/src/modules/application.ts
+++ b/src/modules/application.ts
@@ -49,6 +49,7 @@ export interface ApplicationInstance<Options extends object = object, State = ob
   state?: unknown;
   State: Partial<StateApi<never>>;
   Radio: RadioApi;
+  preinitialize(options?: Options): void;
   initialize(options?: Options): void;
   createState(options?: Options): unknown;
   getState(): State;
@@ -165,6 +166,7 @@ const Application = function(this: ApplicationInternals, options?: ApplicationOp
   this._setOptions(options, ClassOptions);
   this.cid = uniqueId(this.cidPrefix);
 
+  (this.preinitialize as Function).apply(this, arguments);
   this._initRegion();
   this._initRadio();
   this._initState(options);
@@ -528,6 +530,8 @@ export default /* @__PURE__ */ ((methods: object) => {
   Object.defineProperty(Application.prototype, runtimeId, { value: defaultRuntimeId });
   return Application as unknown as ApplicationConstructor;
 })({
+  preinitialize() {},
+
   cidPrefix: 'mna',
 
   _lifecycleState: STOPPED,

--- a/test/types/application.cts
+++ b/test/types/application.cts
@@ -4,6 +4,7 @@ import Region, {type RegionInstance} from '../tmp/typed-core/src/modules/region.
 import type {SupportedView} from '../tmp/typed-core/src/modules/common/view.js';
 
 const Child = Application.extend({
+  preinitialize(options: {label: string}) { this.channelName = options.label; },
   initialize(options: {label: string}) { this.options.label.toUpperCase(); },
   createState() {return {ready: false};},
   async onBeforeStart(application: ApplicationInstance<object, unknown>, options: unknown, context: LifecycleContext) {
@@ -78,9 +79,18 @@ root.Radio.channel('shared').on('change', (value: number) => value.toFixed());
 root.getChannel().request('status');
 
 class NativeApplication extends Application {
+  preinitialize(options?: {region?: string}) { super.preinitialize(options); }
   async onBeforeStart(application: this, options: unknown, {signal}: LifecycleContext) {
     if (!signal.aborted) {application.isRunning();}
   }
   async start(options?: unknown) { return super.start(options); }
 }
 const native: Promise<boolean> = new NativeApplication().start();
+
+const configuredEarly: void = child.preinitialize({label: 'Editor'});
+// @ts-expect-error The preinitialize override retains its declared option type.
+child.preinitialize({label: false});
+declare const applicationInstance: ApplicationInstance<{label: string}>;
+applicationInstance.preinitialize({label: 'Editor'});
+// @ts-expect-error The public instance hook uses the Application option type.
+applicationInstance.preinitialize({label: 1});

--- a/test/types/application.mts
+++ b/test/types/application.mts
@@ -4,6 +4,7 @@ import Region, {type RegionInstance} from '../tmp/typed-core/src/modules/region.
 import type {SupportedView} from '../tmp/typed-core/src/modules/common/view.js';
 
 const Child = Application.extend({
+  preinitialize(options: {label: string}) { this.channelName = options.label; },
   initialize(options: {label: string}) { this.options.label.toUpperCase(); },
   createState() {return {ready: false};},
   async onBeforeStart(application: ApplicationInstance<object, unknown>, options: unknown, context: LifecycleContext) {
@@ -78,9 +79,18 @@ root.Radio.channel('shared').on('change', (value: number) => value.toFixed());
 root.getChannel().request('status');
 
 class NativeApplication extends Application {
+  preinitialize(options?: {region?: string}) { super.preinitialize(options); }
   async onBeforeStart(application: this, options: unknown, {signal}: LifecycleContext) {
     if (!signal.aborted) {application.isRunning();}
   }
   async start(options?: unknown) { return super.start(options); }
 }
 const native: Promise<boolean> = new NativeApplication().start();
+
+const configuredEarly: void = child.preinitialize({label: 'Editor'});
+// @ts-expect-error The preinitialize override retains its declared option type.
+child.preinitialize({label: false});
+declare const applicationInstance: ApplicationInstance<{label: string}>;
+applicationInstance.preinitialize({label: 'Editor'});
+// @ts-expect-error The public instance hook uses the Application option type.
+applicationInstance.preinitialize({label: 1});

--- a/test/unit/application.spec.js
+++ b/test/unit/application.spec.js
@@ -6,6 +6,50 @@ import View from '../../src/modules/view';
 
 describe('Marionette Application', function() {
 
+  describe('#preinitialize', function() {
+    it('prepares instance configuration before Region, Radio, and State setup', async function() {
+      const options = { el: document.createElement('main'), label: 'Editor' };
+      const ConfiguredApplication = Application.extend({
+        preinitialize(receivedOptions) {
+          expect(receivedOptions).to.equal(options);
+          expect(this.options.label).to.equal('Editor');
+          expect(this.cid).to.be.a('string');
+          expect(this.getRegion()).to.be.undefined;
+          expect(this.getChannel()).to.be.undefined;
+          this.region = { el: receivedOptions.el };
+          this.channelName = this.cid;
+          this.state = { label: receivedOptions.label };
+        },
+        initialize() {
+          expect(this.getRegion().el).to.equal(options.el);
+          expect(this.getChannel().channelName).to.equal(this.cid);
+          expect(this.getState()).to.equal(this.state);
+          expect(this.getState().label).to.equal('Editor');
+        }
+      });
+      const app = new ConfiguredApplication(options);
+      await app.destroy();
+    });
+  });
+
+  it('propagates a preinitialize error before setting up instance services', function() {
+    const error = new Error('early configuration failed');
+    const initializeRegion = this.sinon.spy();
+    const initializeRadio = this.sinon.spy();
+    const initializeState = this.sinon.spy();
+    const BrokenApplication = Application.extend({
+      preinitialize() { throw error; },
+      _initRegion: initializeRegion,
+      _initRadio: initializeRadio,
+      _initState: initializeState
+    });
+
+    expect(() => new BrokenApplication()).to.throw(error);
+    expect(initializeRegion).not.to.have.been.called;
+    expect(initializeRadio).not.to.have.been.called;
+    expect(initializeState).not.to.have.been.called;
+  });
+
   describe('#initialize', () => {
     describe('when instantiating an app with specified options', function() {
       let app;
@@ -55,6 +99,9 @@ describe('Marionette Application', function() {
           _setOptions(...args) {
             calls.push(['setOptions', this, args]);
           },
+          preinitialize(...args) {
+            calls.push(['preinitialize', this, args]);
+          },
           _initRegion(...args) {
             calls.push(['initRegion', this, args]);
           },
@@ -84,6 +131,7 @@ describe('Marionette Application', function() {
             'stateEvents'
           ]]],
           ['cidPrefix', 'default'],
+          ['preinitialize', orderedApp, [options, 'extra']],
           ['initRegion', orderedApp, []],
           ['initRadio', orderedApp, []],
           ['initState', orderedApp, [options]],

--- a/test/unit/object-application-composition.spec.js
+++ b/test/unit/object-application-composition.spec.js
@@ -34,6 +34,7 @@ describe('Object and Application prototype composition', function() {
   it('preserves own method order, identities, descriptors, and constructors', function() {
     const objectFinalKeys = ['cidPrefix'];
     const applicationFinalKeys = [
+      'preinitialize',
       'cidPrefix',
       '_lifecycleState',
       'isRunning',


### PR DESCRIPTION
## What
Add synchronous `Application#preinitialize`, after options and cid assignment and before Region, Radio, and State setup. Add runtime order tests, public typing tests, and documentation.

## Why
Applications need the same early configuration opportunity as Views, without replacing their constructor.

## Scope
Application construction, declarations, and documentation. Async startup and lazy owned-State creation remain unchanged.

## Agent-development failure addressed
Instance-dependent configuration can be expressed through a named hook instead of constructor overrides.

## Public behavior contract
`preinitialize` receives the original constructor arguments and receiver. `initialize` still runs after setup, before State event subscriptions. Both hooks run synchronously; returned promises are not awaited.

## Runtime cost
One synchronous hook invocation per Application construction. No additional subscriptions or lifecycle state. No timing claim.

## Deployment Impact
Library source changes only; no forms or application bundles need redeployment as part of this PR. Available to consumers in a future package release; no publication here.

## Testing
- `npm run check:types`
- `npm run test:types`
- Application, composition, and State-owner Vitest suites.
- `npm run docs:check` on the combined follow-up documentation: 55 pages, 506 links, 23 executable examples.
- Combined follow-up build and coverage passed; CI verifies the isolated PR.

## Package and browser impact
Adds a public Application hook. No new entry points, dependencies, or browser APIs.

## Rollback or deprecation
Revert the hook and its documentation if needed; no compatibility path introduced.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synchronous `preinitialize` hook to `Application` that runs after options and `cid` are assigned but before Region, Radio, and State setup. This gives Applications the same early configuration opportunity that Views already have, without needing constructor overrides. `initialize` still runs after setup; both hooks receive the original constructor arguments and run synchronously (returned promises are not awaited).

<sup>Written for commit 661af7144b17218234ec264415b4d0700578a60a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

