### PR TITLE
fix(types): allow nullable root attribute declarations

### DIFF
--- a/src/modules/view.ts
+++ b/src/modules/view.ts
@@ -34,8 +34,8 @@ import type { Constructed, Merge, ArgumentsFor, DefaultOptions, OptionsFor, Stat
 export interface ViewConfiguration {
   el?: Element | (() => Element);
   tagName?: string | (() => string);
-  id?: string | (() => string);
-  className?: string | (() => string);
+  id?: string | null | (() => string | null | undefined);
+  className?: string | null | (() => string | null | undefined);
   attributes?: Record<string, unknown> | (() => Record<string, unknown>);
   model?: unknown;
   collection?: unknown;

--- a/test/types/fixed-root.cts
+++ b/test/types/fixed-root.cts
@@ -24,3 +24,14 @@ const behavior = new Behavior({}, view);
 behavior.el = root;
 // @ts-expect-error Behavior element retargeting is removed.
 behavior._syncElement();
+
+new View({ id: null, className: () => null }).renderAttributes();
+new CollectionView({ id: () => undefined, className: null }).renderAttributes();
+view.id = () => null;
+view.className = () => undefined;
+collectionView.id = null;
+collectionView.className = () => null;
+// @ts-expect-error Root attributes remain strings, null, or undefined.
+view.id = 42;
+// @ts-expect-error A className callback cannot return a boolean.
+collectionView.className = () => false;

--- a/test/types/fixed-root.mts
+++ b/test/types/fixed-root.mts
@@ -24,3 +24,14 @@ const behavior = new Behavior({}, view);
 behavior.el = root;
 // @ts-expect-error Behavior element retargeting is removed.
 behavior._syncElement();
+
+new View({ id: null, className: () => null }).renderAttributes();
+new CollectionView({ id: () => undefined, className: null }).renderAttributes();
+view.id = () => null;
+view.className = () => undefined;
+collectionView.id = null;
+collectionView.className = () => null;
+// @ts-expect-error Root attributes remain strings, null, or undefined.
+view.id = 42;
+// @ts-expect-error A className callback cannot return a boolean.
+collectionView.className = () => false;


### PR DESCRIPTION
Related #376

## What
- Accept `null` for View and CollectionView `id`/`className` declarations, and callbacks returning `null` or `undefined`.
- Add ESM and CommonJS consumer fixtures for constructor options and instance assignments, retaining errors for numeric IDs and boolean class callbacks.

## Why
The documented `renderAttributes()` contract uses explicit `null` to remove attributes and `undefined` to preserve them. Public types rejected these valid declarations with TS2322. Sixteen compiler errors reproduced before this correction.

## Scope
Two public type unions shared by View and CollectionView, plus consumer type fixtures. Runtime attribute handling is unchanged; no new checks or allocations are emitted.

## Deployment Impact
No forms need redeployment. No package publication or release is performed. Consumers receive the declaration correction when they adopt the library through their normal build.

## Testing
- `npm run test:types` before the fix: the added valid cases produce 16 TS2322 errors.
- `npm run build` after the fix: strict source checks, declarations, package builds, and consumer fixtures pass.
- `npx eslint src/modules/view.ts --max-warnings=0`: pass. The .mts/.cts fixtures are validated by TypeScript; ESLint has no matching configuration for those files.
- Existing `test/unit/view-render-attributes.spec.js` covers View/CollectionView root null removal and undefined preservation; browser attribute coverage is already present. This type-only change does not introduce another runtime path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the public type declarations for View and CollectionView root attributes so `id` and `className` accept `null` and callbacks returning `null` or `undefined`, matching the documented `renderAttributes()` contract and resolving 16 TS2322 errors. Runtime attribute handling is unchanged.

- Widens the two shared `id`/`className` type unions in `ViewConfiguration` only.
- Adds ESM and CommonJS consumer fixtures covering constructor options and instance assignments.
- Fixtures still reject numeric IDs and boolean class callbacks.
- `npm run test:types` and `npm run build` pass with strict checks.

<sup>Written for commit a39692b5409d357be8620672548cfd63c5e945c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

