### PR TITLE
fix(collection-view): preserve removals and avoid excess DOM moves

### DIFF
--- a/docs/data.api.md
+++ b/docs/data.api.md
@@ -99,6 +99,11 @@ with their own change events can leave `updated` empty and let child
 merges still update collection order and filtering, without rendering children
 again after their model events have run.
 
+If a child was removed, detached, or destroyed while its model remained in the
+source, updates for that model do not recreate its View. Other children continue
+to update. Rendering the CollectionView again or a source reset recreates children
+from the current source.
+
 An immutable same-key replacement belongs only in `updated`, not in `removed`
 and `added`. Replacing a model with one that has a different stable key is a
 removal plus an addition; changing the key of a retained model is invalid. The

--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -897,6 +897,10 @@ better to use the data to determine what the `CollectionView` should display.
 This method accepts the child view instance to remove as its parameter. It returns
 the removed view.
 
+Later updates to the retained model do not recreate its removed View. Rendering
+the CollectionView again or resetting its collection rebuilds its children from
+the current collection.
+
 ```javascript
 import { CollectionView } from 'marionette';
 

--- a/packages/adapters/readme.md
+++ b/packages/adapters/readme.md
@@ -95,6 +95,10 @@ is reserved by that adapter instance. Every other event-map name is passed to
 event sent to the actor. Subscribing to an already-started actor does not replay
 its current snapshot, so initial rendering reads `getSnapshot()` directly.
 
+Replace the selected array when membership or order changes. Reusing an unchanged
+array lets the adapter skip comparison; a newly allocated array requires a keyed
+scan per observer, even if its contents are identical.
+
 Supplied parent, child, and state actors are borrowed. Destroying a Marionette
 owner releases its subscriptions and Views but does not stop those actors. An
 actor returned by an owner's `createState()` factory is owned; after releasing

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -935,13 +935,37 @@ Object.assign(CollectionView.prototype, ViewMixin, {
       if (attaching.length !== views.length &&
           attaching.every(view => view.el.parentNode === this.container)) {
         const childEls = new Set<Node>(views.map(view => view.el));
-        let next = this.container.firstChild;
-        for (const view of views) {
-          while (next && !childEls.has(next)) { next = next.nextSibling; }
-          if (view.el !== next) {
-            this.Dom.moveEl(view.el, this.container, next);
+        let first = this.container.firstChild;
+        let last = this.container.lastChild;
+        let start = 0;
+        let end = views.length - 1;
+        while (start <= end) {
+          while (first && !childEls.has(first)) { first = first.nextSibling; }
+          const firstEl = views[start].el;
+          if (firstEl === first) {
+            first = first.nextSibling;
+            start++;
+            continue;
           }
-          next = view.el.nextSibling;
+
+          // Match both ends before moving an element through the remaining list.
+          while (last && !childEls.has(last)) { last = last.previousSibling; }
+          const lastEl = views[end].el;
+          if (lastEl === last) {
+            last = last.previousSibling;
+            end--;
+          } else if (lastEl === first) {
+            first = first.nextSibling;
+            this.Dom.moveEl(lastEl, this.container, last!.nextSibling);
+            end--;
+          } else if (firstEl === last) {
+            last = last.previousSibling;
+            this.Dom.moveEl(firstEl, this.container, first);
+            start++;
+          } else {
+            this.Dom.moveEl(firstEl, this.container, first);
+            start++;
+          }
         }
       }
 

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -500,13 +500,13 @@ Object.assign(CollectionView.prototype, ViewMixin, {
   _onCollectionUpdate(this: CollectionViewInternals, changes: Update) {
     if (this._isDestroying || this._isDestroyed) { return; }
 
-    const updateEntries = changes.updated.map(({ key, previous, current }) => {
+    const updateEntries = [];
+    for (const { key, previous, current } of changes.updated) {
       const view = this._children.findByKey(key);
-      if (!view) {
-        throwCollectionProtocolError(`No child View exists for updated key "${ String(key) }".`);
+      if (view) {
+        updateEntries.push({ current, previous, view });
       }
-      return { current, previous, view };
-    });
+    }
     const replacementViews = updateEntries
       .filter(({ current, previous }) => current !== previous)
       .map(({ current }) => this._createChildView(current));

--- a/test/unit/collection-view/collection-view-reconciliation.spec.js
+++ b/test/unit/collection-view/collection-view-reconciliation.spec.js
@@ -822,6 +822,53 @@ describe('CollectionView normalized reconciliation', function() {
     view.destroy();
   });
 
+  Object.entries({
+    'first to last': models => [...models.slice(1), models[0]],
+    'last to first': models => [models.at(-1), ...models.slice(0, -1)],
+    'two distant children': models => [models[0], models[998], ...models.slice(2, 998), models[1], models[999]]
+  }).forEach(([name, reorder]) => {
+    it(`moves only the selected children when reordering ${name}`, function() {
+      const models = Array.from({ length: 1000 }, (_, id) => ({ id, name: String(id) }));
+      const source = { models };
+      const view = new ListView({ collection: source }).render();
+      const children = [...view.children];
+      const move = this.sinon.spy(view.Dom, 'moveEl');
+
+      source.models = reorder(models);
+      source.notify({ kind: 'reorder' });
+
+      expect(move.callCount).to.equal(name === 'two distant children' ? 2 : 1);
+      expect([...view.el.children]).to.deep.equal(source.models.map(model => children[model.id].el));
+      expect(children.every(child => child.renderCount === 1)).to.be.true;
+      view.destroy();
+    });
+  });
+
+  it('retains unmanaged contents around and between reordered children', function() {
+    const models = Array.from({ length: 5 }, (_, id) => ({ id, name: String(id) }));
+    const source = { models };
+    const view = new ListView({ collection: source }).render();
+    const header = document.createElement('header');
+    const footer = document.createElement('footer');
+    const control = document.createElement('input');
+    const marker = document.createComment('retained');
+    view.el.prepend(header);
+    view.el.append(footer);
+    view.children.findByIndex(2).el.after(marker, control);
+
+    for (const order of [[1, 2, 3, 4, 0], [0, 4, 3, 2, 1], [3, 0, 2, 1, 4]]) {
+      source.models = order.map(id => models[id]);
+      source.notify({ kind: 'reorder' });
+      expect(view.el.firstChild).to.equal(header);
+      expect(view.el.lastChild).to.equal(footer);
+      expect(control.parentNode).to.equal(view.el);
+      expect(marker.parentNode).to.equal(view.el);
+      expect([...view.el.children].filter(el => el !== header && el !== footer && el !== control))
+        .to.deep.equal(source.models.map(model => view.children.findByModel(model).el));
+    }
+    view.destroy();
+  });
+
   it('preserves template contents before the children when placing an addition', function() {
     const source = { models: [{ id: 1, name: 'one' }] };
     const List = ListView.extend({ template: () => '<header>Heading</header>' });

--- a/test/unit/collection-view/collection-view-reconciliation.spec.js
+++ b/test/unit/collection-view/collection-view-reconciliation.spec.js
@@ -372,22 +372,46 @@ describe('CollectionView normalized reconciliation', function() {
     view.destroy();
   });
 
-  it('diagnoses an update whose child View is missing', function() {
-    const model = { id: 1, name: 'one' };
-    const source = { models: [model] };
-    const view = new ListView({ collection: source });
-    view.render();
-    const child = view.children.first();
-    view.removeChildView(child);
+  Object.entries({
+    removed: (view, child) => view.removeChildView(child),
+    detached: (view, child) => view.detachChildView(child),
+    destroyed: (view, child) => child.destroy()
+  }).forEach(([state, remove]) => {
+    [false, true].forEach(replace => {
+      it(`ignores ${replace ? 'replacement' : 'in-place'} updates for a ${state} child`, function() {
+        const previous = [{ id: 1, name: 'one' }, { id: 2, name: 'two' }];
+        const source = { models: previous };
+        const view = new ListView({ collection: source }).render();
+        const child = view.children.first();
+        const survivor = view.children.last();
+        remove(view, child);
+        const current = previous.map(model => replace ?
+          { ...model, name: `updated ${model.name}` } : Object.assign(model, { name: `updated ${model.name}` }));
+        source.models = current;
 
-    expect(() => source.notify({
-      kind: 'update',
-      added: [],
-      removed: [],
-      updated: [{ previous: model, current: model }]
-    })).to.throw(MarionetteError).and.include({ code: 'MN0039' });
+        source.notify({
+          kind: 'update', added: [], removed: [],
+          updated: previous.map((model, index) => ({ previous: model, current: current[index] }))
+        });
 
-    view.destroy();
+        expect(view.children).to.have.lengthOf(1);
+        expect(view.children.findByModel(current[0])).to.be.undefined;
+        expect(view.children.first().model).to.equal(current[1]);
+        expect(view.el.textContent).to.equal('updated two');
+        expect(survivor.isDestroyed()).to.equal(replace);
+        expect(child.isDestroyed()).to.equal(state !== 'detached');
+        if (state === 'detached') {
+          expect(child.model).to.equal(previous[0]);
+          child.destroy();
+        }
+
+        view.render();
+        expect(view.children).to.have.lengthOf(2);
+        expect(view.children.findByModel(current[0]).model).to.equal(current[0]);
+        expect(view.el.textContent).to.equal('updated oneupdated two');
+        view.destroy();
+      });
+    });
   });
 
   it('recreates a same-key replacement even when its child is filtered out', function() {


### PR DESCRIPTION
Related #376

## What
- Match CollectionView children from both ends during DOM placement. A 1,000-child first-to-last rotation needs one move instead of 999; a distant exchange needs two instead of 997.
- Ignore update records for children already removed, detached, or destroyed, while processing the remaining children. Explicit rendering or a source reset can recreate those children.
- Document removed-child behavior and the XState adapter's selected-array identity contract.

## Why
Forward-only placement moved most surviving elements for common reorder operations. Separately, a supported public child removal followed by a valid model update incorrectly threw MN0039, preventing other children in the same batch from updating.

## Scope
CollectionView placement and update handling, regression tests, and adapter/data documentation. Source-key validation remains intact. This adds no public API, rollback handling, or persistent reconciliation state. Arbitrary shuffles still use greedy placement; this is not a globally minimal move algorithm.

## Deployment Impact
No forms need redeployment for this PR. No package publication or release is performed. Consumers receive the changes when they adopt the library in their normal application build.

## Testing
- `npm run coverage`: 1,994 unit tests, 19 agent-contract tests, and required coverage pass.
- `npm run build`: strict source checks, generated declarations, package builds, and consumer type fixtures pass.
- `npm run lint:ci -- --ignore-pattern '.claude/**'`: pass; excludes unrelated local Claude worktrees.
- `npm run docs:check`: 23 executable examples, 55 pages, and 506 links pass.
- `npm run test:browser`: all seven headless browser suites pass.
- Six public remove/detach/destroy and in-place/immutable update regressions failed before the correction and pass afterward. Remaining children update, detached children retain caller ownership, and subsequent rendering restores the current source.
- Generated validation: 48,000 jsdom actions for placement; another 28,800 Chromium/Firefox/WebKit actions on the combined source, across four DOM adapters, lifecycle monitoring on/off, sorting modes, and manual child removals. Identity, order, rendered data, destruction, and subscription cleanup checked.
- Bounded Claude reviews of the actual source diff found no correctness blocker. Existing coverage and the generated sequences cover its conditional additional-test suggestions.

### Performance evidence
A controlled original/base/placement comparison retained 840 samples across native, morphdom, lit-html, and jQuery, with fixed data/templates/peers, headless Chrome, accessibility off, monitoring on, and counterbalanced blocks. Ordinary create/update/remove/append/clear paths show no broad increase. This cohort tests placement commit d419f215, separately from the subsequent removed-child correction.

At 10,000 children, first-to-last rotation measured 11.7 to 3.0 ms and distant exchange 11.3 to 3.0 ms. An initial last-to-first median increase (2.7 to 4.1 ms) was retained and investigated: a fresh-browser counterbalanced follow-up with 82 samples per side measured 2.7 to 2.6 ms, so the initial difference did not reproduce.

A separate before/after probe of the removed-child update loop retained 42 samples per side/case. Nonempty 1,000-model updates increased by 0.05–0.06 ms; 10,000-model updates were slightly lower. This is not a claim of zero overhead or a stable-release performance guarantee. Raw samples, frozen build identities, scripts, and reports are retained in the local September 8 CollectionView audit artifacts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CollectionView reorder placement to reduce DOM moves and stops updates for removed children from throwing MN0039.

**Bug Fixes**
- Matches children from both ends during placement: a 1,000-child first-to-last rotation needs one move instead of 999, and a distant exchange needs two instead of 997.
- Updates for removed, detached, or destroyed children are ignored, so other children in the same batch still update; re-rendering or a source reset recreates those children from the current source.
- Arbitrary shuffles still use greedy placement, not a globally minimal algorithm.
- Documents that `XStateAdapter` consumers must replace the selected array when membership or order changes.

<sup>Written for commit 0e775860b2ca61d1ce4b5c591d35c3a991d5fdc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection updates now safely ignore models whose child views were removed, detached, or destroyed.
  * Reordering large collections is more efficient and preserves surrounding unmanaged content.
  * Rendering again or resetting the collection correctly recreates missing child views.

* **Documentation**
  * Clarified collection reconciliation and child-view recreation behavior.
  * Documented how actor adapter arrays are handled when membership, order, or array identity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->