### PR TITLE
fix(collection-view): preserve template during unmonitored cleanup

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -139,6 +139,10 @@ child returns it in its current lifecycle state. Setting
 `monitorViewEvents: false` on the `CollectionView` intentionally disables child
 attachment events and automatic child `isAttached()` updates.
 
+Disabling monitoring does not make child destruction clear surrounding template
+content. Bulk removal is used only when the child container contains those Views'
+root elements and optional formatting whitespace.
+
 | Operation | CollectionView state | Managed child state |
 | --- | --- | --- |
 | Construct | Starts not rendered and not destroyed. It is attached only when its element is already in the document. | No children have been built. |

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -289,6 +289,16 @@ function normalizeCollectionChange(change: RawChange, previous: Snapshot, curren
   };
 }
 
+function canDetachContents(container: Element, children: CollectionChild[]) {
+  if (container.childElementCount !== children.length ||
+      !children.every(view => view.el.parentNode === container)) { return false; }
+
+  // Formatting whitespace may be cleared; preserve other content and renderer markers.
+  return container.childNodes.length === children.length ||
+    Array.from(container.childNodes).every(node => node.nodeType === 1 ||
+      node.nodeType === 3 && !/[^\t\n\f\r ]/.test(node.textContent!));
+}
+
 function modelAttributesMatcher(Data: DataProvider, predicate: Record<string, unknown>) {
   const keys = Object.keys(predicate);
   const length = keys.length;
@@ -1179,8 +1189,12 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     }
 
     this.triggerMethod('before:destroy:children', this);
-    if (this.monitorViewEvents === false) { this.Dom.detachContents(this.el); }
-    this._removeChildViews(this._children._views);
+    const children = this._children._views;
+    const container = this.container;
+    if (this.monitorViewEvents === false && canDetachContents(container, children)) {
+      this.Dom.detachContents(container);
+    }
+    this._removeChildViews(children);
     this._children._init();
     this.children._init();
 

--- a/test/unit/collection-view/collection-view-childviewcontainer.spec.js
+++ b/test/unit/collection-view/collection-view-childviewcontainer.spec.js
@@ -38,6 +38,7 @@ describe('CollectionView - childViewContainer', function() {
       { name: 'nested container', childViewContainer: '#foo', label: '' },
       { name: 'root container', label: '' },
       { name: 'nested container with text', childViewContainer: '#foo', label: 'Keep' },
+      { name: 'nested container with a control', childViewContainer: '#foo', label: '<li><button>Add</button></li>' },
       { name: 'nested container with whitespace', childViewContainer: '#foo', label: '\n' },
       { name: 'nested container with a nonbreaking space', childViewContainer: '#foo', label: '&nbsp;' },
       { name: 'nested container with a comment', childViewContainer: '#foo', label: '<!-- keep -->' }
@@ -56,6 +57,7 @@ describe('CollectionView - childViewContainer', function() {
         const previousChildren = myCollectionView.children.toArray();
         const detachContents = this.sinon.spy(myCollectionView.Dom, 'detachContents');
         input.value = 'edited';
+        if (label.startsWith('<li>')) { previousChildren[0].el.after(labelNode); }
 
         collection.reset([{ foo: 'after' }]);
 
@@ -68,6 +70,8 @@ describe('CollectionView - childViewContainer', function() {
         expect(previousChildren.every(view => view.isDestroyed())).to.be.true;
         if (childViewContainer && !label.trim()) {
           expect(detachContents).to.have.been.calledOnceWithExactly(container);
+        } else {
+          expect(detachContents).not.to.have.been.called;
         }
         if (label && !label.trim()) { expect(labelNode.parentNode).to.be.null; }
 

--- a/test/unit/collection-view/collection-view-childviewcontainer.spec.js
+++ b/test/unit/collection-view/collection-view-childviewcontainer.spec.js
@@ -34,6 +34,73 @@ describe('CollectionView - childViewContainer', function() {
   });
 
   describe('when childViewContainer is defined', function() {
+    [
+      { name: 'nested container', childViewContainer: '#foo', label: '' },
+      { name: 'root container', label: '' },
+      { name: 'nested container with text', childViewContainer: '#foo', label: 'Keep' },
+      { name: 'nested container with whitespace', childViewContainer: '#foo', label: '\n' },
+      { name: 'nested container with a nonbreaking space', childViewContainer: '#foo', label: '&nbsp;' },
+      { name: 'nested container with a comment', childViewContainer: '#foo', label: '<!-- keep -->' }
+    ].forEach(({ name, childViewContainer, label }) => {
+      it(`preserves the template around a ${name} when resetting without monitoring`, function() {
+        const UnmonitoredList = MyCollectionView.extend({ monitorViewEvents: false });
+        const myCollectionView = new UnmonitoredList({
+          collection,
+          template: () => `<input value="original"><ul id="foo">${label}</ul>`,
+          childViewContainer
+        }).render();
+        const input = myCollectionView.el.querySelector('input');
+        const list = myCollectionView.el.querySelector('#foo');
+        const labelNode = label && list.firstChild;
+        const container = myCollectionView.container;
+        const previousChildren = myCollectionView.children.toArray();
+        const detachContents = this.sinon.spy(myCollectionView.Dom, 'detachContents');
+        input.value = 'edited';
+
+        collection.reset([{ foo: 'after' }]);
+
+        expect(myCollectionView.el.querySelector('input')).to.equal(input);
+        expect(input.value).to.equal('edited');
+        expect(myCollectionView.el.querySelector('#foo')).to.equal(list);
+        expect(myCollectionView.children.first().el.parentNode).to.equal(container);
+        expect(myCollectionView.children.first().el.textContent).to.equal('after');
+        if (label.trim()) { expect(list.firstChild).to.equal(labelNode); }
+        expect(previousChildren.every(view => view.isDestroyed())).to.be.true;
+        if (childViewContainer && !label.trim()) {
+          expect(detachContents).to.have.been.calledOnceWithExactly(container);
+        }
+        if (label && !label.trim()) { expect(labelNode.parentNode).to.be.null; }
+
+        collection.reset([]);
+        expect(myCollectionView.el.querySelector('input')).to.equal(input);
+        expect(myCollectionView.el.querySelector('#foo')).to.equal(list);
+        expect(myCollectionView.children.length).to.equal(0);
+        if (label.trim()) { expect(list.firstChild).to.equal(labelNode); }
+        myCollectionView.destroy();
+      });
+    });
+
+    it('preserves unmanaged content when children are mounted by custom attachHtml', function() {
+      const external = document.createElement('section');
+      const UnmonitoredList = MyCollectionView.extend({
+        monitorViewEvents: false,
+        template: () => '<button>Keep</button>',
+        attachHtml(els) { external.append(els); }
+      });
+      collection.reset([{ foo: 'before' }]);
+      const myCollectionView = new UnmonitoredList({ collection }).render();
+      const button = myCollectionView.el.firstChild;
+      const previous = myCollectionView.children.first();
+
+      collection.reset([{ foo: 'after' }]);
+
+      expect(myCollectionView.el.firstChild).to.equal(button);
+      expect(external.textContent).to.equal('after');
+      expect(previous.isDestroyed()).to.be.true;
+      myCollectionView.destroy();
+      expect(external.childNodes.length).to.equal(0);
+    });
+
     describe('when a selector within the el', function() {
       it('should should put the children within the found container', function() {
         const myCollectionView = new MyCollectionView({


### PR DESCRIPTION
Related #376

## What
- Preserve the parent template when an unmonitored CollectionView resets children inside `childViewContainer`.
- Preserve unmanaged text, comments, and controls inside the child container. Keep bulk removal when it contains only managed child roots and formatting whitespace.
- Cover nested/root containers, custom external mounts, interspersed controls, comments, and nonbreaking spaces.

## Why
With `monitorViewEvents: false`, `_destroyChildren` cleared `this.el`. Resetting a list inside a parent template erased the template and left subsequent children rendering into a detached container. The same failure exists in v4.1.3. Changing only the target still erased unrelated content inside that target.

## Scope
CollectionView child destruction and its documented behavior. Uses existing DOM operations; no adapter API, lifecycle default, exception recovery, or package changes.

## Deployment Impact
No forms or applications need redeployment for this repository change. Consumers receive the fix when they adopt a future library build. No release or publication is performed here.

## Testing
- `npm run coverage`: 1,977 unit tests plus 19 agent contract tests passed after integrating #445/#446; required coverage passed. The additional static-control case then passed in the targeted 12-test suite.
- `npm run build`: passed, including source checks and packed consumer typing.
- `npm run lint:ci -- --ignore-pattern '.claude/**'`: passed. The unfiltered local run traversed unrelated Claude scratch worktrees; no repository source exception was added.
- `npm run docs:check`: 23 executable examples, 55 pages, 506 internal links passed.
- `node test/browser/collection-removal-survivors.mjs`: all 15 configurations across Chromium, Firefox, and WebKit passed.
- Additional three-browser reset/clear probe preserved nested container identity, input value, focus, and selection.
- Bounded Claude review found no correctness blockers; added its suggested interspersed static-control regression.

Matched headless Chrome benchmarks, monitoring disabled and accessibility explicitly disabled, base/candidate/candidate/base with 9 samples per operation per block (72 samples):

| Median ms | Base total | Candidate total | Base script | Candidate script |
| --- | ---: | ---: | ---: | ---: |
| Replace 1k | 46.30 | 45.70 | 18.60 | 18.60 |
| Clear 1k | 21.10 | 21.20 | 18.15 | 18.40 |

A rejected first check preserved indentation text and forced per-child removal, increasing clear to 26.1–26.6 ms. The final check permits HTML formatting whitespace and restores bulk removal; all original samples and traces are retained. These measurements isolate the cleanup change before the separately validated #445/#446 integration. They do not establish universal performance parity or accessibility-enabled browser cost.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the parent template when an unmonitored CollectionView resets children, fixing #376. Previously, resetting cleared the entire element, erasing the template.

- Bulk removal only runs when the child container holds only managed child roots and formatting whitespace.
- Custom `attachHtml` implementations that mount children externally are preserved.
- Unmanaged text, comments, controls, and nonbreaking spaces inside the container are kept.

<sup>Written for commit b57b2f339bdd5714506dd5b2509f8ae2e1ea62a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection view resets now preserve surrounding template content when child event monitoring is disabled.
  * Improved cleanup for nested containers and custom child placement while retaining unmanaged content and edited control values.
  * Bulk child removal now occurs only when the container contents match the managed views, allowing harmless formatting whitespace.

* **Documentation**
  * Clarified collection view lifecycle behavior and conditions for bulk removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->