### PR TITLE
perf(collection-view): remove redundant focus and snapshot work

### DIFF
--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -167,7 +167,7 @@ export type CollectionViewConstructor<Props extends object = {}, Args extends un
 interface SnapshotEntry {model: unknown; key: unknown;}
 interface Snapshot {
   entries: SnapshotEntry[];
-  models: Map<unknown, SnapshotEntry>;
+  models: ReadonlyMap<unknown, SnapshotEntry>;
 }
 interface Replacement {key: unknown; previous: unknown; current: unknown;}
 interface Update {kind: 'update'; added: SnapshotEntry[]; removed: SnapshotEntry[]; updated: Replacement[];}
@@ -242,9 +242,8 @@ function throwCollectionProtocolError(message: string): never {
   });
 }
 
-function buildCollectionSnapshot(Data: DataProvider, collection: unknown, previous: SnapshotEntry[]): Snapshot {
+function buildCollectionSnapshot(Data: DataProvider, collection: unknown, previous?: ReadonlyMap<unknown, SnapshotEntry>): Snapshot {
   const models = Data.models(collection as never);
-  const previousKeys = new Map(previous.map(entry => [entry.model, entry.key]));
   const keys = new Set<unknown>();
   const modelEntries = new Map<unknown, SnapshotEntry>();
   const snapshot: SnapshotEntry[] = Array(models.length);
@@ -259,7 +258,8 @@ function buildCollectionSnapshot(Data: DataProvider, collection: unknown, previo
     if (keys.has(key)) {
       throwCollectionProtocolError(`DataApi.key() returned duplicate key "${ String(key) }".`);
     }
-    if (previousKeys.has(model) && !sameValueZero(previousKeys.get(model), key)) {
+    const previousEntry = previous?.get(model);
+    if (previousEntry && !sameValueZero(previousEntry.key, key)) {
       throwCollectionProtocolError('DataApi.key() changed while a model remained in the CollectionView.');
     }
 
@@ -432,7 +432,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     if (this._isDestroying || this._isDestroyed) { return; }
 
     const previous = this._collectionObservedSnapshot || this._collectionSnapshot;
-    const current = buildCollectionSnapshot(this.Data, this.collection, previous.entries);
+    const current = buildCollectionSnapshot(this.Data, this.collection, previous.models);
     const normalized = normalizeCollectionChange(change as RawChange, previous, current);
     const notification = { change: normalized, snapshot: current };
 
@@ -660,7 +660,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
     this._destroyChildren();
 
     if (this.collection != null) {
-      this._collectionSnapshot = buildCollectionSnapshot(this.Data, this.collection, []);
+      this._collectionSnapshot = buildCollectionSnapshot(this.Data, this.collection);
       this._addChildModels(this._collectionSnapshot.entries.map(entry => entry.model));
       this._initialEvents();
     }

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -906,10 +906,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
 
       const documentEl = this.container.ownerDocument;
       const activeElement = documentEl.activeElement as HTMLInputElement | null;
-      const shouldRestoreFocus = activeElement && views.some(view =>
-        view.el === activeElement || view.el.contains(activeElement)
-      );
-      const selection = shouldRestoreFocus &&
+      const selection = activeElement &&
         typeof activeElement.selectionStart === 'number' && {
         end: activeElement.selectionEnd,
         start: activeElement.selectionStart,
@@ -938,8 +935,9 @@ Object.assign(CollectionView.prototype, ViewMixin, {
         }
       }
 
-      if (shouldRestoreFocus && activeElement.isConnected &&
-          documentEl.activeElement !== activeElement) {
+      // Search the children only when rendering actually lost focus.
+      if (activeElement && activeElement.isConnected && documentEl.activeElement !== activeElement &&
+          views.some(view => view.el.contains(activeElement))) {
         activeElement.focus({ preventScroll: true });
         if (selection) {
           activeElement.setSelectionRange(selection.start, selection.end,

--- a/test/unit/collection-view/collection-view-reconciliation.spec.js
+++ b/test/unit/collection-view/collection-view-reconciliation.spec.js
@@ -876,6 +876,30 @@ describe('CollectionView normalized reconciliation', function() {
     }
   });
 
+  it('lets an attaching child receive focus from outside the collection', function() {
+    const input = document.createElement('input');
+    const el = document.createElement('div');
+    document.body.append(input, el);
+    const FocusChild = ChildView.extend({
+      template: () => '<button>Focus me</button>',
+      onAttach() { this.el.firstChild.focus(); }
+    });
+    const source = { models: [] };
+    const view = new ListView({ collection: source, childView: FocusChild });
+    const region = new Region({ el });
+    region.show(view);
+    input.focus();
+
+    const model = { id: 1 };
+    source.models.push(model);
+    source.notify({ kind: 'update', added: [model], removed: [], updated: [] });
+
+    expect(document.activeElement).to.equal(view.children.first().el.firstChild);
+    region.destroy();
+    el.remove();
+    input.remove();
+  });
+
   it('ignores stale observer callbacks after destruction', function() {
     const source = { models: [{ id: 1, name: 'one' }] };
     let staleNotify;

--- a/test/unit/collection-view/collection-view-reconciliation.spec.js
+++ b/test/unit/collection-view/collection-view-reconciliation.spec.js
@@ -879,7 +879,7 @@ describe('CollectionView normalized reconciliation', function() {
   it('lets an attaching child receive focus from outside the collection', function() {
     const input = document.createElement('input');
     const el = document.createElement('div');
-    document.body.append(input, el);
+    this.setFixtures(input, el);
     const FocusChild = ChildView.extend({
       template: () => '<button>Focus me</button>',
       onAttach() { this.el.firstChild.focus(); }
@@ -896,8 +896,6 @@ describe('CollectionView normalized reconciliation', function() {
 
     expect(document.activeElement).to.equal(view.children.first().el.firstChild);
     region.destroy();
-    el.remove();
-    input.remove();
   });
 
   it('ignores stale observer callbacks after destruction', function() {


### PR DESCRIPTION
Related #376

## What
- Defer searching child elements for focus recovery until rendering actually changes focus.
- Reuse the previous snapshot's model/key index instead of rebuilding an equivalent Map and temporary key-pair array on every collection notification.
- Type captured indexes as ReadonlyMap and cover focus moving from an outside control into an attaching child.

## Why
A 1,000-row unchanged sort made 1,000 `contains` calls whether focus was outside the list or remained on its last child. It now makes zero in those cases while retaining the existing focus/selection recovery when DOM movement loses focus. Snapshot construction also copied 1,000 prior key entries even though the captured index already held them; it now reuses that index.

## Scope
CollectionView focus recovery and snapshot bookkeeping, in separate logical commits. Source ordering, stable-key validation, adapter contracts, and lifecycle defaults stay the same. Captured snapshot maps are private and read-only after construction. No runtime guard, new cache, or public API is added.

## Deployment Impact
No forms or applications require deployment for this repository change. Consumers receive it when adopting a later library build; this PR does not publish one.

## Testing
- `npm run coverage`: 1,979 unit tests plus 19 agent contract tests passed with required coverage.
- `npm run build`: source checking and packed consumer types passed.
- `npm run lint:ci -- --ignore-pattern '.claude/**'`: passed; excludes unrelated local reviewer scratch worktrees.
- `node test/browser/collection-removal-survivors.mjs`: all 15 configurations across Chromium, Firefox and WebKit passed.
- `node test/browser/dom-adapters.mjs`: 24 adapter contracts passed in each browser.
- Existing tests cover forced focus loss on moved input/button elements, text selection, removed focused elements, duplicate/missing/changed keys, SameValueZero key equality, and nested update/reorder/reset snapshots. The new test covers an attaching child taking focus from outside the list.
- Bounded Claude reviews approved both changes. Used a read-only map contract; retained tests through public paths rather than exporting private helpers for testing.

### Matched full-operation benchmark

Exact master `ab1f4852` versus this candidate; headless Chrome 152, accessibility explicitly disabled, monitoring enabled, identical harness/template/compiler. Base/candidate/candidate/base, 7 samples per operation per block, 112 samples total:

| Median ms | Base total | Candidate total | Base script | Candidate script |
| --- | ---: | ---: | ---: | ---: |
| Create 1k | 43.65 | 43.95 | 16.90 | 16.80 |
| Remove | 17.45 | 17.05 | 1.50 | 1.30 |
| Append 1k | 48.25 | 47.70 | 16.30 | 16.10 |
| Clear | 29.95 | 29.90 | 27.35 | 27.20 |

### Isolated snapshot work

A browser probe through public DataApi/CollectionView, with `sortWithCollection: false`, measures source reversal and snapshot maintenance without DOM rendering in the timed path. Four alternating blocks, 100 warmups and 25 samples of 20 notifications per size/block (4,000 timed notifications):

| Models | Base ms/notification | Candidate ms/notification |
| ---: | ---: | ---: |
| 1,000 | 0.100 | 0.058 |
| 10,000 | 1.127 | 0.758 |

The algorithm remains O(n); this removes one redundant Map and its temporary entry array, not all allocation.

### Partial-update control and limits

Partial update renders individual rows and does not enter the changed CollectionView path. The focus-only comparison initially measured 39.10→40.65 ms, and a separate reversed-order control measured 40.15→40.90 ms, mostly paint variability. A separately labeled run using identical seeded row data measured 41.45→40.35 ms. Original runs remain intact: 112 initial samples, 72 reversed-order samples, and 72 seeded-control samples. No consistent partial-update regression emerged across those controls.

All raw results, traces and source/bundle identities are retained. These are AX-disabled measurements, not accessibility-enabled browser costs, and do not establish universal end-to-end performance parity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes performance of CollectionView focus recovery and snapshot bookkeeping. A 1,000-row unchanged sort now makes zero `contains` calls when focus is outside the list or stays on the last child, and snapshot construction reuses the previous model/key index instead of rebuilding it.

Related: #376

**Testing**
- Added a test for an attaching child taking focus from outside the list; focus fixtures are managed through the test harness.

<sup>Written for commit 664d1b6e619f34599973051f42e2c37a1dab530c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

