### PR TITLE
chore(ci): move Windows validation after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,18 +107,8 @@ jobs:
           if-no-files-found: warn
 
   package-smoke:
-    name: Package smoke (${{ matrix.name }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: macOS arm64
-            host: macos-arm64
-            runner: macos-15
-          - name: Windows x64
-            host: windows-x64
-            runner: windows-2025
+    name: Package smoke (macOS arm64)
+    runs-on: macos-15
 
     steps:
       - name: Checkout
@@ -133,7 +123,33 @@ jobs:
           cache: npm
 
       - name: Verify release profile
-        run: npm run check:release-profile -- --host ${{ matrix.host }} --runner ${{ matrix.runner }}
+        run: npm run check:release-profile -- --host macos-arm64 --runner macos-15
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test package fixtures
+        run: npm run test:fixtures
+
+  windows-package-smoke:
+    name: Package smoke (Windows x64)
+    if: github.event_name == 'push'
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Verify release profile
+        run: npm run check:release-profile -- --host windows-x64 --runner windows-2025
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,13 +159,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: macOS arm64
-            host: macos-arm64
-            runner: macos-15
-          - name: Windows x64
-            host: windows-x64
-            runner: windows-2025
+        include: >-
+          ${{ fromJSON(github.event_name == 'pull_request'
+            && '[{"name":"macOS arm64","host":"macos-arm64","runner":"macos-15"}]'
+            || '[{"name":"macOS arm64","host":"macos-arm64","runner":"macos-15"},{"name":"Windows x64","host":"windows-x64","runner":"windows-2025"}]') }}
 
     steps:
       - name: Checkout exact source commit

--- a/docs/release-profile.md
+++ b/docs/release-profile.md
@@ -33,11 +33,17 @@ packages, review the exact package and version, and then use
 `npm approve-scripts <package>` to add a version-pinned approval. Isolated fixture
 packages keep their own approvals.
 
-CI runs the complete suite on the canonical Ubuntu 24.04 x64 host. Clean installation
-and packed-package fixtures also run on macOS 15 arm64 and Windows 2025 x64. GitHub's
-fixed OS labels still receive runner-image updates, so release evidence records the
-actual image reported by each run. Hosted-runner timings remain informative rather
-than hard performance gates.
+PR CI runs the complete suite on the canonical Ubuntu 24.04 x64 host and clean
+installation and packed-package fixtures on macOS 15 arm64. The full Windows 2025
+x64 package-fixture suite runs after merge on pushes to `master`, and remains a
+required gate for release artifacts. Windows failures therefore surface after
+merge without delaying routine PRs. Release dry runs on PRs test macOS; manually
+dispatched release validation tests both macOS and Windows against the exact
+candidate tarballs before publication.
+
+GitHub's fixed OS labels still receive runner-image updates, so release evidence
+records the actual image reported by each run. Hosted-runner timings remain
+informative rather than hard performance gates.
 
 ## Browser profiles
 
@@ -70,8 +76,8 @@ browser-support ceilings.
 ## Advancing the profile
 
 Profile changes use a dedicated pull request that updates every pin together and
-passes clean installation, artifact validation, package fixtures, and the complete
-test suite before merge.
+passes the PR checks before merge. Post-merge Windows validation and complete
+release-artifact validation must pass before the new profile is released.
 
 - Review Node and npm patches monthly. Allow a seven-day upstream soak unless a
   security fix requires immediate adoption.


### PR DESCRIPTION
## What
- Run the full Windows package-fixture job on pushes to `master`, while reporting the existing Windows PR check as skipped.
- Exclude Windows from release dry runs triggered by PRs; manually dispatched release validation still tests exact candidate tarballs on macOS and Windows before publication.
- Document the post-merge Windows policy and profile-validation timing.

## Why
Windows package fixtures took over 20 minutes in a recent successful run. Repeating them in both normal CI and release dry runs on PRs adds runner cost and blocks routine merges. Windows compatibility remains covered after merge and before release.

## Scope
GitHub Actions scheduling and release-profile documentation. Linux and macOS PR validation remain in place. No file-specific bypasses, runtime changes, or changes to package support. The existing Windows required-check name is preserved, so branch protection does not need a settings change.

## Deployment Impact
No forms or bundles need redeployment. No package publication or site deployment is performed by this change. Windows-specific failures can now be detected after merge; release publication still requires Windows artifact validation.

## Testing
- `npm run check:workflows` — workflow YAML and pinned actionlint passed.
- `npm run check:release-profile` — passed.
- `npm run check:release-promotion` — dry-run preflight passed.
- `npm run docs:check` — passed, including 106 HTML files and 1,577 internal links.
- `git diff --check` — passed.
- `npm run test:release-promotion` — all 110 tests passed.
- Live PR CI confirms `Package smoke (Windows x64)` is skipped under its existing check name, and the release dry-run fixture matrix schedules only macOS. Post-merge Windows execution and manually dispatched Windows release validation have not been run as part of this PR.
