### PR TITLE
fix(collection-view): retain ownership of hidden children

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -860,6 +860,9 @@ and sorting and may be difficult to manage in complex situations. Use with care.
 `CollectionView` throws [`MN0003`](/errors/MN0003/). Detach the View from its
 current owner before transferring it.
 
+Filtering a child out or adding it with `preventRender` still leaves it managed
+by that CollectionView. Use `detachChildView()` to transfer it to another owner.
+
 #### `preventRender` option
 
 If you wish to add a child view to the children without the collectionview rendering

--- a/docs/marionette.region.md
+++ b/docs/marionette.region.md
@@ -474,7 +474,8 @@ For more information on `showChildView` and `getChildView`, see the
 
 **Errors**
 - An error will be thrown if the value is not a Marionette View or is destroyed.
-- An error will be thrown if the view is already shown in a Region or CollectionView.
+- An error will be thrown if the view is already managed by a Region or CollectionView,
+  including a filtered or deferred CollectionView child. Detach it from that owner first.
 
 ### Checking whether a region is showing a view
 

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -642,6 +642,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
   },
 
   _setupChildView(this: CollectionViewInternals, view: CollectionChild) {
+    view._parent = this;
     // We need to listen for if a view is destroyed in a way other
     // than through the CollectionView.
     // If this happens we need to remove the reference to the view
@@ -1081,11 +1082,11 @@ Object.assign(CollectionView.prototype, ViewMixin, {
       return view;
     }
 
-    if (view._isShown) {
+    if (view._parent) {
       throw new MarionetteError({
         code: 'MN0003',
         name: classErrorName,
-        message: 'View is already shown in a Region or CollectionView',
+        message: 'View is already managed by a Region or CollectionView',
         url: 'marionette.region.html#showing-a-view'
       });
     }
@@ -1154,6 +1155,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     view.off('destroy', this.removeChildView, this);
     shouldDetach ? this._detachChildView(view) : this._destroyChildView(view);
     this.stopListening(view);
+    delete view._parent;
   },
 
   _destroyChildView(this: CollectionViewInternals, view: CollectionChild) {

--- a/src/modules/common/view.ts
+++ b/src/modules/common/view.ts
@@ -15,6 +15,7 @@ export interface ViewLifecycle {
   _isDestroying?: boolean;
   _isAttached?: boolean;
   _isShown?: boolean;
+  _parent?: object;
   _disableDetachEvents?: boolean;
   monitorViewEvents?: boolean;
   _areViewEventsMonitored?: boolean;

--- a/src/modules/region.ts
+++ b/src/modules/region.ts
@@ -178,11 +178,11 @@ Object.assign(Region.prototype, CommonMixin, {
 
     if (view === this.currentView) { return this; }
 
-    if (view._isShown) {
+    if (view._parent) {
       throw new MarionetteError({
         code: 'MN0003',
         name: classErrorName,
-        message: 'View is already shown in a Region or CollectionView',
+        message: 'View is already managed by a Region or CollectionView',
         url: 'marionette.region.html#showing-a-view'
       });
     }
@@ -253,6 +253,7 @@ Object.assign(Region.prototype, CommonMixin, {
   },
 
   _setupChildView(this: RegionInternals, view: SupportedView) {
+    view._parent = this;
     this._proxyChildViewEvents(view);
 
     // We need to listen for if a view is destroyed in a way other than through the region.
@@ -414,6 +415,7 @@ Object.assign(Region.prototype, CommonMixin, {
       this._stopChildViewEvents(view);
     }
 
+    delete view._parent;
     this.triggerMethod('empty', this, view);
   },
 

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -489,6 +489,46 @@ describe('CollectionView Children', function() {
 
     });
 
+    [false, true].forEach(deferred => {
+      it(`keeps ${deferred ? 'deferred' : 'filtered'} children owned until explicitly detached`, function() {
+        const owner = new CollectionView({ viewFilter: () => false }).render();
+        const region = new Region({ el: document.createElement('div') });
+        const child = new View({ template: _.noop });
+        owner.addChildView(child, { preventRender: deferred });
+
+        expect(() => myCollectionView.addChildView(child)).to.throw()
+          .with.property('code', 'MN0003');
+        expect(() => owner.addChildView(child)).to.throw()
+          .with.property('code', 'MN0003');
+        expect(() => region.show(child)).to.throw()
+          .with.property('code', 'MN0003');
+        expect(owner._children.hasView(child)).to.be.true;
+        expect(myCollectionView._children.hasView(child)).to.be.false;
+        expect(region.hasView()).to.be.false;
+
+        owner.detachChildView(child);
+        region.show(child);
+        owner.destroy();
+        expect(child.isDestroyed()).to.be.false;
+        region.detachView();
+        myCollectionView.addChildView(child);
+        expect(myCollectionView.children.hasView(child)).to.be.true;
+        region.destroy();
+        myCollectionView.destroy();
+      });
+
+      it(`destroys and releases an owned ${deferred ? 'deferred' : 'filtered'} child`, function() {
+        const owner = new CollectionView({ viewFilter: () => false }).render();
+        const child = new View({ template: _.noop });
+        owner.addChildView(child, { preventRender: deferred });
+
+        owner.destroy();
+
+        expect(child.isDestroyed()).to.be.true;
+        expect(child).not.to.have.property('_parent');
+      });
+    });
+
     describe('when adding detached view', function() {
       let anotherCollectionView;
       let region;


### PR DESCRIPTION
Related #376

## What
- Track a child's managing Region or CollectionView separately from its visibility.
- Reject registering an already owned child, including filtered/deferred children and duplicate registration in the same CollectionView.
- Release ownership when removal, destruction or explicit detachment completes.

## Why
The existing MN0003 guard used _isShown. Filtering a child out or adding it with preventRender left that flag false, allowing two owners to retain the same View. Destroying either owner could then destroy the other's child. The same existing guard now checks a private owner reference; no render-loop guard is added.

## Scope
Shared Region/CollectionView child ownership, matching the documented single-owner contract. Filtering still retains ownership; detachChildView/detachView transfer a live child after the method returns. DOM visibility and lifecycle monitoring behavior are unchanged.

## Deployment Impact
No forms require redeployment. This affects the next core library build; this PR does not publish a package or deploy an application.

## Testing
- Filtered/deferred ownership regressions failed before the change and passed afterward, including cross-owner and same-owner rejection.
- Explicit CollectionView → Region → CollectionView transfer remains live; bulk destruction releases filtered/deferred children.
- npm run coverage: 1,960 unit tests, 100% required coverage, and 19 agent contract tests passed.
- npm run build: package/declaration builds and packed ESM/CommonJS consumer tests passed.
- npm run docs:check, targeted ESLint and git diff --check passed.
- node test/browser/collection-removal-survivors.mjs: all 15 configurations passed in Chromium, Firefox and WebKit.
- A deterministic external audit ran 2,000 mutation steps over four comparator configurations, checking DOM/order, retained identities, replacement/destruction and observer cleanup; passed.
- Bounded Claude review found no missing cleanup path. Added its requested destruction regression without speculative lifecycle defenses.

### Matched performance check
Standard js-framework-benchmark native fixture; same build tool and template, headless Chrome 152, renderer accessibility explicitly disabled, monitorViewEvents enabled. Base/candidate/candidate/base order; seven samples per operation per block, all 112 samples retained. These are AX-disabled measurements, not an accessibility-enabled performance claim.

| Operation | Base median ms | Candidate median ms | Base script ms | Candidate script ms |
| --- | ---: | ---: | ---: | ---: |
| Create 1k | 44.45 | 44.25 | 17.25 | 16.90 |
| Partial update | 40.65 | 41.20 | 9.50 | 9.65 |
| Remove | 17.90 | 18.05 | 1.55 | 1.50 |
| Clear | 30.60 | 30.55 | 27.85 | 27.80 |

No meaningful create/remove/clear increase appeared in this run. Partial update does not execute the changed ownership transitions. Frozen package inputs, bundle hashes, patch, all raw samples/traces and reproduction scripts are retained locally in the 2026-09-08 marionette-collectionview-audit artifacts. A short focused unit check overlapped the first block's startup; no builds or coverage jobs ran alongside the timed blocks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CollectionView child ownership so filtered or `preventRender` children stay bound to their owner. Previously the MN0003 guard checked `_isShown`, which stayed false for hidden children, letting a second Region or CollectionView claim the same view and destroy it during teardown.

**Changes**
- The guard now checks a private `_parent` reference set on add and cleared on removal, destruction, or explicit detachment.
- Registering an already owned child throws MN0003, including duplicate registration in the same CollectionView.
- `detachChildView()` and `detachView()` transfer a live child after the method returns; filtering still retains ownership.
- Adds regression tests covering filtered/deferred children, cross-owner rejection, and bulk destruction release.
- Docs now describe the single-owner contract for hidden children.

**Testing**
- 1,960 unit tests at 100% required coverage and 19 agent contract tests passed.
- Package/declaration builds, packed ESM/CommonJS consumer tests, and all 15 browser configurations passed.
- A matched js-framework-benchmark run showed no meaningful create/remove/clear regression.
- A 2,000-step mutation audit found no missing cleanup paths.

Related #376.

<sup>Written for commit 5e058ee8ad1daf999b65b8537a6f789a57815988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

