### PR TITLE
fix(collection-view): append options-only manual children

### DIFF
--- a/docs/marionette.collectionview.md
+++ b/docs/marionette.collectionview.md
@@ -860,6 +860,10 @@ the caller. That View may be added again without rendering it a second time.
 `removeChildView()` destroys the removed View, while destroying the
 `CollectionView` destroys every child that it still manages.
 
+An omitted or `null` index appends the child before sorting and filtering.
+The options-only form follows the same rule; use a numeric `index` to choose
+an insertion position.
+
 **Note** Unless an index is specified, this added view will be subject to filtering
 and sorting and may be difficult to manage in complex situations. Use with care.
 

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -1119,7 +1119,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
       this.render();
     }
 
-    this._addChild(view, index as number | null | undefined);
+    this._addChild(view, typeof index === 'number' ? index : undefined);
 
     if (options.preventRender) {
       return view;

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -273,6 +273,20 @@ describe('CollectionView Children', function() {
       });
     });
 
+    it('filters an options-only addition and appends it when the filter is removed', function() {
+      myCollectionView.viewComparator = false;
+      myCollectionView.viewFilter = view => view !== addView;
+      const previousChildren = myCollectionView.children.toArray();
+
+      myCollectionView.addChildView(addView, {});
+
+      expect(myCollectionView.children.toArray()).to.deep.equal(previousChildren);
+      expect(Array.from(myCollectionView.el.children)).to.deep.equal(previousChildren.map(view => view.el));
+      myCollectionView.removeFilter();
+      expect(myCollectionView.children.toArray()).to.deep.equal([...previousChildren, addView]);
+      expect(myCollectionView.el.lastChild).to.equal(addView.el);
+    });
+
     describe('when called with preventRender option', function() {
 
       beforeEach(function() {

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -256,6 +256,23 @@ describe('CollectionView Children', function() {
       });
     });
 
+    [null, {}, { index: null }, { preventRender: true }].forEach(indexOrOptions => {
+      it(`appends without a numeric index when sorting is disabled: ${JSON.stringify(indexOrOptions)}`, function() {
+        myCollectionView.viewComparator = false;
+        const previousChildren = myCollectionView.children.toArray();
+
+        myCollectionView.addChildView(addView, indexOrOptions);
+
+        expect(myCollectionView.children.toArray()).to.deep.equal([...previousChildren, addView]);
+        if (indexOrOptions?.preventRender) {
+          expect(addView.isRendered()).to.be.false;
+          myCollectionView.sort();
+        }
+        expect(Array.from(myCollectionView.el.children)).to.deep.equal(
+          [...previousChildren, addView].map(view => view.el));
+      });
+    });
+
     describe('when called with preventRender option', function() {
 
       beforeEach(function() {


### PR DESCRIPTION
Related #376

## What
- Pass only a numeric index from `addChildView` to child storage. Omitted/null indexes and options-only calls append before normal sorting/filtering.
- Add five regressions for null/options-only insertion, deferred rendering, and revealing an added child after removing a filter.
- State the insertion rule in the CollectionView guide.

## Why
`addChildView(child, { preventRender: true })` passed the options object to `Array.splice` as an index. JavaScript coerced it to zero, silently prepending instead of appending. An explicit null index had the same problem. Existing comparator tests masked the wrong initial order. Four new cases failed before the one-line fix and pass afterward.

Historical [backbone.marionette#3667](https://github.com/marionettejs/backbone.marionette/issues/3667) establishes that manually added children remain subject to later sorting/filtering. This correction preserves that decision; it does not pin manual children permanently.

## Scope
Only public manual-child argument normalization, its regression tests, and documentation. Numeric indexes and `options.index` precedence keep their existing behavior. Source-driven collection updates do not use this public insertion method; no new array, helper, state, or recovery path is introduced.

## Deployment Impact
No forms need redeployment for this PR. No release or package publication is performed. Applications receive the correction when they adopt the library through their normal build.

## Testing
- Before correction: four new order regressions fail.
- `npx vitest run test/unit/collection-view/collection-view-children.spec.js --reporter=dot`: all 116 tests pass after the final filter test, including existing comparator/index cases.
- `npm run coverage` on the integrated #451 source: 1,999 unit tests, 19 agent-contract tests, and required coverage pass.
- `npm run build`: source/declarations/package builds and consumer type fixtures pass.
- `npm run test:browser`: all seven headless suites pass.
- `npm run docs:check`: 23 executable examples, 55 pages, and 506 links pass.
- `npm run lint:ci -- --ignore-pattern '.claude/**'` and targeted ESLint after the final test: pass. The exclusion is for unrelated local worktrees.
- Additional headless Chromium/Firefox/WebKit probe: 36 cases check null/options/deferred/indexed/filtered additions with monitoring on/off, DOM order, focus/selection, and destruction.
- Claude reviewed the actual one-line fix, full method, and relevant tests: no blocking defect. Existing omitted-argument/comparator tests already cover its optional suggestions; no extra numeric-edge guards added.

### Cost check
A retained ABBA headless Chrome probe measures deferred manual registration with construction/destruction outside the timer, monitoring on, and accessibility off. The unchanged positional form measured 0.5 to 0.5 ms for 1,000 children and 5.75 to 5.55 ms for 10,000 (42/22 samples per side). The options-only form measured 13.6 to 6.05 ms at 10,000, but intentionally changes erroneous prepending to appending, so that is not a same-behavior speed comparison. No source-driven reconciliation or DOM rendering is timed in this probe. Scripts, raw samples and build hashes are retained in the local September 8 audit artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `addChildView` so calls with a `null` index or an options-only argument append before sorting and filtering instead of prepending. Previously JavaScript coerced `null` or the options object to `0`, silently inserting children at the front.

- Normalizes non-numeric indexes to `undefined` so `_addChild` takes its append path.
- Adds five regression tests covering null, options-only, and `index: null` insertion, plus the `preventRender` and filter-removal cases.
- Documents the insertion rule in the CollectionView guide.

<sup>Written for commit d5b2701661ad5a38bb73e38c90126f7c4076a41f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

