### PR TITLE
docs(release): base stable v5 on contracts and usability

### DIFF
--- a/.github/ISSUE_TEMPLATE/v5-task.yml
+++ b/.github/ISSUE_TEMPLATE/v5-task.yml
@@ -1,11 +1,11 @@
 name: v5 implementation task
-description: Maintainer task for the agent-ready Marionette v5 release.
+description: Maintainer task for dependable contracts and demonstrated v5 usability.
 title: "[v5]: "
 body:
   - type: markdown
     attributes:
       value: |
-        Use this template for focused stable-v5 work. The task must be implementable and reviewable using public evidence, with an explicit production-cost boundary.
+        Use this template for focused stable-v5 work under the current ROADMAP.md. The task must be implementable and reviewable using public evidence, with an explicit production-cost boundary. Identify whether it supports a release requirement or separate comparative research; a comparative win is not a stable-release gate.
 
   - type: textarea
     id: goal
@@ -18,8 +18,8 @@ body:
   - type: textarea
     id: agent-failure
     attributes:
-      label: Agent-development failure addressed
-      description: Name the observed ambiguity, mistake, or verification gap.
+      label: Consumer or agent problem addressed
+      description: Name the observed contract defect, migration problem, usability failure, or verification gap.
     validations:
       required: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,5 +64,5 @@ Follow the public [synchronous failure contract](docs/view.lifecycle.md#synchron
 - Keep test, lint, benchmark, and diagnostic tooling outside production import graphs. Runtime cost remains part of review.
 - Use stable diagnostic codes for invariants. Do not make agent workflows depend on exact prose or undocumented maintainer knowledge.
 - New async CLI code must await work and propagate failures. Preserve concise failure output plus detailed machine-readable artifacts.
-- Report commands actually run, source revision, failures, and gaps. Coverage and a successful reference solution do not establish agent readiness; that requires the frozen benchmark and scored evidence.
-- Do not run paid agent benchmarks without the predeclared profile, model, permissions, run count, spend and elapsed-time budget required by #128.
+- Report commands actually run, source revision, failures, and gaps. Coverage and a successful reference solution do not establish agent usability; that requires the frozen usability evaluation and public application evidence in ROADMAP.md. Comparative research is separate from release readiness.
+- Do not run paid agent pilots or evaluations without a predeclared model/runner profile, permissions, run count, spend and elapsed-time budget, and authorization for that envelope. Follow [the evaluation plan](benchmarks/agent/evaluation-plan.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,17 +1,25 @@
 # Agent-ready Marionette v5
 
-Date: 2026-09-08
+Date: 2026-09-09
 Status: Governing project strategy
 
 ## Decision
 
-Marionette v5 will be released as stable only when the framework is demonstrably
-good for AI-agent development and remains a clean, fast runtime.
+Marionette v5 should let people and agents build and maintain substantial
+applications predictably, with understandable code and reasonable effort. Stable
+`5.0.0` requires dependable public contracts and demonstrated usability through
+migration, public application work, and independent agent maintenance attempts.
 
-Pre-releases may continue while that work is in progress. `5.0.0` is the public
-promise that Marionette's contracts, documentation, diagnostics, types, and tooling
-are coherent enough for agents and humans to make correct changes without hidden
-application knowledge.
+Comparative superiority over earlier Marionette versions or other frameworks is a
+separate research claim, not a condition of stability. Prereleases may continue
+while release evidence is incomplete. Passing library tests alone does not establish
+application usability or agent effectiveness.
+
+The September 9, 2026 decision replaces the historical baseline-improvement,
+architecture-violation reduction, fixed task/run floors, and statistical thresholds
+as stable-release requirements. It also replaces the earlier proving-ground order.
+Existing issue descriptions must be reconciled with this direction; their old
+acceptance text does not reinstate those gates or establish completion.
 
 Agent readiness does not justify mandatory runtime machinery. The default production
 path must stay small and predictable:
@@ -21,8 +29,8 @@ path must stay small and predictable:
 - Put optional runtime capabilities behind explicit subpath imports and opt-in use.
 - Add no per-instance state, subscription, observer, or allocation to applications
   that do not use an optional feature.
-- Reject features whose measured runtime or bundle cost is not justified by measured
-  agent-development value.
+- Reject features whose runtime or bundle cost is not justified by demonstrated
+  consumer value.
 
 This file is the strategy authority. Detailed work and status belong in GitHub issues,
 not parallel numbered roadmaps.
@@ -183,55 +191,55 @@ unimplemented and are not stable-v5 blockers (maintainer decision, September 9,
 - Machine-readable output includes a schema version. Only documented fields are
   stable; ordering and presentation-only fields are not accidental contracts.
 
-### Measured agent outcomes
+### Demonstrated usability
 
-- A public task corpus covers representative maintenance work: implementing plain
-  and stateful Views, choosing among plain classes, MnObject, and Application,
-  composing Regions and Applications, repairing lifecycle bugs, adding Behaviors,
-  implementing an overlay through a shared host Region, using communication
-  boundaries, and proving cleanup.
-- The model version, agent harness, permissions, commands, evaluator, expected
-  outcomes, repository revisions, and task classification are pinned for each
-  benchmark series.
-- Every task is assigned to one of two strata before its pilot or scored runs. A
-  paired-comparable task uses byte-identical prompts, visible workspaces, hidden
-  acceptance tests, commands, and evaluator rules for the Phase 0 revision and release
-  candidate; only the installed Marionette revision differs, and the objective is
-  achievable through public APIs in both revisions. A candidate-only task is allowed
-  only when its acceptance criteria necessarily exercise an accepted public contract
-  absent from Phase 0. A poor or failed Phase 0 result never justifies reclassification.
-- The stable-v5 benchmark uses at least 10 paired-comparable tasks. Candidate-only
-  tasks do not count toward that floor. Across the full candidate corpus, every named
-  capability area is exercised by at least two independently scored tasks. One task
-  may cover multiple areas, but no single task certifies an area.
-- The classification and run count for every task are predeclared, and every count is
-  at least 10. A Phase 0 pilot sets each paired-comparable task's count with at least 80
-  percent power to detect an absolute regression of 15 percentage points. Release
-  decisions use one-sided exact McNemar tests and control family-wise error at 0.05
-  with the Holm correction. Sample-size planning uses the conservative Bonferroni
-  level of 0.05 divided by the paired-comparable task count and the pilot's one-sided
-  95 percent upper confidence bound for discordant pairs under that regression
-  alternative. Candidate-only counts, the executable power calculation, and all
-  inputs are published before candidate runs.
-- Across the full candidate corpus, including both strata, the aggregate fully-correct
-  rate has a 95 percent Wilson lower bound of at least 80 percent, and no individual
-  task has a fully-correct point estimate below 60 percent. Aborted runs count as not
-  fully correct.
-- Only the paired-comparable stratum supports relative claims. Relative to its Phase 0
-  baseline on the same pinned harness, the candidate's fully-correct point estimate
-  does not regress and either improves by at least 20 percentage points or reaches at
-  least 95 percent. Cataloged framework-architecture violations per 100 attempted
-  paired-comparable runs fall by at least 50 percent, and no paired-comparable task has
-  a statistically significant regression after the predeclared correction. Violations
-  found before an aborted run still count. Candidate-only results and violations are
-  reported separately and never enter a comparative denominator.
-- A model, harness, permissions, paired task artifact, evaluator, pairing,
-  classification, or statistical-procedure change starts a new benchmark series and
-  requires rerunning both the Phase 0 revision and release candidate. Candidate-only
-  tasks are frozen after their public contracts are accepted and before candidate
-  collection; changing one after collection invalidates the full-corpus candidate
-  result and requires a fresh candidate evaluation. Results are not compared across
-  unlike series.
+Stable v5 requires evidence that independent agents can implement and maintain
+representative application behavior using public packages and documentation.
+The [evaluation plan](benchmarks/agent/evaluation-plan.md) defines the preparation,
+attempt records, review, and stabilization procedure.
+
+- Start with a bounded exploratory pilot to identify realistic tasks, failure modes,
+  and useful measurements. Pilot results inform the evaluation policy; they do not
+  count as the separate release evaluation.
+- Before evaluation, freeze the task scope, acceptance policy, models, runner,
+  permissions, documentation access, repetitions, human-assistance rules, budgets,
+  and candidate artifacts. Select counts and thresholds from the pilot's evidence;
+  no historical percentage or arbitrary task floor applies automatically.
+- Cover building, changing, and repairing behavior, including fresh-agent handoffs
+  and successive changes to an existing application. Cover editing, navigation,
+  asynchronous work, collections, overlays, and cleanup. Explain coverage gaps.
+- Judge complete requested behavior and preservation of existing behavior. Review
+  observable ownership, lifecycle, accessibility, and maintenance failures. Valid
+  public-API solutions need not resemble a reference implementation; API-specific
+  exercises must disclose their narrower purpose.
+- Retain every attempt, timeout, failure, repair cycle, and human intervention.
+  Report task-level correctness, regressions, elapsed time, spend including failed
+  attempts, and success on later changes. Attribute failures to framework defects,
+  documentation gaps, unsupported requirements, harness problems, or model mistakes
+  with evidence; attribution does not erase an unsuccessful attempt.
+- Repeated framework or documentation failures must be resolved and re-evaluated or
+  explicitly bounded in the support contract. Do not narrow frozen acceptance after
+  seeing failures; a changed scope or policy requires a new evaluation series.
+- Publish the evaluation policy, results, remaining limitations, and maintainer's
+  release decision. An uncollected policy or incomplete evaluation cannot pass this
+  gate. Successful reference solutions and green tooling checks are not agent runs.
+
+### Comparative agent research
+
+The proposed independent `ai-framework-benchmark` measures when particular
+framework, model, and runner combinations deliver correct software with reasonable
+effort. Start with React, Vue, and Marionette; allow later framework contributions.
+It may report mixed or negative results for Marionette without blocking a dependable
+release. It is planned work, not an available benchmark or measured advantage.
+
+Use equivalent behavioral requirements and independent acceptance checks with
+idiomatic framework implementations. Pin each stack, model and runner, documentation
+and tool access, budgets, and evaluation rules. Separate realistic ecosystem use
+from controlled core-framework experiments. Publish failures, uncertainty, and
+results by task family and configuration; do not infer framework superiority from
+one migration, pooled unlike runs, or resemblance to Marionette architecture.
+Historical-version comparisons may answer a focused question but are not mandatory.
+A credible comparative result needs its own predeclared sampling and analysis plan.
 
 ## Architecture boundaries
 
@@ -350,8 +358,8 @@ contracts must pass a bounded API-shape audit. Historical behavior is evidence, 
 an automatic compatibility requirement. Each decision must reconstruct the original
 rationale, identify whether the contract is public or merely an internal source
 path, scan representative public code, and exercise the explicit replacement in the
-reference app and agent benchmark. Available app-frontend and Marionette Toolkit
-migrations may reveal implementation or migration problems but do not define the
+reference app and relevant usability tasks. Available app-frontend and Marionette
+Toolkit migrations may reveal implementation or migration problems but do not define the
 public contract.
 
 This roadmap names the public contracts and decision hypotheses so the release gate
@@ -503,11 +511,11 @@ current-evidence findings:
 
 The gate passes only when every reviewed contract has one documented canonical form,
 an executable migration where behavior changes, source and package entrypoints that
-name their real owner, no unverified alias or fallback path, and paired agent tasks
-that distinguish the retained form from the removed alternative. These are contract
-discrimination checks; they use the statistical paired-comparable protocol only when
-registered in that benchmark stratum. API-shape changes land as small dedicated
-changes rather than being mixed into unrelated lifecycle or ownership work.
+name their real owner, no unverified alias or fallback path, and executable contract
+checks that distinguish the retained form from the removed alternative. Relevant usability
+attempts must exercise the documented form without hidden maintainer guidance.
+Contract discrimination does not require a historical-version agent comparison.
+API-shape changes land as small dedicated changes rather than being mixed into unrelated lifecycle or ownership work.
 
 Stable v5 removes Underscore as a required Marionette runtime peer without removing
 the documented, useful Backbone-era ergonomics of `CollectionView.children`. The
@@ -626,45 +634,52 @@ is allowed. Resource ownership may allocate only after the first registration.
 Size and allocation changes inform review during v5 development; package correctness
 and measurement validity remain required.
 
-## Public proving grounds
+## Application trials and public proving grounds
 
-External examples and benchmarks answer different questions and remain advisory
-unless a later roadmap decision explicitly promotes one into a release gate. Pursue
-them in this order:
+The application trials and comparative benchmark answer different questions. Pursue
+these four workstreams with bounded scope and explicit evidence:
 
-1. Finish the Marionette v5 [js-framework-benchmark][js-framework-benchmark]
-   implementation. It supplies the hot keyed-list and retained-memory signal, but its
-   benchmark-specific code does not define idiomatic application structure.
-2. Modernize the existing [Backbone.Marionette TodoMVC example][todomvc-marionette]
-   for v5 and submit it to the maintained [TodoMVC][todomvc] set. This is the highest
-   priority public normal-application artifact: it must demonstrate idiomatic
-   composition, routing and filtering, editable child Views, persistence, collection
-   changes, and lifecycle cleanup while passing TodoMVC's shared behavioral suite.
-3. Build a [RealWorld][realworld] implementation in a dedicated repository following
-   its starter-kit flow. Its shared API, CSS, and end-to-end suite give it the highest
-   architectural evidence value: API requests, authentication, routing, forms, nested
-   screens, error states, and asynchronous replacement exercise lifecycle races,
-   stale-request handling, Region replacement, teardown, and data-adapter ergonomics.
-   Its maintenance cost is accepted only after the smaller TodoMVC reference is current.
-4. Add Marionette to the [Framework Benchmarks weather application][framework-benchmarks]
-   if its maintainers are receptive. Its bundle, load, CPU, memory, build, and code
-   characteristics complement the list-operation focus above.
-5. Track [Speedometer][speedometer-3] rather than optimizing specifically for
-   admission. Maintaining a current, idiomatic TodoMVC implementation is useful
-   groundwork but does not imply inclusion in a browser-vendor-selected workload.
+1. **app-frontend migration:** use the existing application as the principal
+   integration trial. Begin with representative routing, async loading, editable
+   collections, overlays, and teardown before expanding the migration. Distinguish
+   adopting v5 from independently replacing Backbone, jQuery, or Toolkit. Preserve
+   existing behavior checks and record framework fixes and human interventions.
+   Publish anonymous reproductions and migration guidance for the important
+   boundaries. The private application is useful evidence, but public release
+   verification must not require access to it or completion of its full migration.
+2. **React application rebuild:** qualify a substantial public project by running
+   its existing browser suite at a pinned revision. [Actual Budget](https://github.com/actualbudget/actual) is a candidate,
+   not an accepted or verified migration. Start with a complete user workflow,
+   preserve backend/data contracts and reusable non-UI logic, then expand according
+   to findings and budget.
+3. **Vue application rebuild:** apply the same qualification process to a different
+   application; [Vikunja](https://github.com/go-vikunja/vikunja) is a candidate. Test whether the result generalizes beyond
+   the first application's architecture. Two complete rewrites are not release gates.
+4. **Independent framework benchmark:** pilot build, change, and repair tasks for
+   React, Vue, and Marionette under the comparative research policy above. Keep
+   public contributions and evaluation independent of Marionette's release outcome.
 
-[Builder.io framework-benchmarks][builder-framework-benchmarks] and
-[UIBench][uibench] remain lower-priority investigations. The former uses
-best-effort generated framework code, which makes idiomatic Marionette harder to
-defend; the latter offers useful rendering cases but less current ecosystem reach.
-Standalone bundle-size comparisons do not prove application-framework fitness and
-remain covered by Marionette's own release budgets.
+Stable v5 needs at least one substantial public application workflow with editing,
+async work, navigation, collections, overlays, and cleanup, followed by realistic
+changes from fresh agents. Select its scope before evaluation; it may come from a
+qualified migration or an expanded public reference application. Fieldnotes and
+small examples are starting material, not automatic proof of this requirement.
 
-Together the selected proving grounds provide four distinct signals: peak list
-performance, understandable small-application code, realistic application
-architecture, and startup, bundle, and resource cost. Results follow the external
-benchmark evidence rules above and never justify a default API solely because a
-benchmark-specific implementation is fast.
+For migrations, freeze tests, helpers, fixtures, screenshots, browser/environment
+settings, and test discovery before implementation. Establish the original baseline
+in that environment; disclose existing failures and exclusions. Preserve the suite
+where applicable. Any necessary test adaptation must be independently justified and
+versioned before the migration evaluation; never weaken checks to accept a result.
+An unchanged suite proves its tested behavior, not complete application equivalence.
+Record what was actually replaced and whether original-framework components remain.
+
+[js-framework-benchmark][js-framework-benchmark] remains useful runtime evidence.
+[TodoMVC][todomvc], [RealWorld][realworld], the
+[weather application comparison][framework-benchmarks], [Speedometer][speedometer-3],
+[Builder.io framework-benchmarks][builder-framework-benchmarks], and [UIBench][uibench]
+are optional supporting investigations, not a prerequisite sequence. External
+admission or a winning performance rank is not a release condition. Their findings
+follow the performance evidence rules and do not define the default application API.
 
 ## Work phases
 
@@ -683,11 +698,12 @@ when it does not bypass an earlier gate.
   publication profile.
 - Establish bundle, startup, allocation, render, and retention baselines.
 - Publish a neutral reference application and agent task corpus.
-- Pin the initial benchmark harness and record its baseline.
+- Run a bounded usability pilot and freeze the separate release evaluation policy.
 - Define the rule-catalog format, severity model, and ownership.
 
-Gate: a clean contributor can reproduce performance and agent baselines from public
-instructions, and every release blocker maps to this strategy.
+Gate: a clean contributor can reproduce performance evidence and the usability
+evaluation setup from public instructions. The release evaluation policy is frozen,
+and every release blocker maps to this strategy.
 
 ### Phase 1: Core contracts
 
@@ -861,10 +877,10 @@ check. Present any necessary library change for scrutiny before implementing it.
 No extension-hook dispatch or new runtime instrumentation is authorized by this
 future checkpoint.
 
-### Phase 4: Integration and benchmark closure
+### Phase 4: Integration, usability, and stabilization
 
 - Once the remaining runtime correctness blockers close, pack an unpublished early
-  integration candidate for the benchmark, Toolkit migration, app-frontend migration
+  integration candidate for usability trials, Toolkit migration, app-frontend migration
   probe, and package fixtures. Use that evidence while package boundaries, source layout,
   declarations, and documentation are completed; do not wait for speculative Phase 5
   APIs before testing the code broadly.
@@ -884,7 +900,12 @@ future checkpoint.
   one keyed O(n) comparison per observer; unrelated notifications are no-ops; unchanged
   child Views retain identity; and core plus every optional adapter is measured as a separate
   production graph and packed import.
-- Run the fixed agent corpus against the complete release candidate.
+- Complete the public migration evidence and substantial application workflow, then
+  run the frozen usability evaluation against the complete release candidate.
+- Predeclare a bounded stabilization period and required workflow coverage. Resolve
+  integration defects, rerun affected application and contract checks, and record
+  candidate changes and evidence gaps. A changed evaluation input starts a new series;
+  identify any earlier evidence retained only as supporting history.
 - Validate plain Views, Views with supplied and factory-owned state sources, nested
   Applications, the selected Application
   startup and restart contract, Application cleanup through public lifecycle
@@ -912,8 +933,16 @@ closed rather than retained as dormant APIs.
 
 - All Phase 0, 1, 2 and 4 gates pass on the release commit. Phase 3 is explicitly
   deferred and is not a stable-release gate.
-- The public agent benchmark meets its functional, task-floor, improvement,
-  architecture-violation, and non-regression thresholds.
+- No known unresolved defect remains in a supported critical workflow. Public
+  contracts and limitations are settled and verified against the candidate.
+- Representative migration boundaries have public reproductions and current upgrade
+  guidance. No private consumer's full migration is a prerequisite.
+- A substantial public application workflow and fresh-agent maintenance attempts
+  meet the predeclared usability acceptance policy. Results include failed attempts,
+  intervention, repair effort, and unresolved limitations.
+- The bounded stabilization period and required workflow checks are complete, with
+  integration fixes verified against the final candidate. Comparative superiority
+  and completion of the React and Vue rewrites are not release requirements.
 - Production entrypoints contain no development inspector, validation, benchmark, or
   test-helper code unless an application explicitly imports an allowed opt-in runtime
   feature.
@@ -964,9 +993,8 @@ closed rather than retained as dormant APIs.
   factory are documented; no replacement flag registry or duplicate factory
   path is presented as canonical.
 - Every contract in the API-shape and agent-ergonomics gate has an explicit keep or
-  remove decision, an executable migration when behavior changes, paired agent tasks
-  that distinguish the selected form from the rejected alternative, truthful source
-  ownership, and no unverified duplicate root utility or internal forwarding path.
+  remove decision, an executable migration when behavior changes, public contract
+  checks and relevant usability evidence for the selected form, truthful source ownership, and no unverified duplicate root utility or internal forwarding path.
 - The selected neutral DataApi protocol passes compatibility, source,
   distribution, packed-package, and real-browser tests.
 - Parent rerender conformance proves active Region children are destroyed exactly once
@@ -1037,7 +1065,6 @@ block stable v5.
 [issue-104]: https://github.com/marionettejs/marionette/issues/104
 [js-framework-benchmark]: https://github.com/krausest/js-framework-benchmark
 [todomvc]: https://github.com/tastejs/todomvc
-[todomvc-marionette]: https://github.com/tastejs/todomvc/tree/master/examples/backbone_marionette
 [realworld]: https://github.com/realworld-apps/realworld
 [framework-benchmarks]: https://github.com/Lissy93/framework-benchmarks
 [speedometer-3]: https://webkit.org/blog/15131/speedometer-3-0-the-best-way-yet-to-measure-browser-performance/

--- a/benchmarks/agent/README.md
+++ b/benchmarks/agent/README.md
@@ -2,14 +2,14 @@
 
 This directory contains Fieldnotes, a runnable public reference application, thirteen
 draft implementation tasks, hidden public-API acceptance cases, known reference
-solutions, and a local evaluator. Eleven tasks are proposed as paired-comparable and
-two as candidate-only. These classifications have not been verified against a chosen
-Phase 0 revision. This is an unscored prototype, not a frozen benchmark or evidence of
-agent effectiveness.
+solutions, and a local evaluator. This is an unscored prototype, not a completed
+release evaluation or evidence of agent effectiveness.
 
-No model, permissions profile, paired revisions, counts, budgets, pilot, statistical
-procedure, or scored series has been selected. `series-decisions.json` records these
-inputs as uncollected. The stable-v5 gates below remain unchanged.
+No model, runner/permissions profile, acceptance policy, counts, budgets, pilot,
+or evaluation series has been selected. `series-decisions.json` records these
+inputs as uncollected. Follow the [evaluation plan](evaluation-plan.md) to prepare
+release usability evidence; comparative framework research is a separate project.
+The [roadmap](../../ROADMAP.md#demonstrated-usability) owns the release requirements.
 
 ## Task isolation
 
@@ -46,48 +46,25 @@ abort.
 
 ## Capability coverage
 
-`capabilities.json` is the canonical vocabulary derived from the capability areas in
-ROADMAP.md and issue #128. A complete corpus contains at least ten paired-comparable
-tasks and exercises every capability through at least two independently scored tasks
-across the full candidate corpus. One task may exercise several capabilities, but no
-single task certifies a capability. Candidate-only tasks do not count toward the
-paired-comparable task floor.
+`capabilities.json` identifies the current prototype's framework contract areas.
+Its requirement for two independent tasks per capability is a fixture-diversity
+check, not a release task floor, sample-size rule, or proof of application coverage.
+The thirteen tasks are implementation exercises. A release evaluation still needs
+realistic change and repair work, successive changes, fresh-agent handoffs, and the
+public application and migration evidence specified in the roadmap.
 
-## Evaluation strata
+## Evaluation policy
 
-The frozen benchmark profile classifies every task before that task's pilot or scored
-runs. The classification and predeclared run count are evaluation inputs; the current
-task metadata schema does not infer either one from a prompt or fixture.
+Use the [evaluation plan](evaluation-plan.md) for pilot selection, frozen acceptance,
+model/runner profiles, attempt reporting, budgets, and stabilization. The earlier
+paired-baseline classifications and prescribed statistical improvement thresholds
+are retired. No historical revision is required for a usability evaluation.
 
-- A **paired-comparable** task uses byte-identical prompts, visible workspaces, hidden
-  acceptance tests, commands, and evaluator rules against the Phase 0 revision and the
-  release candidate. Only the installed Marionette revision differs, and both revisions
-  can complete the objective using their public APIs.
-- A **candidate-only** task is permitted only when its acceptance criteria necessarily
-  exercise an accepted public contract absent from Phase 0. It is not a fallback for a
-  weak baseline result. Its classification and run count are frozen after that public
-  contract is accepted and before candidate results are collected.
-
-Every task receives at least ten predeclared runs. The Phase 0 pilot powers counts for
-the paired-comparable stratum; candidate-only counts are still fixed before collection
-and included in the published run, spend, and elapsed-time envelope.
-
-The absolute fully-correct Wilson gate and per-task floor apply to the full candidate
-corpus, including both strata. Improvement, McNemar non-regression, and relative
-architecture-violation claims use only paired-comparable runs. Candidate-only results
-and violations are reported separately and never improve a comparative denominator.
-
-Changes to the pinned model, harness, permissions, paired task artifacts, evaluator,
-pairing, classification, or statistical procedure start a new series and require a new
-Phase 0 and candidate comparison. Changing a frozen candidate-only task after candidate
-collection invalidates the full-corpus candidate result and requires a fresh candidate
-evaluation. Results from unlike series are not compared.
-
-The local harness is implemented, but is not frozen for scored collection. Proposed
-classifications are planning inputs only. A maintainer must verify both public API
-profiles, collect the remaining decisions, and freeze the series before any pilot or
-scored attempt. Passing known reference solutions is a tooling control and cannot
-substitute for a pilot, baseline, or candidate score.
+`series-decisions.json` is an uncollected planning record, not an enforced runner
+configuration. The loader checks that it identifies every prototype task exactly
+once. An operator must freeze and enforce the full evaluation policy before scored
+collection. Passing known solutions is a tooling control and cannot substitute for
+independent agent implementation or maintenance results.
 
 ## Run the prototypes
 
@@ -154,7 +131,10 @@ attempted and incorrect. Catalog findings are deduplicated and retained even on 
 passing submission until an architecture review is supplied to the evaluator API;
 failed/aborted attempts are `false`. Architecture review must assess the explicit
 role requirements (including Behavior composition), code quality, and shared catalog
-rules. No automatic tool here claims to detect every architecture violation.
+rules. These tasks explicitly name some API roles; that is a narrower contract
+exercise, not a universal architecture rubric. Accept valid public-API solutions
+without requiring reference-solution structure. No automatic tool here claims to
+detect every architecture violation.
 
 **This local evaluator is not a security sandbox.** Use it only for trusted local
 work and reference controls. Do not give an agent access to the repository root or
@@ -170,30 +150,24 @@ environment alone do not enforce those permissions or resist malicious Node code
 All tasks have a visible starter, explicit input/output requirements, a separate
 reference solution, and withheld acceptance. Each is independently evaluated.
 
-| Task | Required outcomes | Proposed stratum |
-| --- | --- | --- |
-| `nested-workspace` | Nested Region replacement, text safety, emptying, teardown | Paired |
-| `nested-notice` | Independent navigation/notice ownership and callback cleanup | Paired |
-| `filter-projects` | CollectionView filter/reveal identity and immutable domain data | Paired |
-| `rank-projects` | Row/draft preservation, sorting, atomic invalid-input rejection | Paired |
-| `save-shortcut` | Host-scoped Behavior shortcut, rerender and cleanup | Paired |
-| `connection-status` | Behavior provider subscription and latest-state rerender | Paired |
-| `overlay-switch` | Shared Region, valid live Views, external positioning/exclusivity | Paired |
-| `overlay-dismiss` | Shared Region dismissal and document-listener cleanup | Paired |
-| `async-panel` | Out-of-order completion, invalidation, errors, destroyed owner | Paired |
-| `async-session` | Async resource acquisition, stale cleanup, plain-service role | Paired |
-| `scoped-message-presenter` | Optional MnObject role, independent borrowed-source listeners | Paired |
-| `owned-workspace-state` | Nested Applications and separately owned Application/View state | Candidate only |
-| `borrowed-workspace-state` | Nested ownership rejection and borrowed state/domain survival | Candidate only |
+| Task | Required outcomes |
+| --- | --- |
+| `nested-workspace` | Nested Region replacement, text safety, emptying, teardown |
+| `nested-notice` | Independent navigation/notice ownership and callback cleanup |
+| `filter-projects` | CollectionView filter/reveal identity and immutable domain data |
+| `rank-projects` | Row/draft preservation, sorting, atomic invalid-input rejection |
+| `save-shortcut` | Host-scoped Behavior shortcut, rerender and cleanup |
+| `connection-status` | Behavior provider subscription and latest-state rerender |
+| `overlay-switch` | Shared Region, valid live Views, external positioning/exclusivity |
+| `overlay-dismiss` | Shared Region dismissal and document-listener cleanup |
+| `async-panel` | Out-of-order completion, invalidation, errors, destroyed owner |
+| `async-session` | Async resource acquisition, stale cleanup, plain-service role |
+| `scoped-message-presenter` | Optional MnObject role, independent borrowed-source listeners |
+| `owned-workspace-state` | Nested Applications and separately owned Application/View state |
+| `borrowed-workspace-state` | Nested ownership rejection and borrowed state/domain survival |
 
-The last two tasks necessarily ask for named nested-Application ownership and public
-state-source composition. Their proposed candidate-only status must still be checked
-against the selected Phase 0 public API. The other tasks specify outcomes achievable
-through longstanding Views, Regions, Behaviors, collection ownership, and application
-code. A poor baseline result never permits reclassification.
-
-`loadCorpus` validates the task isolation contract, proposed paired floor, and at
-least two independent tasks for every capability in `capabilities.json`. This proves
-metadata coverage; the acceptance/control runs establish the actual case behavior.
-None of these checks establishes sample size, statistical power, agent productivity,
-or stable release readiness.
+`loadCorpus` validates task isolation, a complete decision inventory, and at least
+two independent tasks for every capability in `capabilities.json`. This proves
+prototype metadata coverage; acceptance/control runs establish their actual case
+behavior. Neither establishes evaluation sample size, agent productivity, or stable
+release readiness.

--- a/benchmarks/agent/capabilities.json
+++ b/benchmarks/agent/capabilities.json
@@ -1,7 +1,6 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "coverage": {
-    "minimumTasks": 10,
     "minimumIndependentTasksPerCapability": 2
   },
   "capabilities": [

--- a/benchmarks/agent/evaluation-plan.md
+++ b/benchmarks/agent/evaluation-plan.md
@@ -1,0 +1,123 @@
+# Usability evaluation and comparative research
+
+Use this plan to collect evidence for the [stable-v5 usability gate](../../ROADMAP.md#demonstrated-usability).
+Stable means dependable contracts and demonstrated application usability. Comparative
+research asks when a framework is more effective than another choice. These have
+separate acceptance policies and reports.
+
+This is a preparation procedure. No pilot, frozen policy, scored evaluation, or
+stabilization result is established by this document. The existing
+[prototype corpus](README.md) supplies fixtures and evaluator controls; it is not yet
+a complete build/change/repair evaluation or a cross-framework runner.
+
+## 1. Explore before setting acceptance
+
+Choose realistic work from public application development and anonymous migration
+reproductions. Include building a feature, extending an existing application,
+repairing a seeded defect, and asking a fresh agent to maintain another agent's work.
+Include successive changes that can expose loss of drafts or focus, async races,
+regressions, and resource leaks. Map editing, navigation, collections, overlays,
+async work, and cleanup to executable checks and document gaps.
+
+Run a bounded exploratory pilot to learn task difficulty, failure modes, and useful
+measurements. Preserve its results as pilot evidence. Use those findings to justify
+the release evaluation's repetitions, task-level and aggregate acceptance criteria,
+and human-assistance limits. Do not count pilot attempts in that evaluation or tune
+acceptance to a previously observed candidate score.
+
+Before any paid pilot or evaluation, declare and obtain authorization for its exact
+model/runner profile, permissions, run count, spend ceiling, and elapsed-time budget.
+Creating this plan or running local reference controls does not authorize paid runs.
+
+## 2. Freeze a reviewable evaluation policy
+
+Record the following in the evaluation's public evidence directory before attempts:
+
+| Input | Required record |
+| --- | --- |
+| Objective | Release usability or comparative research; exact claim and exclusions |
+| Tasks | Prompts, starter revisions, build/change/repair families, sequence and handoff rules |
+| Acceptance | Frozen tests, helpers, fixtures, screenshots, discovery, review rubric, and passing criteria |
+| Candidate | Source commit and exact package integrity; supporting docs and application revisions |
+| Agent | Model version, runner version/settings, tools, permissions, documentation/network access |
+| Resources | Repetitions, attempt limits, spend/time ceilings, retries, human-assistance rules |
+| Analysis | Task-level reporting, aggregation, uncertainty, and handling of failures and infrastructure faults |
+| Stabilization | Duration, required workflows, issue severity policy, and evidence refresh rules |
+
+The policy must be executable and approved before collection. Until it is selected
+and evaluated, the release usability gate remains open. There is no automatic
+historical-version comparison or inherited numerical improvement threshold.
+Changes to models, prompts, acceptance, candidate artifacts, or other frozen inputs
+start a new series; preserve the prior results and explain the change.
+
+## 3. Qualify and isolate the work
+
+Run the original public application and frozen tests first. Record test inventory,
+existing failures, exclusions, backend services, data fixtures, browser versions,
+and environment. Keep source-framework UI dependencies and non-UI reuse explicit.
+Do not call a workflow migration a whole-application replacement.
+
+Withheld acceptance tests and reference solutions must be inaccessible to the agent.
+Use enforced isolation, not merely a new directory. Give agents only the declared
+public materials and feedback, then stop their processes before independent
+acceptance. The existing local evaluator is not a security sandbox or a model runner.
+
+Judge requested behavior and documented public contracts. Valid idiomatic solutions
+need not match a reference solution's structure. A task specifically requiring a
+Behavior or other named API is a contract exercise, not a neutral architecture test.
+Do not require unsupported synchronous recovery; apply the documented
+[synchronous failure boundary](../../docs/view.lifecycle.md#synchronous-failures).
+
+## 4. Record every outcome
+
+For each attempt retain the prompt, input hashes, submission, trace, commands,
+acceptance results, elapsed time, available token/spend records, repair cycles, and
+all human intervention. An assisted success is not an unassisted success. Timeouts
+and abandoned work remain unsuccessful attempts; do not publish only best-of runs.
+Record unavailable cost or timing data as unknown.
+
+Report fully correct tasks, existing-behavior regressions, success on later changes,
+accessibility and lifecycle failures, time, and spend. Cost per successful task
+includes failed attempts; when no attempt succeeds, report that directly. Publish
+per-task and per-configuration results before aggregates so easy tasks cannot hide
+repeated failures. Avoid an unexplained composite framework score.
+
+Classify failure causes with evidence: framework defect, documentation gap,
+unsupported requirement, harness problem, or model error. Multiple causes may apply.
+A cause label never converts failed behavior into a pass. Apply predeclared rules
+for infrastructure reruns and retain both the original and rerun records.
+
+## 5. Make the release decision
+
+The maintainer reviews the frozen policy and complete results, including gaps and
+interventions. Repeated framework or documentation failures need a fix and fresh
+evaluation, or a support limitation justified in a new policy and series. Do not
+silently remove a difficult requirement or reclassify a failed task after collection.
+
+Complete the predeclared stabilization period and workflow coverage. Verify
+integration fixes in affected applications and contract suites against the final
+candidate. Identify earlier evidence retained only as history and remaining checks;
+a new version label alone does not transfer a previous result. Publish the release
+decision and limitations alongside the evidence. Package certification and explicit
+publication authorization remain separate requirements.
+
+## Independent ai-framework-benchmark
+
+The proposed separate project starts with React, Vue, and Marionette. Its initial
+question is how often a pinned agent system delivers complete behavior without
+human rescue within a resource budget. Start with realistic documented stacks;
+label any core-framework-only experiment separately. Define and date the model
+selection rule rather than treating "mid-tier" as a permanent category.
+
+Use equivalent behavioral specifications and shared independent acceptance checks,
+while allowing idiomatic framework-specific starters and implementations. Pin
+component libraries, tooling, documentation access, and environment. Report model,
+runner, and framework effects separately where the experiment can distinguish them;
+do not attribute a runner or ecosystem advantage solely to a core framework.
+
+Allow additional frameworks through a documented contribution contract: a reproducible
+starter, passing controls, declared dependencies, and the same acceptance criteria.
+Framework maintainers can review idiomatic usage but cannot weaken shared tests.
+Include failures, uncertainty, and predeclared sampling/analysis rules. Results may
+favor different frameworks for different tasks. Neither a leaderboard win nor
+completion of this independent project is required for stable v5.

--- a/benchmarks/agent/series-decisions.json
+++ b/benchmarks/agent/series-decisions.json
@@ -1,91 +1,68 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "status": "uncollected",
-  "phase0Revision": null,
+  "purpose": "release-usability",
   "candidateRevision": null,
   "model": null,
+  "runner": null,
   "permissions": null,
-  "runPairing": null,
+  "documentationAccess": null,
+  "acceptancePolicy": null,
   "budgets": null,
   "pilot": null,
-  "statisticalProcedure": null,
+  "analysisPlan": null,
+  "stabilization": null,
   "tasks": [
     {
       "id": "nested-workspace",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "nested-notice",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "filter-projects",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "rank-projects",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "save-shortcut",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "connection-status",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "overlay-switch",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "overlay-dismiss",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "async-panel",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "async-session",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "scoped-message-presenter",
-      "proposedStratum": "paired-comparable",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "owned-workspace-state",
-      "proposedStratum": "candidate-only",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     },
     {
       "id": "borrowed-workspace-state",
-      "proposedStratum": "candidate-only",
-      "classificationVerifiedAgainstPhase0": false,
       "predeclaredRuns": null
     }
   ]

--- a/benchmarks/docs/README.md
+++ b/benchmarks/docs/README.md
@@ -2,9 +2,10 @@
 
 These focused tasks test whether an agent can use the distributed skill and
 matching package documentation to implement an application change. They are
-editorial regression trials, separate from the scored release benchmark in
-[benchmarks/agent](https://github.com/marionettejs/marionette/blob/2b5fde974abd94c2da911a02a4bbc0b486c7f661/benchmarks/agent/README.md). They do not establish comparative accuracy,
-model superiority, a release gate, or complete application quality.
+editorial regression trials. They can inform the usability pilot described in the
+[evaluation plan](../agent/evaluation-plan.md), but do not complete the frozen release
+evaluation or establish comparative accuracy, model superiority, or complete
+application quality.
 
 ## Run an independent attempt
 

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -15,7 +15,7 @@ stable; record any change in migration guidance and the release notes.
 
 Stable v5 requires dependable contracts, public migration and application evidence,
 fresh-agent maintenance work, and bounded stabilization under the
-[roadmap](../ROADMAP.md#stable-v5-release-criteria). Comparative agent superiority
+[roadmap](https://github.com/marionettejs/marionette/blob/master/ROADMAP.md#stable-v5-release-criteria). Comparative agent superiority
 and two complete application rewrites are not release requirements.
 
 This beta makes no comparative agent-effectiveness claim. The public corpus remains

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -13,9 +13,15 @@ coordination, optional data/state providers, and first-party package declaration
 Use those documented public contracts. Beta feedback can still change an API before
 stable; record any change in migration guidance and the release notes.
 
+Stable v5 requires dependable contracts, public migration and application evidence,
+fresh-agent maintenance work, and bounded stabilization under the
+[roadmap](../ROADMAP.md#stable-v5-release-criteria). Comparative agent superiority
+and two complete application rewrites are not release requirements.
+
 This beta makes no comparative agent-effectiveness claim. The public corpus remains
-an unscored prototype. This candidate includes consumer lint, a compact contract reference, source maps,
-and a typed starter with browser tests; those tools do not establish agent effectiveness.
+an unscored prototype. This candidate includes consumer lint, a compact contract
+reference, source maps, and a typed starter with browser tests; those tools do not
+establish application usability or complete the release evaluation.
 
 Core is `marionette`. The companion packages are `@mnjs/utils`,
 `@mnjs/radio`, `@mnjs/data`, and `@mnjs/adapters`. Keep all package

--- a/docs/maintainers/documentation-trial.md
+++ b/docs/maintainers/documentation-trial.md
@@ -83,4 +83,5 @@ withholds acceptance files until an attempt ends and does not configure paid inf
 
 The widget reader found misleading Region reuse prose, which was corrected.
 These trials add implementation evidence to the earlier reading check; they remain
-separate from the scored release benchmark and the deferred complete application.
+separate from the frozen release usability evaluation and substantial public
+application evidence required by the [roadmap](../../ROADMAP.md#demonstrated-usability).

--- a/docs/maintainers/documentation.md
+++ b/docs/maintainers/documentation.md
@@ -164,5 +164,6 @@ Then review the reading path. Can a reader identify the relevant version, choose
 approach, find required setup, understand ownership, and verify the result without
 private knowledge? Test a few representative retrieval and implementation tasks
 using the published formats, record failures, and fix the pages those failures
-expose. Use the [agent benchmark](../../benchmarks/agent/README.md) for broader
-performance claims; a small editorial trial is not a scored release result.
+expose. Follow the [evaluation plan](../../benchmarks/agent/evaluation-plan.md) for
+release usability evidence and separate comparative research. A small editorial
+trial does not complete either evaluation.

--- a/docs/maintainers/readme.md
+++ b/docs/maintainers/readme.md
@@ -93,10 +93,12 @@ A passing documentation fixture establishes its assertions for the tested packag
 and environment. It does not establish that agents choose the right pattern, that
 all examples work, or that a release gate is complete.
 
-Use the [agent benchmark contract](../../benchmarks/agent/README.md) for measured
-agent outcomes. A small retrieval or implementation trial can find documentation
-problems, but must state its task, source revision, environment, and untested scope.
-Do not call that trial the full benchmark or a proven improvement.
+Use the [evaluation plan](../../benchmarks/agent/evaluation-plan.md) for public
+application work and independent agent usability evidence. A small retrieval or
+implementation trial can find documentation problems, but must state its task,
+source revision, environment, and untested scope. It does not complete the release
+evaluation or establish a comparative advantage. Follow the
+[release checklist](release-checklist.md) to record acceptance and stabilization.
 
 Keep agent services and developer tools outside the production import graph. A
 new MCP service, inspector, or runtime hook needs an observed problem and an

--- a/docs/maintainers/release-checklist.md
+++ b/docs/maintainers/release-checklist.md
@@ -22,6 +22,36 @@ copying credentials or provider configuration into this checklist.
 | Recovery | Previous verified npm tag targets, website deployment, MCP deployment, and known limitations |
 | Approval | Exact publication/deployment scope and maintainer authorization |
 
+## Stable-v5 acceptance
+
+Before certifying `5.0.0`, attach a decision for each of the
+[roadmap release criteria](../../ROADMAP.md#stable-v5-release-criteria). This section
+is additional to the package and publication steps below; it does not declare the
+current beta stable. The [evaluation plan](../../benchmarks/agent/evaluation-plan.md)
+owns the usability procedure and required records.
+
+- [ ] Supported public contracts are settled and verified. No known unresolved
+  defect remains in a supported critical workflow; limitations are documented.
+- [ ] Representative migration boundaries have public reproductions and upgrade
+  guidance. Record private integration findings without requiring private access
+  or a completed app-frontend migration to verify release readiness.
+- [ ] A substantial public application workflow covers editing, async work,
+  navigation, collections, overlays, and cleanup, with preserved behavior checks
+  and explicit baseline gaps. Record the application, scope, and exact revisions.
+- [ ] The exploratory pilot is recorded separately. The release acceptance policy,
+  model/runner profile, assistance rules, repetitions, and budgets were frozen
+  before independent implementation and fresh-agent maintenance attempts.
+- [ ] Publish every evaluation outcome, including failures, regressions, repair
+  effort, human interventions, later-change results, and evidence-backed causes.
+  Attach the maintainer's acceptance decision against the frozen policy. Unselected
+  criteria and missing results remain open requirements.
+- [ ] Complete the predeclared stabilization duration and workflow coverage.
+  Verify integration fixes against the final candidate; identify superseded
+  evidence and remaining limitations. Changed evaluation inputs require a new
+  series, not a silent transfer of old scores.
+- [ ] Keep comparative claims separate. Historical improvement percentages,
+  framework rankings, and two complete React/Vue rewrites are not release gates.
+
 ## 1. Prepare and certify the library
 
 - [ ] Review the changelog, migration guidance, beta limitations, and resolved

--- a/docs/release-promotion.md
+++ b/docs/release-promotion.md
@@ -147,8 +147,11 @@ Markdown. See [MCP setup](https://marionettejs.com/docs/mcp/) for client instruc
 ## Stable publication authorization
 
 Final release authorization requires one reviewed commit that changes
-`publication.stable` to `true` after every gate in issue #147 passes. Before merging
-that authorization:
+`publication.stable` to `true` after the current
+[roadmap release criteria](../ROADMAP.md#stable-v5-release-criteria) pass and the
+[release checklist](maintainers/release-checklist.md) records the evidence. Issue
+#147 tracks that decision; its historical acceptance text is not an additional gate.
+Before merging that authorization:
 
 1. Create the protected GitHub environment named `stable-release` and require the
    maintainer approval appropriate for the release.

--- a/docs/release-promotion.md
+++ b/docs/release-promotion.md
@@ -16,8 +16,11 @@ disabled; prerelease authorization is restricted to `5.0.0-beta.2`. Schema 2 sep
 A beta authorization never authorizes stable or a later prerelease. Both channels
 use the same protected workflow and exact-artifact checks. Pull requests and manual
 dry runs exercise validation without creating an npm version, tag, or release.
-Stable authorization still requires the final evidence in
-[issue #147](https://github.com/marionettejs/marionette/issues/147).
+Stable authorization still requires the final evidence under the current
+[release criteria](../ROADMAP.md#stable-v5-release-criteria), recorded through the
+[release checklist](maintainers/release-checklist.md) and
+[issue #147](https://github.com/marionettejs/marionette/issues/147). Historical issue
+acceptance text does not reinstate retired comparative benchmark gates.
 Pull-request output cannot activate the write-capable jobs: those jobs also require a
 manual dispatch from `master` in this repository with the `publish` input enabled,
 followed by approval of the protected `stable-release` environment.

--- a/readme.md
+++ b/readme.md
@@ -38,8 +38,9 @@ We're optimistic about agents. We've also read the diffs.
 The v5 pre-release is under active development. These guides describe the current
 source; published prereleases can lag behind it. Registry commands below require
 the named version to be published. Stable v5 will ship only after
-the public correctness, agent-development, packaging, browser, and performance gates
-in the [project roadmap](ROADMAP.md) pass.
+the public contract, migration, application usability, packaging, browser, performance,
+and stabilization gates in the [project roadmap](ROADMAP.md) pass. Comparative
+agent advantages require separate evidence and are not a condition of stability.
 
 ## Install
 

--- a/scripts/agent-benchmark/harness.mjs
+++ b/scripts/agent-benchmark/harness.mjs
@@ -34,10 +34,8 @@ export async function loadCorpus(root = repositoryRoot) {
   await validateTaskContracts({ root, tasks: corpus.tasks });
   const catalog = await readJson(join(root, 'benchmarks/agent/capabilities.json'));
   const decisions = await readJson(join(root, 'benchmarks/agent/series-decisions.json'));
-  const proposedPaired = decisions.tasks.filter(task => task.proposedStratum === 'paired-comparable');
-  if (proposedPaired.length < catalog.coverage.minimumTasks) { throw new Error('At least ten proposed paired tasks are required'); }
   for (const capability of catalog.capabilities) {
-    if (corpus.tasks.filter(task => task.capabilities.includes(capability.id)).length < 2) {
+    if (corpus.tasks.filter(task => task.capabilities.includes(capability.id)).length < catalog.coverage.minimumIndependentTasksPerCapability) {
       throw new Error(`Capability needs independent tasks: ${capability.id}`);
     }
   }

--- a/scripts/agent-benchmark/harness.mjs
+++ b/scripts/agent-benchmark/harness.mjs
@@ -31,9 +31,10 @@ function execute(command, args, cwd, timeout = 120000) {
 export async function loadCorpus(root = repositoryRoot) {
   const corpus = await readJson(join(root, 'benchmarks/agent/corpus.json'));
   if (corpus.schemaVersion !== 1 || corpus.status !== 'prototype-unscored') { throw new Error('Unsupported corpus contract'); }
-  await validateTaskContracts({ root, tasks: corpus.tasks });
   const catalog = await readJson(join(root, 'benchmarks/agent/capabilities.json'));
+  await validateTaskContracts({ root, tasks: corpus.tasks, capabilities: catalog });
   const decisions = await readJson(join(root, 'benchmarks/agent/series-decisions.json'));
+  if (decisions.schemaVersion !== 2) { throw new Error('Unsupported series decisions contract'); }
   for (const capability of catalog.capabilities) {
     if (corpus.tasks.filter(task => task.capabilities.includes(capability.id)).length < catalog.coverage.minimumIndependentTasksPerCapability) {
       throw new Error(`Capability needs independent tasks: ${capability.id}`);

--- a/scripts/agent-benchmark/task-contract.mjs
+++ b/scripts/agent-benchmark/task-contract.mjs
@@ -35,18 +35,14 @@ function validateCapabilityCatalog(catalog, errors) {
     errors.push('capability catalog must contain only schemaVersion, coverage, and capabilities');
   }
 
-  if (catalog?.schemaVersion !== 1) {
-    errors.push('capability catalog schemaVersion must be 1');
+  if (catalog?.schemaVersion !== 2) {
+    errors.push('capability catalog schemaVersion must be 2');
   }
 
   if (!catalog?.coverage ||
     Object.keys(catalog.coverage).sort().join(',') !==
-      'minimumIndependentTasksPerCapability,minimumTasks') {
-    errors.push('capability catalog coverage must contain only the two minimum task fields');
-  }
-
-  if (catalog?.coverage?.minimumTasks !== 10) {
-    errors.push('capability catalog minimumTasks must be 10');
+      'minimumIndependentTasksPerCapability') {
+    errors.push('capability catalog coverage must contain only minimumIndependentTasksPerCapability');
   }
 
   if (catalog?.coverage?.minimumIndependentTasksPerCapability !== 2) {

--- a/test/agent-benchmark/harness.test.mjs
+++ b/test/agent-benchmark/harness.test.mjs
@@ -5,7 +5,7 @@ import { join, posix, win32 } from 'node:path';
 import { test } from 'node:test';
 import { evaluateAttempt, evaluateOutcome, inventory, isWithin, loadCorpus } from '../../scripts/agent-benchmark/harness.mjs';
 
-test('prototype corpus covers every capability twice and proposes ten paired tasks', async() => {
+test('prototype corpus covers every capability twice without historical comparison decisions', async() => {
   const corpus = await loadCorpus();
   assert.equal(corpus.tasks.length, 13);
   assert.equal(corpus.status, 'prototype-unscored');

--- a/test/agent-benchmark/harness.test.mjs
+++ b/test/agent-benchmark/harness.test.mjs
@@ -170,6 +170,25 @@ test('preparation consumes locked tarballs from an isolated cache without regist
   } finally { await rm(directory, { recursive: true, force: true }); }
 });
 
+test('corpus rejects retired metadata from the selected workspace', async() => {
+  const { cp, readFile } = await import('node:fs/promises');
+  const { repositoryRoot } = await import('../../scripts/agent-benchmark/harness.mjs');
+  const directory = await mkdtemp(join(tmpdir(), 'agent-metadata-'));
+  try {
+    await cp(join(repositoryRoot, 'benchmarks/agent'), join(directory, 'benchmarks/agent'), { recursive: true });
+    for (const [file, message] of [
+      ['capabilities.json', /capability catalog schemaVersion must be 2/],
+      ['series-decisions.json', /Unsupported series decisions contract/],
+    ]) {
+      const path = join(directory, 'benchmarks/agent', file);
+      const original = await readFile(path, 'utf8');
+      await writeFile(path, JSON.stringify({ ...JSON.parse(original), schemaVersion: 1 }));
+      await assert.rejects(loadCorpus(directory), message);
+      await writeFile(path, original);
+    }
+  } finally { await rm(directory, { recursive: true, force: true }); }
+});
+
 test('corpus decisions reject an extra duplicate task', async() => {
   const { cp, readFile } = await import('node:fs/promises');
   const { repositoryRoot } = await import('../../scripts/agent-benchmark/harness.mjs');

--- a/test/agent-benchmark/task-contract.test.mjs
+++ b/test/agent-benchmark/task-contract.test.mjs
@@ -9,9 +9,8 @@ import {
 } from '../../scripts/agent-benchmark/task-contract.mjs';
 
 const capabilities = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   coverage: {
-    minimumTasks: 10,
     minimumIndependentTasksPerCapability: 2,
   },
   capabilities: [


### PR DESCRIPTION
Related #128

## What
- Make stable v5 depend on verified public contracts, public migration and application evidence, fresh-agent maintenance work, and bounded stabilization.
- Add the usability evaluation procedure and align maintainer, beta, release-checklist, issue-template, and agent guidance. Keep comparative framework research separate from release acceptance.
- Remove retired baseline task classifications and the fixed paired-task floor from uncollected benchmark metadata and development tooling; retain task isolation and prototype capability-diversity checks.

## Why
The previous gates mixed dependable-release evidence with prescribed improvements over a historical Marionette revision. The accepted direction requires demonstrated application usability without making a comparative win or two complete application rewrites prerequisites for stability. The pilot must inform a frozen policy before a separate release evaluation; existing prototypes do not establish that evaluation is complete.

## Scope
Project strategy, contributor/consumer guidance, release preparation, and benchmark development tooling. No production library source, public runtime API, package version, publication authorization, or recorded historical result changes. Existing GitHub issue acceptance text still needs reconciliation; this PR does not complete #128 or run an agent evaluation.

## Deployment Impact
No application or form redeployment is required. Documentation publication follows the normal exact-revision import/deployment process after merge. This PR does not publish packages, deploy documentation, or run paid agents.

## Testing
- `npm run test:agent-benchmark-contract` — 37 tests passed, including corpus validation, hidden-test isolation, duplicate decision rejection, selected-workspace schema rejection, and unsuccessful-attempt handling.
- `npm run docs:check` — passed; 114 pages built, 115 HTML files and 1,734 internal links validated.
- `npm run check:api-contracts` — public contract inventory matches.
- `node node_modules/eslint/bin/eslint.js scripts/agent-benchmark/harness.mjs scripts/agent-benchmark/task-contract.mjs test/agent-benchmark/harness.test.mjs test/agent-benchmark/task-contract.test.mjs --max-warnings=0` — passed.
- `git diff --check` — passed.
- `npm run test:fixtures -- --fixture docs-package` — passed after correcting a CI-discovered relative roadmap link in the packaged beta guide; includes the package build and installed-documentation checks.
- Production browser/runtime suites were not run locally because no production source changed; the PR workflows provide the broader checks. These checks establish documentation/tooling consistency, not agent usability or release readiness.

## Breaking changes
No public runtime API change. Uncollected benchmark planning and capability metadata move to schema 2 and discard the retired fields; there is no compatibility path for the obsolete prototype policy.
