### PR TITLE
chore(deps): update tooling and the Playwright browser profile

### DIFF
--- a/config/performance.json
+++ b/config/performance.json
@@ -8,7 +8,7 @@
   "toolchain": {
     "releaseProfile": {
       "path": "config/release-profile.json",
-      "sha256": "405b0135261d44bc5c1cb7832f7bbdbcadfe8415704e40e14abee217ce2e5162",
+      "sha256": "4bad1c8507e0b38c48d44caed2d4d51ca63045d9b0c398b19ebeb82ce3880d34",
       "node": "24.19.0",
       "npm": "11.17.0",
       "lockfileVersion": 3,

--- a/config/release-profile.json
+++ b/config/release-profile.json
@@ -35,22 +35,22 @@
   "browsers": {
     "playwright": {
       "package": "@playwright/test",
-      "version": "1.62.1",
+      "version": "1.63.0",
       "browserBuilds": [
         {
           "name": "chromium",
-          "version": "151.0.7922.34",
-          "revision": "1234"
+          "version": "153.0.8010.12",
+          "revision": "1243"
         },
         {
           "name": "firefox",
-          "version": "153.0",
-          "revision": "1538"
+          "version": "155.0",
+          "revision": "1543"
         },
         {
           "name": "webkit",
-          "version": "26.5",
-          "revision": "2336"
+          "version": "26.6",
+          "revision": "2359"
         }
       ]
     },

--- a/docs/release-profile.md
+++ b/docs/release-profile.md
@@ -48,10 +48,10 @@ informative rather than hard performance gates.
 ## Browser profiles
 
 Browser behavior and transpilation use separate pinned profiles. The
-real-browser contract lane uses `@playwright/test` 1.62.1 with Chromium
-151.0.7922.34 revision 1234, Firefox 153.0 revision 1538, and WebKit 26.5 revision
-2336. These are the builds published for the [Playwright 1.62
-release](https://playwright.dev/docs/release-notes#version-162). Playwright WebKit is
+real-browser contract lane uses `@playwright/test` 1.63.0 with Chromium
+153.0.8010.12 revision 1243, Firefox 155.0 revision 1543, and WebKit 26.6 revision
+2359. These are the builds published for the [Playwright 1.63
+release](https://playwright.dev/docs/release-notes#version-163). Playwright WebKit is
 the compatibility engine; it is not evidence that branded Safari ran in CI.
 
 `npm run test:browser` runs named Playwright projects for all three engines. CI

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/plugin-transform-typescript": "7.29.7",
         "@babel/preset-env": "7.29.7",
         "@eslint/js": "10.0.1",
-        "@playwright/test": "1.62.1",
+        "@playwright/test": "1.63.0",
         "@reduxjs/toolkit": "2.12.0",
         "@rollup/plugin-babel": "7.1.0",
         "@rollup/plugin-json": "6.1.0",
@@ -37,12 +37,12 @@
         "ajv": "8.20.0",
         "backbone": "^1.4.0",
         "backbone.radio": "2.0.0",
-        "browserslist": "4.28.8",
+        "browserslist": "4.28.9",
         "c8": "12.0.0",
         "eslint": "10.10.0",
-        "eslint-plugin-jsdoc": "64.3.5",
+        "eslint-plugin-jsdoc": "64.3.6",
         "fast-check": "4.9.0",
-        "globals": "17.11.0",
+        "globals": "17.12.0",
         "jquery": "4.0.0",
         "jsdom": "30.0.1",
         "lit-html": "3.3.3",
@@ -1906,17 +1906,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.96.0.tgz",
-      "integrity": "sha512-nvtxrDqAJOKMPSsMHqshCnHvnCqFnJTsKpTaTSaZoUi9VxGVe2JvgQeAY/Qvh2wyqXByIAqNTgI7h9elXzn0yQ==",
+      "version": "0.97.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.97.0.tgz",
+      "integrity": "sha512-EP8uoFfh6+GsdGCduYtmWAW0h7AO+Ayik9Vh5YbA2r/3N6lmJKkCNZX+q3QBXC1K6ixjQ/9igF2b7WVvLm063g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/types": "^8.69.0",
         "comment-parser": "1.4.8",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~9.2.0"
+        "jsdoc-type-pratt-parser": "~9.2.1"
       },
       "engines": {
         "node": "^22.22.2 || >=24.15.0"
@@ -2618,13 +2618,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.1"
+        "playwright": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4878,9 +4878,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
-      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4914,9 +4914,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -4934,11 +4934,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5306,9 +5306,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.416",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
-      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -5464,13 +5464,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "64.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.3.5.tgz",
-      "integrity": "sha512-BqRUwfREoBH+7pzDD+uIQ3aema5P7BnPYcHj3mU0DLm+p/5TEHdimkXgnQfYl0AGgB9PZxZW/Lk7D69FTJSLXw==",
+      "version": "64.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.3.6.tgz",
+      "integrity": "sha512-lo7IXmgUUNy88SxW7KnJmmD2iPQBIRMomfCFPHidW1M3zNNVuzxlB2uoNrNyE1g4v2/L+RtYmiROPwQhSNzL8Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.96.0",
+        "@es-joy/jsdoccomment": "~0.97.0",
         "@es-joy/resolve.exports": "1.2.0",
         "@typescript-eslint/utils": "^8.69.0",
         "are-docs-informative": "^0.1.1",
@@ -5999,9 +5999,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7225,28 +7225,25 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.1"
+        "playwright-core": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7254,21 +7251,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@babel/plugin-transform-typescript": "7.29.7",
     "@babel/preset-env": "7.29.7",
     "@eslint/js": "10.0.1",
-    "@playwright/test": "1.62.1",
+    "@playwright/test": "1.63.0",
     "@reduxjs/toolkit": "2.12.0",
     "@rollup/plugin-babel": "7.1.0",
     "@rollup/plugin-json": "6.1.0",
@@ -137,12 +137,12 @@
     "ajv": "8.20.0",
     "backbone": "^1.4.0",
     "backbone.radio": "2.0.0",
-    "browserslist": "4.28.8",
+    "browserslist": "4.28.9",
     "c8": "12.0.0",
     "eslint": "10.10.0",
-    "eslint-plugin-jsdoc": "64.3.5",
+    "eslint-plugin-jsdoc": "64.3.6",
     "fast-check": "4.9.0",
-    "globals": "17.11.0",
+    "globals": "17.12.0",
     "jquery": "4.0.0",
     "jsdom": "30.0.1",
     "lit-html": "3.3.3",
@@ -157,8 +157,7 @@
     "yaml": "2.9.0"
   },
   "allowScripts": {
-    "fsevents@2.3.3": true,
-    "fsevents@2.3.2": true
+    "fsevents@2.3.3": true
   },
   "workspaces": [
     "packages/utils",


### PR DESCRIPTION
## What
- Incorporate Dependabot #495–#498: eslint-plugin-jsdoc 64.3.6, Browserslist 4.28.9, globals 17.12.0, and Playwright 1.63.0, with npm-generated lockfile updates.
- Advance the complete browser profile to Chromium 153.0.8010.12/revision 1243, Firefox 155.0/revision 1543, and WebKit 26.6/revision 2359. Update the profile checksum in the performance contract and the release-profile documentation together.
- Remove the obsolete fsevents@2.3.2 lifecycle permission after Playwright removed that dependency.

## Why
The standalone Playwright bump fails check:browser-profile because it leaves the old package/browser pins behind. This PR updates all coupled pins and validates actual browser behavior. The other three tooling updates passed their original PR CI and are validated here with the combined dependency graph. The four bot PRs will be closed after this replacement merges.

Browser builds were read from the installed playwright-core manifest and checked against the upstream [Playwright 1.63 release notes](https://playwright.dev/docs/release-notes#version-163).

## Scope
Development/lint tooling, browser-test builds, locked Browserslist data, and release/performance profile metadata. The semantic `baseline widely available` transpilation policy is unchanged and still resolves to 128 targets. No library source, test assertions, or coverage thresholds change. Historical audit records retain their original tested versions.

## Deployment Impact
No forms or form bundles require redeployment. Normal configured merge workflows apply; no package publication or release tag is created. The updated profile requires fresh release evidence before publication. Under the existing workflow, Windows package validation runs after merge and full Windows release-artifact validation runs on manual release validation.

## Testing
- npm ci --no-audit --no-fund passed, including the build, declaration consumers, and distribution validation.
- npm run check:browser-profile passed: Playwright 1.63.0 and 128 resolved Baseline targets.
- npm run check:release-profile passed: Node 24.19.0 / npm 11.17.0.
- npm run lint passed.
- npx playwright install --no-remove --only-shell --no-progress chromium firefox webkit completed.
- npm run test:browser -- --reporter=dot passed: all 126 tests across Chromium, Firefox, and WebKit on macOS arm64.
- npm run test:performance passed: 70 checks, including profile checksum validation.
- npm run docs:check passed: 30 executable example markers, 105 built pages, 106 HTML files, and 1,577 internal links validated.
- git diff --check passed. Required PR CI and reviews must finish before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated browser testing tools and supported browser builds to newer versions.
  * Refreshed development tooling versions for improved compatibility and maintenance.
  * Updated permitted script configuration for the current browser-testing environment.

* **Documentation**
  * Updated browser testing documentation and linked release information to match the newer tooling versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combines four Dependabot tooling updates and advances the Playwright browser profile so `check:browser-profile` passes with `@playwright/test` 1.63.0.

**What changed**
- `@playwright/test` 1.62.1 → 1.63.0, `browserslist` 4.28.8 → 4.28.9, `eslint-plugin-jsdoc` 64.3.5 → 64.3.6, and `globals` 17.11.0 → 17.12.0.
- Browser pins advance to Chromium 153.0.8010.12, Firefox 155.0, and WebKit 26.6, with the profile checksum and `docs/release-profile.md` updated to match.
- Removes the `fsevents@2.3.2` lifecycle permission that Playwright no longer needs.

No library source, test assertions, or transpilation targets change; the `baseline widely available` policy still resolves to 128 targets. No redeployment or package publication is needed — the updated profile just requires fresh release evidence before publication.

<sup>Written for commit aa0728e43b9d5c3950095c1218cd2fc56eafb259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

