### PR TITLE
fix(collection-view): sort each notification from its snapshot

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -958,6 +958,17 @@ By default the `CollectionView` will maintain a sorted collection's order
 in the DOM. This behavior can be disabled by specifying `{sortWithCollection: false}`
 on initialize.
 
+Default source ordering uses each notification's captured snapshot. A nested
+notification waits for the current sort, filter, and render pass to finish.
+Calling `sort()` outside a collection notification reads the current source
+after `before:sort`. With the default comparator, manually added children whose
+models are absent from the source stay before the source children.
+
+Custom comparators still determine their own order and data reads. With
+`sortWithCollection` enabled, source order breaks ties and manually added
+children follow source children on ties. With it disabled, ties retain the
+existing child order.
+
 ### Defining the `viewComparator`
 
 `CollectionView` allows for a custom `viewComparator` option if you want your

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -190,9 +190,9 @@ type CollectionViewInternals = CollectionViewInstance & ViewMixinHost & {
   _initChildViewStorage(): void;
   _initialEvents(): void;
   _onCollectionChange(change: unknown): void;
-  _onCollectionReorder(snapshot: Snapshot): void;
+  _onCollectionReorder(): void;
   _onCollectionReset(snapshot: Snapshot): void;
-  _onCollectionUpdate(changes: Update, snapshot: Snapshot): void;
+  _onCollectionUpdate(changes: Update): void;
   _setChildrenFromSnapshot(snapshot: Snapshot): void;
   _removeChild(view: CollectionChild): void;
   _addChildModels(models: unknown[]): CollectionChild[];
@@ -444,21 +444,20 @@ Object.assign(CollectionView.prototype, ViewMixin, {
       return;
     }
 
-    const queue: Notification[] = this._collectionChangeQueue = [];
-    let pending: Notification | undefined = notification;
+    const queue: Notification[] = this._collectionChangeQueue = [notification];
 
     try {
-      while (pending) {
-        const { change: pendingChange, snapshot } = pending;
+      while (queue.length) {
+        const { change: pendingChange, snapshot } = queue[0];
         if (pendingChange.kind === 'reorder') {
-          this._onCollectionReorder(snapshot);
+          this._onCollectionReorder();
         } else if (pendingChange.kind === 'reset') {
           this._onCollectionReset(snapshot);
         } else {
-          this._onCollectionUpdate(pendingChange, snapshot);
+          this._onCollectionUpdate(pendingChange);
         }
         this._collectionSnapshot = snapshot;
-        pending = queue.shift();
+        queue.shift();
       }
     } finally {
       delete this._collectionChangeQueue;
@@ -466,16 +465,14 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     }
   },
 
-  // Internal method. This checks for any changes in the order of the collection.
-  // If the index of any view doesn't match, it will re-sort.
-  _onCollectionReorder(this: CollectionViewInternals, snapshot: Snapshot) {
+  // Follow source reorders unless the CollectionView manages its own order.
+  _onCollectionReorder(this: CollectionViewInternals) {
     if (this._isDestroying || this._isDestroyed) { return; }
 
     if (!this.sortWithCollection) {
       return;
     }
 
-    this._setChildrenFromSnapshot(snapshot);
     this.sort();
   },
 
@@ -489,8 +486,8 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     this.sort();
   },
 
-  // Handle collection update model additions and  removals
-  _onCollectionUpdate(this: CollectionViewInternals, changes: Update, snapshot: Snapshot) {
+  // Handle collection additions, removals, and updated models.
+  _onCollectionUpdate(this: CollectionViewInternals, changes: Update) {
     if (this._isDestroying || this._isDestroyed) { return; }
 
     const updateEntries = changes.updated.map(({ key, previous, current }) => {
@@ -533,9 +530,6 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     }
 
     this._detachChildren(removedViews);
-    if (this.sortWithCollection) {
-      this._setChildrenFromSnapshot(snapshot);
-    }
     for (const view of updatedViews) { view._isRendered = false; }
     this.sort();
 
@@ -714,14 +708,25 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     if (!this._children.length) { return; }
 
     let viewComparator = this.getComparator();
+    const notification = this._collectionChangeQueue?.[0];
+
+    if (viewComparator) { this.triggerMethod('before:sort', this); }
+
+    // Source order supplies custom-comparator ties, or the final order when
+    // the comparator is disabled. Reset children are already in source order.
+    if (notification && this.sortWithCollection && viewComparator !== defaultViewComparator &&
+        notification.change.kind !== 'reset') {
+      this._setChildrenFromSnapshot(notification.snapshot);
+    }
 
     if (!viewComparator) { return; }
 
-    this.triggerMethod('before:sort', this);
-
     if (viewComparator === defaultViewComparator && this._children.length) {
       const indexByModel = new Map<unknown, number>();
-      const models = this.Data.models(this.collection as never);
+      // The queue head remains the current notification until rendering ends;
+      // nested notifications must not change this pass's source order.
+      const models = notification ? notification.snapshot.entries.map(entry => entry.model) :
+        this.Data.models(this.collection as never);
       for (let index = 0; index < models.length; index++) {
         indexByModel.set(models[index], index);
       }

--- a/test/unit/collection-view/collection-view-reconciliation.spec.js
+++ b/test/unit/collection-view/collection-view-reconciliation.spec.js
@@ -459,6 +459,127 @@ describe('CollectionView normalized reconciliation', function() {
     view.destroy();
   });
 
+  it('renders each queued notification in its captured source order', function() {
+    const first = { id: 1, name: 'one' };
+    const second = { id: 2, name: 'two' };
+    const replacement = { id: 2, name: 'replacement' };
+    const source = { models: [first] };
+    const orders = [];
+    const ReentrantList = ListView.extend({
+      onAddChild(owner, child) {
+        if (child.model !== second) { return; }
+        source.models = [first, replacement];
+        source.notify({ kind: 'update', added: [], removed: [],
+          updated: [{ previous: second, current: replacement }] });
+      }
+    });
+    const view = new ReentrantList({ collection: source }).render();
+    view.on('render:children', owner => orders.push(owner.children.map(child => child.model)));
+
+    source.models = [first, second];
+    source.notify({ kind: 'update', added: [second], removed: [], updated: [] });
+
+    expect(orders).to.deep.equal([[first, second], [first, replacement]]);
+    expect(view.el.textContent).to.equal('onereplacement');
+    view.destroy();
+  });
+
+  it('fires before:sort before changing children to the new source order', function() {
+    const first = { id: 1, name: 'one' };
+    const second = { id: 2, name: 'two' };
+    const source = { models: [first, second] };
+    const view = new ListView({ collection: source }).render();
+    let before;
+    view.on('before:sort', owner => { before = owner._children.map(child => child.model); });
+
+    source.models = [second, first];
+    source.notify({ kind: 'reorder' });
+
+    expect(before).to.deep.equal([first, second]);
+    expect(view.children.map(child => child.model)).to.deep.equal([second, first]);
+    view.destroy();
+  });
+
+  it('keeps a reorder queued from before:sort separate from the current render', function() {
+    const first = { id: 1, name: 'one' };
+    const second = { id: 2, name: 'two' };
+    const source = { models: [first, second] };
+    const view = new ListView({ collection: source }).render();
+    const orders = [];
+    view.on('render:children', owner => orders.push(owner.children.map(child => child.model)));
+    view.once('before:sort', () => {
+      source.models = [first, second];
+      source.notify({ kind: 'reorder' });
+    });
+
+    source.models = [second, first];
+    source.notify({ kind: 'reorder' });
+
+    expect(orders).to.deep.equal([[second, first], [first, second]]);
+    expect(view.el.textContent).to.equal('onetwo');
+    view.destroy();
+  });
+
+  it('sorts reset children from the reset snapshot when an add hook queues a reorder', function() {
+    const first = { id: 1, name: 'one' };
+    const second = { id: 2, name: 'two' };
+    const source = { models: [] };
+    const orders = [];
+    const ReentrantList = ListView.extend({
+      onAddChild(owner, child) {
+        if (child.model !== second) { return; }
+        source.models = [second, first];
+        source.notify({ kind: 'reorder' });
+      }
+    });
+    const view = new ReentrantList({ collection: source }).render();
+    view.on('render:children', owner => orders.push(owner.children.map(child => child.model)));
+
+    source.models = [first, second];
+    source.notify({ kind: 'reset' });
+
+    expect(orders).to.deep.equal([[first, second], [second, first]]);
+    expect(view.el.textContent).to.equal('twoone');
+    view.destroy();
+  });
+
+  [undefined, false, function(child) { return child.model.rank; }].forEach(viewComparator => {
+    it(`preserves manual children and source ties with a ${typeof viewComparator} comparator`, function() {
+      const first = { id: 1, rank: 0, name: 'one' };
+      const second = { id: 2, rank: 0, name: 'two' };
+      const manual = { id: 3, rank: 0, name: 'manual' };
+      const source = { models: [first, second] };
+      const view = new ListView({ collection: source, viewComparator }).render();
+      const manualView = new ChildView({ model: manual });
+      view.addChildView(manualView);
+
+      source.models = [second, first];
+      source.notify({ kind: 'reorder' });
+
+      expect(view.children.map(child => child.model)).to.deep.equal(viewComparator === undefined ?
+        [manual, second, first] : [second, first, manual]);
+      expect(view.children.findByModel(manual)).to.equal(manualView);
+      expect(manualView.renderCount).to.equal(1);
+      view.destroy();
+    });
+  });
+
+  it('retains custom comparator ties when source ordering is disabled', function() {
+    const first = { id: 1, rank: 0, name: 'one' };
+    const second = { id: 2, rank: 0, name: 'two' };
+    const added = { id: 3, rank: 0, name: 'three' };
+    const source = { models: [first, second] };
+    const view = new ListView({ collection: source, sortWithCollection: false,
+      viewComparator: child => child.model.rank }).render();
+
+    source.models = [added, second, first];
+    source.notify({ kind: 'update', added: [added], removed: [], updated: [] });
+
+    expect(view.children.map(child => child.model)).to.deep.equal([first, second, added]);
+    expect(view.el.textContent).to.equal('onetwothree');
+    view.destroy();
+  });
+
   it('reconciles a same-key replacement queued from an add hook', function() {
     const first = { id: 1, name: 'one' };
     const second = { id: 2, name: 'two' };

--- a/test/unit/collection-view/collection-view-sorting.spec.js
+++ b/test/unit/collection-view/collection-view-sorting.spec.js
@@ -323,12 +323,12 @@ describe('CollectionView - Sorting', function() {
       view.destroy();
     });
 
-    it('reads one snapshot for validation and one for sorting a collection change', function() {
+    it('uses one source snapshot to validate and sort a collection change', function() {
       const view = new MyCollectionView({ collection }).render();
       const models = this.sinon.spy(view.Data, 'models');
       const added = collection.add({ index: 5, sort: 6, altSort: 0 }, { at: 2 });
 
-      expect(models).to.have.been.calledTwice;
+      expect(models).to.have.been.calledOnce;
       expect(view.children.findByIndex(2).model).to.equal(added);
       view.destroy();
     });


### PR DESCRIPTION
Related #376

## What
- Use the current collection notification's captured snapshot for default source ordering, including nested update/reorder/reset notifications.
- Perform source ordering inside the normal sort path, after before:sort, and remove the redundant default source-child partition/rebuild.
- Preserve manual-child placement, stable custom-comparator ties, disabled source ordering and explicit sort's live-source behavior.

## Why
A child-add hook can enqueue an immutable replacement before the current update renders. The old default comparator reread the live source, making the earlier update render children in a future snapshot's order. It also reordered children before before:sort fired and read Data.models twice per ordinary update. The queue now retains its processing notification until rendering ends; sorting reads that snapshot once.

## Scope
CollectionView sorting and notification dispatch, regression tests and documentation. The existing sort → filter → render flow remains canonical. Overrides that skip the parent sort now own all sorting; no fallback is injected. Custom comparators retain control of their own data reads, and the existing built-in comparator identity check continues to preserve overrides. No callback-destruction guards, new dispatch flags or rollback behavior are added.

## Deployment Impact
No forms require redeployment. This affects the next core package build; there is no package publication or application deployment in this PR.

## Testing
- Three regressions failed before the source fix: queued replacement render order, before:sort timing, and duplicate source reads. They pass after the fix.
- Additional coverage checks nested reorder/reset notifications, default/manual order, custom comparator ties and sortWithCollection:false.
- npm run coverage: 1,966 unit tests, 100% required coverage and 19 agent contract tests passed.
- npm run build: package/declaration builds and packed ESM/CommonJS consumer checks passed.
- npm run docs:check, targeted ESLint and git diff --check passed.
- node test/browser/collection-removal-survivors.mjs: all 15 configurations passed across Chromium, Firefox and WebKit.
- External deterministic audit: 8,000 mutation steps across 16 combinations of native/jQuery/morphdom/lit-html and sorting modes passed, checking DOM order, retained identity, rendered data, destruction and observer cleanup.
- Bounded Claude review completed with no blockers after clarifying the custom-comparator data-read boundary. No override interception was added.

### Matched performance check
Standard native js-framework-benchmark fixture; same row template/build tooling, headless Chrome 152, renderer accessibility explicitly disabled, lifecycle monitoring enabled. Base/candidate/candidate/base blocks, seven samples per operation per block; all 140 timed samples retained. No concurrent builds/tests during timed blocks. These AX-off numbers do not represent accessibility-enabled user performance.

| Operation | Base total median ms | Candidate total median ms | Base script ms | Candidate script ms |
| --- | ---: | ---: | ---: | ---: |
| Create 1k | 44.55 | 44.60 | 17.25 | 17.15 |
| Partial update | 41.25 | 40.40 | 9.45 | 9.55 |
| Remove | 17.65 | 17.90 | 1.60 | 1.70 |
| Append 1k | 48.55 | 48.75 | 16.20 | 16.30 |
| Clear | 30.30 | 29.80 | 27.55 | 27.10 |

This run remains close to baseline; it does not demonstrate a general speedup. The concrete work reduction is one source read instead of two plus removing the default source-child rebuild. Frozen inputs, hashes, raw samples/traces and reproduction scripts are retained in the 2026-09-08 marionette-collectionview-audit local artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CollectionView sorting to order children from each notification's captured snapshot instead of the live source, so nested updates and reorders render correctly and `before:sort` fires before source order changes.

**Bug Fixes**
- Update and reorder notifications now sort from the notification snapshot rather than reading the live collection twice.
- `before:sort` now fires before any source-order changes are applied.

**Refactors**
- Kept the notification queue's head snapshot active until rendering ends, so nested notifications don't alter the current sort pass.
- Removed the redundant default source-child rebuild from update handling.
- Documented that `sort()` outside a notification uses the current source, and that custom comparators retain control of their own ordering and ties.

<sup>Written for commit b8b876010cc3c2f3a3e530f1ac988a0a903184d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

