### PR TITLE
docs(agents): improve first-draft guidance and typed starter

### DIFF
--- a/config/api-contracts/inventory.json
+++ b/config/api-contracts/inventory.json
@@ -8072,7 +8072,7 @@
   },
   "evidence": {
     "config/diagnostics/catalog.json": "a044dac8d4242de8e7c6c58a6442fb58384069c0f4d76ec6fabec03f34697eac",
-    "docs/choosing-integrations.md": "24ce6295dcc8cf8f587a52a935e2b351ebab4e9721e6ed311625c611eec0bc6c",
+    "docs/choosing-integrations.md": "385bfb2c7d85a8e0db71fd795ed1fef488aa637aa5094e93210810ff91f31f12",
     "docs/data.api.md": "c9bf72e4afd8c9b774391b3e343284808705887c8a38265609bfad910193e45c",
     "docs/diagnostic-catalog.md": "1df844c7e8edbea59a8c07776d656d45f77266108babb770d7690183fe85d180",
     "docs/dom.api.md": "a697a637ae4c6cc92aa5d72850b404763f08e0417800feacc0b431ec073d3916",

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -62,6 +62,33 @@ for repeated children. Use an Application when work has an asynchronous feature
 lifecycle. A plain function or class is enough when it needs none of these
 contracts. The [class guide](./classes.md) explains the boundaries.
 
+Before expanding a small example into an application, revisit its data and ownership
+choices. A recipe demonstrating manually managed children is not a default data
+architecture for a todo application. Domain records belong in a data source;
+CollectionView children are their presentation. Do not use child View traversal as
+the application's record store. Plain arrays can remain appropriate for explicit
+snapshot updates. When records need shared observation, filtering, and coordinated
+updates, select an observable provider; for a new application without one, start
+with `@mnjs/data` and its [DataApi setup](./data.api.md).
+
+Native DOM defaults describe the integration, not a replacement for View composition.
+Render ordinary content through `template` and `templateContext`, place child Views
+through named Regions, and declare controls with `ui`, `events`, and `triggers`.
+Use `events` when the handler needs input or keyboard details; use `triggers` when
+an interaction should become a View event. Direct DOM work still belongs at real
+integration boundaries, such as focus, measurements, and an external animation or
+widget. Keep its lifetime with the owning View.
+
+Observe each field used by a template or derived display, including changes that
+do not come from its main button. Let CollectionView handle membership changes
+without a second whole-list render subscription. Keep focused editors stable
+when processing their own input.
+
+When building teaching examples, make the application runnable independently of
+narration and inspection. Prefer ordinary modules with explicit imports and exports.
+Check that the preview supports the selected packages and module structure; a tiny
+sandbox's restrictions should not silently become the recommended app architecture.
+
 Configure the selected runtime before creating its consumers. The default named
 exports share a runtime. Use [runtime isolation](./runtime-isolation.md) when
 independent configurations must coexist; do not create a runtime per View.
@@ -106,6 +133,13 @@ Use a real browser when correctness depends on focus, attachment, DOM event
 propagation, or editable state. A build or screenshot alone does not prove those
 interactions. Use documented public APIs for assertions rather than private
 framework fields.
+
+Review the architecture separately from interaction results: identify the data
+source, the Views and Regions that own the screen, and the external work each owner
+releases. Working buttons do not establish that the example teaches those contracts.
+For observable data, change the source directly and verify all intended consumers
+update. For attachment-bound resources, also detach and reattach the same View;
+replacement alone does not prove that repeated attachment releases resources.
 
 When reporting a change, name the behavior, the tested package/source, the exact
 commands or interactions performed, and any untested boundary. Keep changes

--- a/docs/choosing-integrations.md
+++ b/docs/choosing-integrations.md
@@ -81,11 +81,8 @@ import { View } from 'marionette';
 import BackboneApi from '@mnjs/adapters/backbone';
 
 const AccountView = View.extend({
-  template: () => '<span class="name"></span>',
-  modelEvents: { change: 'render' },
-  onRender() {
-    this.el.querySelector('.name').textContent = this.model.get('name');
-  }
+  template: ({ active }) => `<span>${active ? 'Active' : 'Inactive'}</span>`,
+  modelEvents: { change: 'render' }
 });
 AccountView.setDataApi(BackboneApi);
 ```

--- a/skills/marionette/SKILL.md
+++ b/skills/marionette/SKILL.md
@@ -42,8 +42,8 @@ immutable release.
 
 Start with packaged `docs/agents.md`, then use these source paths from the manifest:
 
-- New setup or an integration decision: `docs/installation.md` and
-  `docs/choosing-integrations.md`.
+- New application: `docs/development.md` for the executable typed starter;
+  `docs/installation.md` and `docs/choosing-integrations.md` for setup decisions.
 - UI ownership and replacement: `docs/marionette.view.md`,
   `docs/marionette.region.md`, and `docs/view.lifecycle.md`.
 - Changing lists: `docs/marionette.collectionview.md` and `docs/data.api.md`.
@@ -75,6 +75,26 @@ router independently. A Backbone router does not require Backbone data or state.
 Register configuration before creating its consumers; use an isolated runtime only
 when independent configurations must coexist.
 
+Make the first draft idiomatic: templates for ordinary content, named Regions for
+composition, `ui` for controls, `triggers` for semantic View events, and `events`
+when the handler needs the DOM event. Domain records belong in data sources;
+CollectionView children are their presentation, not a record store. For a new
+observable list, start with `@mnjs/data` and configure DataApi before construction.
+Native Collection `toArray()` returns plain attributes; iteration yields Models.
+Do not assume Backbone/Underscore methods.
+Update the smallest responsible View so unrelated drafts, focus and child identity
+survive. Cover every displayed or calculated field in data subscriptions, and let
+CollectionView reconcile membership without an extra whole-list render handler.
+Do not replace focused inputs in response to their own edits.
+Native DOM access belongs at boundaries such as focus or a widget.
+
+For a personalized app, connect a real user preference to both the interaction and
+visual design. Choose a specific visual direction before coding; preserve readable
+hierarchy, spacing, contrast, labels and narrow layouts. Do not force a line count
+that collapses independent owners into one View. Keep teaching/test controls out of
+the app itself. The website's optional personal-app brief supplies its own starter;
+it does not authorize browsing private sources for personalization.
+
 Name the owner and cleanup operation for Views, subscriptions, widgets, and async
 work. Use public lifecycle APIs. Check stale work before committing side effects;
 framework cancellation cannot undo arbitrary writes by application code. Consult
@@ -83,7 +103,10 @@ it from a method name.
 
 Use the application's own test commands. Exercise the requested behavior and its
 relevant boundary: stale navigation, surviving edits/focus, rerendered event
-handlers, or resource cleanup. Browser behavior needs a browser check. Report
+handlers, or resource cleanup. For observable records, change a source directly and verify all interested Views,
+not just the clicked row. Check repeated attachment for attachment-bound work.
+Browser behavior needs a browser check; visual quality needs rendered inspection
+at desktop and narrow widths. Report
 commands actually run and untested boundaries; a successful build is not proof of
 those interactions. Record changed integration decisions in the application's own
 instructions without copying the library's maintainer policy.

--- a/test/fixtures/data-package-starter/AGENTS.md
+++ b/test/fixtures/data-package-starter/AGENTS.md
@@ -22,8 +22,10 @@ workshop, not this application.
   `@mnjs/data` DataApi and StateApi before creating Views. Rendering uses function
   templates and native DOM. There is no Backbone dependency or URL router.
 - The root Region owns the shell. Its list Region owns the CollectionView and
-  rows; its detail Region owns the selected View. Draft inputs survive ordinary
-  collection reordering. Shell-created status state is owned by the shell.
+  rows; its detail Region owns the selected View. A separate status View borrows
+  shell-owned state and renders updates without disturbing editable rows. Draft
+  inputs survive ordinary collection reordering. Templates render escaped content;
+  `ui` and semantic `triggers` declare controls.
 - The workspace owns the note collection and pending AbortController. `navigate`
   cancels obsolete loads and checks cancellation before committing results, even
   if a loader ignores its signal. `destroy` releases the workspace.

--- a/test/fixtures/data-package-starter/workspace.test.mjs
+++ b/test/fixtures/data-package-starter/workspace.test.mjs
@@ -68,7 +68,7 @@ test('missing attributes render empty text and supplied text stays escaped', asy
   try {
     const { createWorkspace } = await import('./workspace.ts');
     const { Model } = await import('@mnjs/data');
-    const literal = '\"><img src=x onerror="alert(1)">&';
+    const literal = '"><img src=x onerror="alert(1)">&';
     workspace = createWorkspace({
       el: document.querySelector('main'),
       async loadNote(id) {

--- a/test/fixtures/data-package-starter/workspace.test.mjs
+++ b/test/fixtures/data-package-starter/workspace.test.mjs
@@ -59,3 +59,38 @@ test('editable survivors, latest selection and cleanup use installed package API
     delete globalThis.document;
   }
 });
+
+test('missing attributes render empty text and supplied text stays escaped', async() => {
+  const dom = new JSDOM('<main></main>');
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  let workspace;
+  try {
+    const { createWorkspace } = await import('./workspace.ts');
+    const { Model } = await import('@mnjs/data');
+    const literal = '\"><img src=x onerror="alert(1)">&';
+    workspace = createWorkspace({
+      el: document.querySelector('main'),
+      async loadNote(id) {
+        return id === 'missing' ? { title: null } : { title: literal, body: literal };
+      }
+    });
+    workspace.notes.add(new Model({ id: 'missing' }));
+    workspace.notes.add(new Model({ id: 'null', title: null }));
+    workspace.notes.add(new Model({ id: 'escaped', title: literal }));
+    assert.deepEqual([...document.querySelectorAll('input')].slice(2).map(input => input.value), ['', '', literal]);
+    assert.equal(await workspace.navigate('missing'), true);
+    assert.equal(document.querySelector('h2').textContent, '');
+    assert.equal(document.querySelector('section p').textContent, '');
+    assert.equal(document.querySelector('[role="status"]').textContent, 'Loaded.');
+    assert.equal(await workspace.navigate('escaped'), true);
+    assert.equal(document.querySelector('h2').textContent, literal);
+    assert.equal(document.querySelector('section p').textContent, literal);
+    assert.equal(document.querySelectorAll('img, [onerror]').length, 0);
+  } finally {
+    workspace?.destroy();
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  }
+});

--- a/test/fixtures/data-package-starter/workspace.ts
+++ b/test/fixtures/data-package-starter/workspace.ts
@@ -1,6 +1,10 @@
 import { createMarionette } from 'marionette';
 import { Collection, DataApi, Model, StateApi } from '@mnjs/data';
 
+const escapeHTML = (value: string) => value.replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+
 export type Note = { title: string; body: string };
 export type NoteRow = { id: string; title: string };
 export type WorkspaceOptions = {
@@ -24,51 +28,51 @@ export function createWorkspace({ el, loadNote }: WorkspaceOptions) {
   const Row = View.extend({
     tagName: 'li',
     initialize(options: { model: Model<NoteRow> }) { void options; },
-    template: () => '<label>Draft title <input></label><button type="button">Open</button>',
-    events: { 'click button': 'open' },
-    onRender() { this.input().value = this.options.model.get('title') ?? ''; },
-    input(): HTMLInputElement {
-      const input = this.el.querySelector('input');
-      if (!input) { throw new Error('Row template requires an input'); }
-      return input;
+    template: ({ title }: NoteRow) => `<label>Draft title <input value="${escapeHTML(title)}"></label><button type="button">Open</button>`,
+    ui: { input: 'input', open: 'button' },
+    triggers: { 'click @ui.open': 'click:open' },
+    inputValue(): string {
+      const input = this.getUI('input')?.[0];
+      if (!input || !('value' in input) || typeof input.value !== 'string') {
+        throw new Error('Row template requires an input');
+      }
+      return input.value;
     },
-    open() {
+    onClickOpen() {
       const model = this.options.model;
       const id = model.get('id');
       if (id === undefined) { throw new Error('A note requires an id'); }
-      model.set('title', this.input().value);
+      model.set('title', this.inputValue());
       void navigate(id).catch(() => undefined); // navigate owns the visible error state.
     }
   });
   const List = CollectionView.extend({ tagName: 'ul', childView: Row });
   const Detail = View.extend({
     initialize(options: { model: Note }) { void options; },
-    template: () => '<h2></h2><p></p>',
-    onRender() {
-      const heading = this.el.querySelector('h2');
-      const body = this.el.querySelector('p');
-      if (!heading || !body) { throw new Error('Detail template is incomplete'); }
-      heading.textContent = this.options.model.title;
-      body.textContent = this.options.model.body;
-    }
+    templateContext() { return this.options.model; },
+    template: ({ title, body }: Note) => `<h2>${escapeHTML(title)}</h2><p>${escapeHTML(body)}</p>`
+  });
+  const Status = View.extend({
+    tagName: 'p',
+    attributes: { role: 'status' },
+    initialize(options: { state: Model<{ message: string }> }) { void options; },
+    templateContext() { return this.options.state.toObject(); },
+    template: ({ message }: { message: string }) => escapeHTML(message),
+    stateEvents: { 'change:message': 'render' }
   });
   const Shell = View.extend({
     createState() { return new Model({ message: 'Choose a note.' }); },
-    stateEvents: { 'change:message': 'showStatus' },
-    showStatus() {
-      const status = this.el.querySelector('[role="status"]');
-      if (status) { status.textContent = this.getState().get('message') ?? ''; }
-    },
-    template: () => '<h1>Notes</h1><button type="button" data-reorder>Reverse rows</button><div data-list></div><p role="status"></p><section aria-label="Selected note" data-detail></section>',
-    regions: { list: '[data-list]', detail: '[data-detail]' },
-    events: { 'click [data-reorder]': 'reverse' },
-    reverse() {
+    template: () => '<h1>Notes</h1><button type="button" data-reorder>Reverse rows</button><div data-list></div><div data-status></div><section aria-label="Selected note" data-detail></section>',
+    regions: { list: '[data-list]', status: '[data-status]', detail: '[data-detail]' },
+    ui: { reorder: '[data-reorder]' },
+    triggers: { 'click @ui.reorder': 'click:reverse' },
+    onClickReverse() {
       const first = notes.at(0);
       if (first) { notes.move(first, notes.length - 1); }
     },
     onRender() {
       this.showChildView('list', new List({ collection: notes }));
-      this.showStatus();
+      this.showChildView('status', new Status({ state: this.getState() }));
     }
   });
   const region = new Region({ el });
@@ -102,6 +106,7 @@ export function createWorkspace({ el, loadNote }: WorkspaceOptions) {
     pending?.abort();
     pending = undefined;
     region.destroy();
+    notes.destroy();
   }
   return { notes, navigate, destroy };
 }

--- a/test/fixtures/data-package-starter/workspace.ts
+++ b/test/fixtures/data-package-starter/workspace.ts
@@ -1,7 +1,8 @@
 import { createMarionette } from 'marionette';
 import { Collection, DataApi, Model, StateApi } from '@mnjs/data';
 
-const escapeHTML = (value: string) => value.replaceAll('&', '&amp;')
+// Escape text and quoted HTML attributes, not URLs, scripts, or styles.
+const escapeHTML = (value: unknown) => String(value ?? '').replaceAll('&', '&amp;')
   .replaceAll('<', '&lt;').replaceAll('>', '&gt;')
   .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
 
@@ -48,15 +49,13 @@ export function createWorkspace({ el, loadNote }: WorkspaceOptions) {
   });
   const List = CollectionView.extend({ tagName: 'ul', childView: Row });
   const Detail = View.extend({
-    initialize(options: { model: Note }) { void options; },
-    templateContext() { return this.options.model; },
     template: ({ title, body }: Note) => `<h2>${escapeHTML(title)}</h2><p>${escapeHTML(body)}</p>`
   });
   const Status = View.extend({
     tagName: 'p',
     attributes: { role: 'status' },
     initialize(options: { state: Model<{ message: string }> }) { void options; },
-    templateContext() { return this.options.state.toObject(); },
+    templateContext(this: { getState(): Model<{ message: string }> }) { return this.getState().toObject(); },
     template: ({ message }: { message: string }) => escapeHTML(message),
     stateEvents: { 'change:message': 'render' }
   });


### PR DESCRIPTION
## What
- Make the consumer guide and packaged Marionette skill teach templates, named Regions, data ownership, complete update subscriptions, focused-input preservation, and rendered personal-app review.
- Replace imperative content updates in the integration example and typed data starter with escaped templates, UI bindings, semantic triggers, and a separate status View.
- Release the starter's owned collection during workspace destruction.

## Why
Agents following the starter should encounter the same composition and ownership patterns expected in finished applications. Working buttons alone missed architecture, direct-data updates, draft preservation, and visual-quality checks; the guidance now identifies those separately.

## Scope
Consumer documentation, the packaged skill, and `test/fixtures/data-package-starter`. No changes to `src/`, `packages/*/src/`, runtime APIs, or production allocation costs. The accepted synchronous lifecycle failure contract is unchanged; this does not introduce synchronous recovery or rollback behavior.

## Deployment Impact
No forms or bundles need redeployment and no application deployment is required. These examples run on published beta.2. The updated packaged documentation/skill and distributed starter require the next package publication (beta.3 if that is the next release); the website can publish equivalent guidance independently now. This PR does not release packages, publish tags, or deploy documentation.

## Testing
Completed locally with Node 24.19.0:
- `npm ci`
- `npm run docs:check` — 30 executable documentation examples, 114 built pages, and 1,735 internal links validated.
- `npm run test:fixtures -- --fixture data-package-starter` — package build/pack plus isolated starter typecheck, lint, public-contract tests, and Vite build passed.
- Independently copied this starter into a fresh consumer directory with exact npm `marionette@5.0.0-beta.2` and `@mnjs/data@5.0.0-beta.2`; `npm install`, `npm run validate`, and `npm run test:browser` passed. All three browser checks passed: editable-row identity/draft preservation during reorder and navigation, latest-selection wins, and departure cleanup.
- `npm run check:api-contracts` — passed after refreshing only the edited integration guide's evidence hash; the first CI attempt identified the stale hash.
- Review regression: a missing row title reproduced `TypeError: Cannot read properties of undefined (reading replaceAll)` before the fix. The new public-behavior test now verifies missing/null row and detail fields render empty text, quotes/markup remain literal, and status still updates.
- After the review fix, reran the targeted package fixture and the published-beta.2 consumer validation (typecheck, lint, two Node tests, build, and all three browser tests); all passed.
- `npm run lint` — full repository lint passed after correcting the unnecessary escape in the new fixture test; both starter Node tests also passed again against published beta.2.
- `git diff --check`

The complete library verification suite was not run locally for these docs/fixture-only changes; CI provides broader checks. This is reference-path evidence, not a scored fresh-agent benchmark or a guarantee of beautiful generated applications.

## Breaking changes
None to published runtime APIs. Examples now canonically demonstrate composed Views and template-owned content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for choosing application patterns, validating behavior, and building idiomatic Marionette applications.
  - Updated integration examples to demonstrate template-driven rendering and clearer application architecture.
  - Clarified ownership, escaped content, controls, and status updates in the starter application guidance.

- **Bug Fixes**
  - Starter application examples now safely escape rendered content and handle missing note values without creating unintended markup or handlers.
  - Improved repeated view attachment and cleanup behavior.

- **Tests**
  - Added coverage for empty values, literal content, HTML escaping, and workspace cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->