### PR TITLE
perf(collection-view): avoid scans and lookups on unchanged paths

### DIFF
--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -934,14 +934,18 @@ Object.assign(CollectionView.prototype, ViewMixin, {
       // implementations that use another parent manage their own placement.
       if (attaching.length !== views.length &&
           attaching.every(view => view.el.parentNode === this.container)) {
-        const childEls = new Set<Node>(views.map(view => view.el));
+        let childEls: Set<Node> | undefined;
         let first = this.container.firstChild;
         let last = this.container.lastChild;
         let start = 0;
         let end = views.length - 1;
         while (start <= end) {
-          while (first && !childEls.has(first)) { first = first.nextSibling; }
           const firstEl = views[start].el;
+          // Ordered children need no ownership lookup.
+          if (first !== firstEl) {
+            childEls ||= new Set<Node>(views.map(view => view.el));
+            while (first && !childEls.has(first)) { first = first.nextSibling; }
+          }
           if (firstEl === first) {
             first = first.nextSibling;
             start++;
@@ -949,7 +953,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
           }
 
           // Match both ends before moving an element through the remaining list.
-          while (last && !childEls.has(last)) { last = last.previousSibling; }
+          while (last && !childEls!.has(last)) { last = last.previousSibling; }
           const lastEl = views[end].el;
           if (lastEl === last) {
             last = last.previousSibling;

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -952,6 +952,7 @@ Object.assign(CollectionView.prototype, ViewMixin, {
             continue;
           }
 
+          // Matching children continue above, so the lookup is initialized here.
           // Match both ends before moving an element through the remaining list.
           while (last && !childEls!.has(last)) { last = last.previousSibling; }
           const lastEl = views[end].el;

--- a/src/modules/collection-view.ts
+++ b/src/modules/collection-view.ts
@@ -279,8 +279,8 @@ function normalizeCollectionChange(change: RawChange, previous: Snapshot, curren
   const removed = new Set(change.removed);
   return {
     kind: 'update',
-    added: current.entries.filter(entry => added.has(entry.model)),
-    removed: previous.entries.filter(entry => removed.has(entry.model)),
+    added: added.size ? current.entries.filter(entry => added.has(entry.model)) : [],
+    removed: removed.size ? previous.entries.filter(entry => removed.has(entry.model)) : [],
     updated: change.updated.map(pair => ({
       key: current.models.get(pair.current)!.key,
       previous: pair.previous,

--- a/test/unit/collection-view/collection-view-children.spec.js
+++ b/test/unit/collection-view/collection-view-children.spec.js
@@ -26,6 +26,25 @@ describe('CollectionView Children', function() {
     });
   });
 
+  it('collects attachments after all child render hooks finish', function() {
+    const collectionView = new CollectionView({ viewComparator: false });
+    const first = new View({ template: false });
+    const second = new View({ template: () => '' });
+    collectionView.render();
+    collectionView.addChildView(first);
+    second.on('render', () => first.el.remove());
+
+    const attached = [];
+    collectionView.attachHtml = function(buffer, container) {
+      attached.push(...buffer.childNodes);
+      container.append(buffer);
+    };
+    collectionView.addChildView(second);
+
+    expect(attached).to.deep.equal([first.el, second.el]);
+    collectionView.destroy();
+  });
+
   describe('when instantiating a CollectionView', function() {
     let myCollectionView;
 


### PR DESCRIPTION
Related #127

## What

- Skip full current/previous collection scans when the added or removed change list is empty.
- Allocate the DOM child-element lookup only after the expected first child differs from the current node. Preserve the existing head/tail placement algorithm.
- Cover the public `attachHtml` boundary when a later child's render hook detaches an earlier child, preserving the separate rendering and attachment scans.

## Why

An ordinary structural update scanned collections with no additions/removals, and already ordered children paid for a `Set` of every child element. Both costs can be avoided with small local branches and no persistent cache or alternate render path.

Matched headless Chromium measurements on attached simple span rows, four alternating/reversed blocks, compiled baseline `95d1955e` versus this source:

| 10,000 models; median operation time | Baseline | Candidate |
| --- | ---: | ---: |
| Isolated structural update bookkeeping | 1.095 ms | 0.920 ms |
| Source addition + removal pair | 5.0 ms | 4.0 ms |
| Source update of every tenth model | 3.3 ms | 2.8 ms |
| First-to-last source reorder | 2.3 ms | 2.2 ms |

These are local operation probes, not js-framework-benchmark frame scores or portable release baselines. Timings do not force layout/paint. The unchanged capture/clear paths serve as noise controls; their small movements are not credited as improvements. At 1k, the add/remove pair measured 0.5 to 0.4 ms, while partial update and reorder were unchanged at the timer's resolution. Separate manual-child placement prototypes improved across Chromium, Firefox and WebKit.

Alternatives measured and rejected: entry reuse (no consistent gain); singleton-change helper (no gain beyond empty guards); fused render/attachment scanning (inconsistent timings and changes `attachHtml` inputs); simplified bulk-cleanup guard (roughly doubles formatted-container cleanup); removing focus handling (no consistent saving). Removing key validation reduced cost, but also removes existing identity diagnostics, so it is retained.

## Scope

CollectionView notification normalization and DOM placement only. Public APIs, source ordering, key validation, lifecycle events, unmanaged DOM preservation, focus handling and adapter contracts remain unchanged. No new adapter-specific branch, recovery mechanism or runtime cache.

## Deployment Impact

Library source change only. No forms or bundles need redeployment for this PR; no package publication, release tag or deployment is included. Consumers receive the optimization when they adopt a later library build.

## Testing

- `npm run build` — packages, strict source types, generated declarations and consumer type fixtures passed.
- `npx vitest run test/unit/collection-view --reporter=dot` — 414 tests passed.
- `npm run coverage` — 2,000 unit tests, required coverage thresholds and 19 agent-contract tests passed.
- `npm run test:browser` — all seven repository suites passed across Chromium, Firefox and WebKit, including adapter contracts, survivor identity, focus/selection, custom attachment, source sorting and removal.
- `npm run lint:ci -- --ignore-pattern '.claude/**'` — passed. The unqualified local command traversed unrelated pre-existing Claude worktrees and failed on their generated/stale files; no product lint failure was found outside those directories.
- `git diff --check` — passed.
- Local `collection-cost.mjs baseline final` — four counterbalanced blocks at 1k/10k; raw samples and frozen sources retained in the September 8 hot-path assessment. This scratch probe is not part of the repository's public benchmark tooling.
- Bounded Claude review found no correctness defect. Requested coverage/browser checks passed; the requested static-node reorder coverage already exists and passed unchanged. An extra lazy accessor closure was declined because the existing control flow guarantees initialization before the tail lookup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves collection view performance by skipping full collection scans when there are no additions or removals, and by deferring the DOM child-element lookup until it's actually needed. Previously the code always scanned current and previous collections and built a `Set` of all child elements; now it does neither for unchanged paths, preserving the existing placement algorithm and public APIs.

- Adds a test verifying attachment collection still works when a later child's render hook removes an earlier child.

<sup>Written for commit f9cfce02fe94d0d80610ad56da4a669303d5c531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collection updates when no items are added or removed, ensuring empty results are handled correctly.
  - Improved child reordering behavior while rendering.

- **Tests**
  - Added coverage for collecting and attaching child elements after render hooks complete, including when a child is removed during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->