### PR TITLE
fix(backbone): leave merged model rendering to child events

### DIFF
--- a/docs/data.api.md
+++ b/docs/data.api.md
@@ -93,6 +93,12 @@ every same-key replacement View before removing any existing child. A
 replacement-construction or rendering failure propagates to the caller. Core
 does not undo a partial update or promise recovery on the next notification.
 
+An in-place `updated` entry requests a child render. Adapters for mutable models
+with their own change events can leave `updated` empty and let child
+`modelEvents` handle rendering. The Backbone adapter follows this approach:
+merges still update collection order and filtering, without rendering children
+again after their model events have run.
+
 An immutable same-key replacement belongs only in `updated`, not in `removed`
 and `added`. Replacing a model with one that has a different stable key is a
 removal plus an addition; changing the key of a retained model is invalid. The

--- a/docs/optional-backbone.md
+++ b/docs/optional-backbone.md
@@ -47,6 +47,12 @@ Backbone's `sort`, `reset`, and `update` payloads are translated to the neutral
 records documented by [`DataApi.observeCollection()`](./data.api.md#collection-observations).
 Those Backbone-specific shapes do not enter Marionette core.
 
+As in Marionette v4, child `modelEvents` control rendering after model changes.
+For example, `modelEvents: { change: 'render' }` renders a child when its model
+changes. Collection merges still sort and filter children, but do not request
+another render. Backbone also reports unchanged models as merged, so treating
+every merge as a render request would redraw unchanged children.
+
 Sort handling follows Marionette v4: the adapter skips `sort` events carrying
 `add`, `remove`, or `merge` flags and handles those mutations through `update`.
 Explicit `collection.sort()` calls still notify the View. The observer does not

--- a/packages/adapters/src/data/backbone.ts
+++ b/packages/adapters/src/data/backbone.ts
@@ -64,7 +64,8 @@ const BackboneApi = {
         kind: 'update',
         added: changes.added,
         removed: changes.removed,
-        updated: changes.merged.map(model => ({ previous: model, current: model }))
+        // Merges retain the model; child model events own its rendering, as in v4.
+        updated: []
       });
     };
     const events = {

--- a/test/unit/backbone-adapter.spec.js
+++ b/test/unit/backbone-adapter.spec.js
@@ -187,6 +187,54 @@ describe('Backbone adapter', function() {
     view.destroy();
   });
 
+  it('leaves merged model rendering to child model events', function() {
+    const runtime = createMarionette();
+    runtime.setDataApi(BackboneApi);
+    const collection = new Backbone.Collection([{ id: 1, title: 'before' }, { id: 2, title: 'same' }]);
+    const rendered = [];
+    const ChildView = runtime.View.extend({
+      template: ({ title }) => `<span>${title}</span>`,
+      modelEvents: { change: 'render' },
+      onRender() { rendered.push(this.model.id); }
+    });
+    const view = new runtime.CollectionView({ collection, childView: ChildView }).render();
+    const unchangedContents = view.children.findByIndex(1).el.firstChild;
+    rendered.length = 0;
+
+    collection.set([{ id: 1, title: 'after' }, { id: 2, title: 'same' }]);
+
+    expect(rendered).to.deep.equal([1]);
+    expect(view.el.textContent).to.equal('aftersame');
+    expect(view.children.findByIndex(1).el.firstChild).to.equal(unchangedContents);
+    view.destroy();
+  });
+
+  it('sorts and filters merged models without rendering retained children', function() {
+    const runtime = createMarionette();
+    runtime.setDataApi(BackboneApi);
+    const collection = new Backbone.Collection([
+      { id: 1, rank: 1, visible: true },
+      { id: 2, rank: 2, visible: true },
+      { id: 3, rank: 3, visible: true }
+    ], { comparator: 'rank' });
+    const onRender = this.sinon.spy();
+    const ChildView = runtime.View.extend({ template: ({ id }) => String(id), onRender });
+    const view = new runtime.CollectionView({
+      collection,
+      childView: ChildView,
+      viewFilter: child => child.model.get('visible')
+    }).render();
+    const first = view.children.findByModel(collection.get(1));
+    onRender.resetHistory();
+
+    collection.set([{ id: 1, rank: 4 }, { id: 2, visible: false }], { remove: false });
+
+    expect(view.el.textContent).to.equal('31');
+    expect(view.children.findByModel(collection.get(1))).to.equal(first);
+    expect(onRender).not.to.have.been.called;
+    view.destroy();
+  });
+
   it('configures only the selected runtime', function() {
     const first = createMarionette();
     const second = createMarionette();

--- a/test/unit/runtime/backbone-api.spec.js
+++ b/test/unit/runtime/backbone-api.spec.js
@@ -81,7 +81,7 @@ describe('BackboneApi', function() {
       kind: 'update',
       added: [added],
       removed: [removed],
-      updated: [{ previous: updated, current: updated }]
+      updated: []
     });
 
     cleanup();
@@ -128,7 +128,7 @@ describe('BackboneApi', function() {
     expect(callback).to.have.been.calledTwice;
     expect(callback.secondCall.args[0]).to.deep.equal({
       kind: 'update', added: [], removed: [],
-      updated: [{ previous: collection.get(1), current: collection.get(1) }]
+      updated: []
     });
     expect(collection.pluck('id')).to.deep.equal([1, 3, 2]);
 


### PR DESCRIPTION
Related #376

## What
- Leave Backbone merged-model rendering to child model events, matching Marionette v4.
- Continue collection sorting and filtering after merges without invalidating retained children.
- Document the distinction between model events and explicit DataApi render requests.

## Why
A collection.set() merging one changed model and one unchanged model rendered children [1, 1, 2] when the children subscribed to change:render. It now renders only [1]. Backbone reports unchanged models as merged, so forwarding every merge as an in-place render request also replaced DOM unnecessarily.

## Scope
Backbone adapter observation and its tests/documentation. Core DataApi explicit invalidation and immutable replacement behavior remain intact.

## Deployment Impact
No forms require redeployment. This changes the optional Backbone adapter in the next package build; no package publication is part of this PR.

## Testing
- Added two regressions, observed both fail before the fix, then pass afterward.
- npx vitest run test/unit/backbone-adapter.spec.js test/unit/runtime/backbone-api.spec.js test/unit/collection-view test/unit/data-api-integration.spec.js --reporter=dot: 396 passed.
- npm run coverage: 1,958 unit tests and 19 agent contract tests passed, coverage requirements passed.
- npm run build: package builds and packed ESM/CommonJS TypeScript consumers passed.
- npm run docs:check: executable examples, 55 documentation pages and 506 internal links passed.
- Targeted ESLint and git diff --check passed.
- Render counts prove the removed work; no browser timing claim is made for this adapter-only change. The existing native/morphdom/lit-html/jQuery benchmark fixtures use @marionette/data, not the Backbone adapter.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Backbone adapter so merged models no longer trigger child re-renders, matching Marionette v4. A `collection.set()` merging one changed and one unchanged model previously rendered children [1, 1, 2]; it now renders only [1] since rendering is left to child `modelEvents`.

**Behavior change**
- Merges still update collection order and filtering without invalidating retained children.
- Unchanged models are no longer redrawn because Backbone reports them as merged too.
- Only the optional Backbone adapter changes; core DataApi explicit invalidation and immutable replacement behavior stay intact.
- Relates to #376.

<sup>Written for commit f0f5d3665649148dbcc9b93338c9821424ec4bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection updates so only models with actual data changes re-render.
  * Preserved existing content for unchanged items, reducing unnecessary visual refreshes.
  * Collection sorting and filtering now update correctly without re-rendering retained items.
  * Removed items are correctly dropped from collection views during updates.

* **Documentation**
  * Clarified how model changes and collection updates control child rendering in the Data API and Backbone integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->