### PR TITLE
docs(agents): streamline consumer and maintainer guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,10 @@
 These instructions are for changing this library. For building an application
 with Marionette, start with [the consumer agent guide](docs/agents.md).
 
-1. Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup and repository conventions.
-2. Use the [maintainer guide](docs/maintainers/readme.md) to select the public
-   contract, source, and checks for the task. Load only the relevant references.
-3. Follow [ROADMAP.md](ROADMAP.md) for architecture and release decisions. A
-   roadmap item is planned work until source and public evidence establish it.
+Use [CONTRIBUTING.md](CONTRIBUTING.md) for setup and repository conventions,
+[the maintainer guide](docs/maintainers/readme.md) to locate an affected contract
+and its checks, and [ROADMAP.md](ROADMAP.md) for architecture or release decisions.
+Read the sections needed for the task; roadmap plans are not available APIs.
 
 Before editing, inspect the branch and worktree. Preserve unrelated changes.
 Identify the requested behavior and whether its cost is documentation/static,
@@ -24,10 +23,12 @@ Use authored TypeScript source and public package APIs. Keep agent guidance,
 benchmarks, inspection tools, and development helpers out of production imports.
 An unused optional feature must add no per-instance resources or global registry.
 
-Run the smallest checks that prove the change, then the broader checks required
-by its contracts. Report exactly what ran, what it proves, and any remaining
-uncertainty. Do not infer behavior from declarations, doc markers, or green CI
-alone. Do not publish, release, or deploy without authorization for that action.
+Completion means the requested behavior is implemented, superseded code and
+associated contracts are updated, and relevant checks establish the result.
+Continue through failures caused by the change within the authorized scope.
+Report the source revision, commands actually run, results, and remaining gaps;
+declarations, doc markers, and green CI alone do not prove runtime behavior.
+Do not publish, release, or deploy without authorization for that action.
 
 ## Tests are public contracts
 
@@ -53,16 +54,14 @@ Follow the public [synchronous failure contract](docs/view.lifecycle.md#synchron
 [Test guide](test/README.md) maps contracts to suites, commands, reports, and replay instructions.
 
 - Fast iteration: `npm test -- <file> -t '<contract>'` or `npm run test:watch -- <file>`.
-- Local review: `npm run verify`; complete local validation: `npm run verify -- --full`.
+- Choose checks for the affected contract. `npm run verify` and `npm run verify -- --full` are broader local validation options, not requirements for every edit.
 - Lint is read-only: `npm run lint`. Apply fixes explicitly with `npm run lint:fix`.
 - Source changes require `npm run build` before direct browser, distribution, or consumer-type checks.
 - Release candidates require a clean source commit, `release:artifact`, then `release:validate` against those exact tarballs. Never publish packages/tags or deploy documentation as a side effect of testing.
 
 ## Implementation and evidence
 
-- Make the requested behavior canonical. Avoid aliases, fallbacks, dual paths, or new runtime infrastructure without a verified consumer and removal condition.
-- Keep test, lint, benchmark, and diagnostic tooling outside production import graphs. Runtime cost remains part of review.
 - Use stable diagnostic codes for invariants. Do not make agent workflows depend on exact prose or undocumented maintainer knowledge.
 - New async CLI code must await work and propagate failures. Preserve concise failure output plus detailed machine-readable artifacts.
-- Report commands actually run, source revision, failures, and gaps. Coverage and a successful reference solution do not establish agent usability; that requires the frozen usability evaluation and public application evidence in ROADMAP.md. Comparative research is separate from release readiness.
+- Coverage and a successful reference solution do not establish agent usability; that requires the frozen usability evaluation and public application evidence in ROADMAP.md. Comparative research is separate from release readiness.
 - Do not run paid agent pilots or evaluations without a predeclared model/runner profile, permissions, run count, spend and elapsed-time budget, and authorization for that envelope. Follow [the evaluation plan](benchmarks/agent/evaluation-plan.md).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,8 +6,8 @@ For changes to Marionette itself, use the [maintainer guide](https://github.com/
 
 ## Establish the installed contract
 
-Before choosing an API, inspect the application's package manifest, lockfile,
-installed declarations, and existing Marionette configuration. Record:
+Use the application's manifest, lockfile, and configuration to establish the
+contract when it is not already known. Relevant facts are:
 
 - the installed `marionette` version and matching optional package versions;
 - whether the dependency comes from a published package, Git commit, or local build;
@@ -28,8 +28,9 @@ silently upgrade dependencies to make an example fit.
 
 ## Read for the task
 
-Use the [compact framework reference](./compact-reference.md) for an overview of
-contracts, ownership, imports, and diagnostics before opening the specific guide.
+Use the task table directly. The [compact framework reference](./compact-reference.md)
+provides an overview when the task spans unfamiliar contracts; it is not a
+prerequisite for reading a specific guide.
 
 | Task | Start here | Verify |
 | --- | --- | --- |
@@ -69,7 +70,9 @@ CollectionView children are their presentation. Do not use child View traversal 
 the application's record store. Plain arrays can remain appropriate for explicit
 snapshot updates. When records need shared observation, filtering, and coordinated
 updates, select an observable provider; for a new application without one, start
-with `@mnjs/data` and its [DataApi setup](./data.api.md).
+with `@mnjs/data` and its [DataApi setup](./data.api.md). Native Collection
+`toArray()` returns plain attributes; iteration yields Models. Do not assume
+Backbone/Underscore methods.
 
 Native DOM defaults describe the integration, not a replacement for View composition.
 Render ordinary content through `template` and `templateContext`, place child Views
@@ -88,6 +91,13 @@ When building teaching examples, make the application runnable independently of
 narration and inspection. Prefer ordinary modules with explicit imports and exports.
 Check that the preview supports the selected packages and module structure; a tiny
 sandbox's restrictions should not silently become the recommended app architecture.
+
+For personalized applications, connect a real user preference to interaction and
+visual design. Preserve readable hierarchy, spacing, contrast, labels, and narrow
+layouts; inspect the rendered result at desktop and narrow widths when changing
+visuals. Do not collapse independent owners to meet a line count or include
+teaching/test controls in the app. The website's optional personal-app brief supplies
+its own starter; it does not authorize browsing private sources for personalization.
 
 Configure the selected runtime before creating its consumers. The default named
 exports share a runtime. Use [runtime isolation](./runtime-isolation.md) when
@@ -118,12 +128,13 @@ side effects. Marionette suppresses stale lifecycle completion; it cannot undo a
 arbitrary write made by application code. Follow the complete
 [routing pattern](./routing.md) for navigation and feature startup.
 
-## Prove the behavior in the application
+## Completion evidence
 
 Use the application's existing test runner, scripts, and package manager. Library
 maintenance commands are not a consumer project's test strategy.
 
-Test the successful interaction and the boundary most likely to break. For an
+The requested behavior is complete when its interaction and affected ownership
+boundary work in the installed application. For an
 asynchronous screen, navigate away while work is pending and ensure its stale
 result cannot replace the current screen. For a list, edit a surviving row while
 inserting, removing, or reordering another row. For a subscription, destroy one
@@ -152,25 +163,10 @@ Follow [Set up an agent](./agent-tools.md) to install the consumer skill and rea
 version-matched packaged docs. Adapt the [application instruction template](./application-agent-template.md)
 to preserve this project's actual decisions across tasks.
 
-For optional structured retrieval, follow the website's
-[documentation MCP setup](https://marionettejs.com/docs/mcp/). A link does not
-configure a client or activate a skill. Read `marionette://catalog` first; use its
-tools only when package version and source match this application, passing the
-exact installed `version` on every call. Follow `nextOffset` until it is `null`
-to read the complete contract, not just a search
-snippet. An unsupported version should send you back to the installed docs, not
-cause a dependency upgrade. WebMCP is separate: it controls website examples.
+For structured retrieval or service setup, use [the agent tools guide](./agent-tools.md).
+It owns exact-version/source matching, MCP pagination, and offline retrieval rules.
+Read those rules before using a remote service. No hosted service is required.
+Website WebMCP controls its example; its results do not establish application behavior.
 
-A Markdown page or versioned documentation index can be read directly. A service
-such as Context7 can help locate the relevant passage, but verify its library and
-version selection before using the result. When retrieval is unavailable, use the
-same source documents in the repository or the matching documentation artifact.
-
-A documentation index does not install instructions into every agent. An
-application's own agent instructions should link to this guide and record its
-installed version and architecture choices. They should not copy this entire guide
-or use this library's maintainer instructions as application policy.
-
-Use playground tools only to examine the example they control. Their results do
-not establish behavior in your application. No hosted AI service or MCP server is
-required to use Marionette or follow this workflow.
+Application instructions should record local decisions and link to the relevant
+contracts, not copy this guide or the library's maintainer policy.

--- a/docs/application-agent-template.md
+++ b/docs/application-agent-template.md
@@ -47,8 +47,9 @@ a router choice does not imply a data, state, renderer, or DOM adapter change.
 - Build/type check: [existing command and working directory].
 - Relevant existing patterns: [a few actual source or test paths].
 
-For the changed behavior, verify the appropriate interaction and cleanup boundary.
-Report the checks actually run and anything left untested. Update this file when
+Completion means the requested behavior works with evidence for the affected
+interaction and cleanup boundary. Use the relevant checks above; report actual
+results and anything left untested. Update this file when
 an application decision changes; keep the API reference in the matching docs.
 ```
 

--- a/docs/maintainers/documentation.md
+++ b/docs/maintainers/documentation.md
@@ -149,21 +149,21 @@ boundary explicit: inspecting an example is not inspecting the reader's app, and
 browser tool is not a remote docs server. Expose only the example's supported
 operations; keep them optional and outside the library's production import graph.
 
-## Review in two passes
+## Documentation completion
 
-First verify correctness against source, package exports, and the example's actual
-behavior. A matching executable marker only connects a snippet to a fixture; run
-the fixture to establish its assertions. Check links, anchors, version selection,
-and generated Markdown as well as the rendered page.
+Changed contracts must agree with source and package exports. A matching executable
+marker only connects a snippet to a fixture; changed executable examples need their
+fixture results. Prose/link edits need documentation checks; rendering changes need
+rendered inspection. Unchanged examples do not require reruns for editorial edits.
 
 External live examples, including older JSFiddle links, are illustrative until
 their package and source provenance are verified. Their presence is not current
 version evidence. Prefer repository-owned fixtures for canonical patterns.
 
-Then review the reading path. Can a reader identify the relevant version, choose an
+The reading path should let a reader identify the relevant version, choose an
 approach, find required setup, understand ownership, and verify the result without
-private knowledge? Test a few representative retrieval and implementation tasks
-using the published formats, record failures, and fix the pages those failures
-expose. Follow the [evaluation plan](../../benchmarks/agent/evaluation-plan.md) for
-release usability evidence and separate comparative research. A small editorial
-trial does not complete either evaluation.
+private knowledge. For changes to discovery or task guidance, representative
+retrieval or implementation trials can expose gaps; record their scope and failures.
+Follow the [evaluation plan](../../benchmarks/agent/evaluation-plan.md) for release
+usability evidence and separate comparative research. A small editorial trial does
+not complete either evaluation.

--- a/docs/maintainers/readme.md
+++ b/docs/maintainers/readme.md
@@ -4,22 +4,11 @@ This guide is the operating procedure for changing the library. It gives agents
 and human contributors the same route from a task to a public contract and useful
 evidence. Application authors should use the [consumer guide](../agents.md).
 
-## Orient once
-
-Read the requested change and inspect the current branch and worktree. Record the
-source revision when evidence depends on it. Use the toolchain in the
-[release profile](../release-profile.md) and the setup in
-[CONTRIBUTING.md](../../CONTRIBUTING.md).
-
-Classify the work as documentation/static, development/test, an existing production
-path, or an opt-in runtime path. Identify the affected contract: lifecycle,
-ownership, data/state, DOM, diagnostics, types, or distribution. Consult the relevant
-part of [ROADMAP.md](../../ROADMAP.md) when changing architecture or release scope.
-Its planned tooling is not an available API.
-
-Proceed with routine implementation choices supported by the existing contract.
-If the requested change leaves a material public behavior undecided, state the
-specific decision and continue independent work while it is resolved.
+Use [CONTRIBUTING.md](../../CONTRIBUTING.md) and the
+[release profile](../release-profile.md) when setting up the toolchain.
+[AGENTS.md](../../AGENTS.md) defines production-change, public-test, and failure
+boundaries. Routine implementation choices within the established contract do not
+need a separate decision gate; unresolved public behavior does.
 
 ## Find the contract and its implementation
 
@@ -44,16 +33,12 @@ the affected public symbol and inspect its direct collaborators and tests.
 For a release, use the [release checklist](./release-checklist.md) across package
 publication, GitHub notes, website deployment, and the matching MCP snapshot.
 
-1. Describe the expected observable behavior. For a bug, reproduce the failing
-   behavior through the public API before relying on a proposed fix.
-2. Change the owner of the contract. Update types, diagnostics, examples, and tests
-   that encode the same behavior. Remove superseded paths rather than retaining
-   speculative compatibility.
-3. Validate the behavior and its relevant boundaries. For lifecycle changes, test
-   ownership and teardown; for asynchronous work, test supersession and rejection;
-   for data reconciliation, test surviving child identity and editable state.
-4. Review the diff for unrelated edits and accidental production dependencies.
-   Report the changed contract, commands actually run, outcomes, and limitations.
+Completion requires the requested observable behavior, consistent types,
+diagnostics, examples and tests, and evidence for the affected boundaries.
+A bug fix needs a public reproduction; lifecycle work needs ownership and teardown
+evidence, async work supersession and rejection, and reconciliation surviving child
+identity and editable state. Remove superseded paths under the compatibility policy
+in [AGENTS.md](../../AGENTS.md).
 
 Use stable diagnostic codes when testing framework invariants. Error prose can
 change. Public tooling and public fixtures must use documented APIs rather than

--- a/docs/maintainers/readme.md
+++ b/docs/maintainers/readme.md
@@ -33,8 +33,10 @@ the affected public symbol and inspect its direct collaborators and tests.
 For a release, use the [release checklist](./release-checklist.md) across package
 publication, GitHub notes, website deployment, and the matching MCP snapshot.
 
-Completion requires the requested observable behavior, consistent types,
-diagnostics, examples and tests, and evidence for the affected boundaries.
+Completion requires the requested result and evidence for the affected boundaries.
+Update types, diagnostics, examples, and tests when the change affects them.
+For prose or link changes, use `npm run docs:check`; unchanged executable examples
+do not require reruns.
 A bug fix needs a public reproduction; lifecycle work needs ownership and teardown
 evidence, async work supersession and rejection, and reconciliation surviving child
 identity and editable state. Remove superseded paths under the compatibility policy

--- a/skills/marionette/SKILL.md
+++ b/skills/marionette/SKILL.md
@@ -1,112 +1,64 @@
 ---
 name: marionette
-description: Build and debug applications using Marionette v5 with the installed version's documentation, independent integration choices, and lifecycle-aware validation. Use for application work involving Marionette Views, Regions, CollectionViews, Application, state, or adapters; library maintenance follows its own repository instructions.
+description: Build or debug Marionette v5 applications using version-matched docs. For changes to the library itself, use its repository guidance.
 ---
 
 # Build with Marionette
 
-Use the application's installed contract. This skill does not select a package
-version, authorize an upgrade, or replace the application's existing decisions.
+Use the application's installed contract and preserve compatible integration
+choices. This skill does not authorize dependency upgrades.
 
-## Find the contract
+## Locate matching docs
 
-Inspect the application's manifest, lockfile, and runtime configuration. Resolve
-paths relative to the application being edited, including its workspace directory
-in a monorepo. Do not use the skill's own directory as the application root.
-
-Run the bundled helper with Node 24 or later (replace both absolute paths):
+Resolve the package from the application workspace, not the copied skill directory
+or a neighboring monorepo package. The read-only helper requires Node 24 or later:
 
 ```sh
 node /path/to/marionette/scripts/docs.mjs --project /path/to/application --list
 node /path/to/marionette/scripts/docs.mjs --project /path/to/application --page docs/agents.md
 ```
 
-The helper reads files only. It finds the installed `marionette` package without
-executing project code, checks the packaged documentation's version and hashes,
-and reports provenance. Use its returned paths to read further pages. It does not
-search the internet or run a package manager. For an installation without a
-`node_modules` tree, supply `--package-root /physical/path/to/marionette` obtained
-from that project's package manager. Do not substitute a different workspace's
-package just because it is available.
+These are lookup options, not a required sequence. `--list` returns provenance and
+available page paths; `--page` reads one source path. The helper checks packaged
+documentation hashes and version without executing project code or using a network.
+For installations without `node_modules`, supply `--package-root` with the physical
+package directory obtained from that application's package manager.
 
-If the installed artifact has no `dist/docs`, inspect its exports and declarations
-and obtain docs from that package's exact release or known source commit. An alpha
-version string alone does not establish a source match. Report missing provenance;
-do not silently use `master`, current website docs, or another project's package.
-A hash check detects inconsistent documentation files, not whether a custom build's
-JavaScript actually matches those docs. Validate uncertain behavior against the
-installed runtime. A `sourceDirty: true` manifest describes local changes, not an
-immutable release.
+If packaged docs are absent, use the exact release or known source commit and
+installed exports/declarations. Do not silently substitute current website docs,
+`master`, or another workspace's package. An alpha version alone does not establish
+source identity; `sourceDirty: true` is not an immutable release. Documentation
+hashes do not prove a custom runtime matches them; test uncertain runtime behavior.
 
-## Read only what the task needs
+## Select the relevant contract
 
-Start with packaged `docs/agents.md`, then use these source paths from the manifest:
+Read the task's page using its source path from the manifest or returned local path:
 
-- New application: `docs/development.md` for the executable typed starter;
-  `docs/installation.md` and `docs/choosing-integrations.md` for setup decisions.
-- UI ownership and replacement: `docs/marionette.view.md`,
-  `docs/marionette.region.md`, and `docs/view.lifecycle.md`.
-- Changing lists: `docs/marionette.collectionview.md` and `docs/data.api.md`.
-- Asynchronous features or routing: `docs/marionette.application.md` and
-  `docs/routing.md`.
-- State or a diagnostic: `docs/marionette.state.md` or
-  `docs/diagnostic-catalog.md`.
+| Task | Packaged page |
+| --- | --- |
+| New application | `docs/development.md` for the typed starter; `docs/choosing-integrations.md` for integration decisions |
+| Application architecture or unfamiliar ownership | `docs/agents.md` |
+| Rendering or screen replacement | `docs/marionette.view.md`, `docs/marionette.region.md`, `docs/view.lifecycle.md` |
+| Changing lists or observable records | `docs/marionette.collectionview.md`, `docs/data.api.md` |
+| Async features or navigation | `docs/marionette.application.md`, `docs/routing.md` |
+| State ownership or framework error | `docs/marionette.state.md` or `docs/diagnostic-catalog.md` |
+| Skill setup or optional documentation MCP | `docs/agent-tools.md` |
 
-If the client already has the Marionette documentation MCP configured, consult
-the `marionette://catalog` resource before searching. Use remote documents only
-when version and source match this installation. Pass the exact installed
-`version` to every tool and follow `nextOffset` until it is `null` to retrieve the
-complete page or example.
-Setup instructions: https://marionettejs.com/docs/mcp/. A URL in these instructions
-does not install an MCP connection. Keep the installed docs when the catalog is
-unsupported or the service is unavailable. Website WebMCP only controls its own
-examples, not this application.
+Follow relevant links rather than loading an overview and every reference. For MCP,
+read the retrieval rules in `docs/agent-tools.md` before remote use: exact version
+and source must match. Installed Markdown remains sufficient. For v4 applications,
+use matching migration material and installed APIs; this skill is not an upgrade plan.
 
-The manifest is the available-page index. Follow direct links for the selected
-task instead of loading the whole reference. For v4 work, use matching migration
-material and installed APIs; these v5 instructions are not an upgrade plan.
+DataApi, StateApi, renderer, DomApi, EventDelegator, and router are independent
+choices; a Backbone router does not require Backbone data. Register configuration
+before consumers. Use templates, named Regions, and public lifecycle APIs; domain
+records belong in data sources, not child View traversal. For application design,
+including personalized examples, use `docs/agents.md`.
 
-## Make the application decision
+## Completion
 
-Preserve a compatible established integration. For a new application, use built-in
-behavior when it supplies the capability; select an observable source when updates
-need observation. Choose DataApi, StateApi, renderer, DomApi, EventDelegator, and
-router independently. A Backbone router does not require Backbone data or state.
-Register configuration before creating its consumers; use an isolated runtime only
-when independent configurations must coexist.
-
-Make the first draft idiomatic: templates for ordinary content, named Regions for
-composition, `ui` for controls, `triggers` for semantic View events, and `events`
-when the handler needs the DOM event. Domain records belong in data sources;
-CollectionView children are their presentation, not a record store. For a new
-observable list, start with `@mnjs/data` and configure DataApi before construction.
-Native Collection `toArray()` returns plain attributes; iteration yields Models.
-Do not assume Backbone/Underscore methods.
-Update the smallest responsible View so unrelated drafts, focus and child identity
-survive. Cover every displayed or calculated field in data subscriptions, and let
-CollectionView reconcile membership without an extra whole-list render handler.
-Do not replace focused inputs in response to their own edits.
-Native DOM access belongs at boundaries such as focus or a widget.
-
-For a personalized app, connect a real user preference to both the interaction and
-visual design. Choose a specific visual direction before coding; preserve readable
-hierarchy, spacing, contrast, labels and narrow layouts. Do not force a line count
-that collapses independent owners into one View. Keep teaching/test controls out of
-the app itself. The website's optional personal-app brief supplies its own starter;
-it does not authorize browsing private sources for personalization.
-
-Name the owner and cleanup operation for Views, subscriptions, widgets, and async
-work. Use public lifecycle APIs. Check stale work before committing side effects;
-framework cancellation cannot undo arbitrary writes by application code. Consult
-the current reference for exact return and readiness behavior rather than inferring
-it from a method name.
-
-Use the application's own test commands. Exercise the requested behavior and its
-relevant boundary: stale navigation, surviving edits/focus, rerendered event
-handlers, or resource cleanup. For observable records, change a source directly and verify all interested Views,
-not just the clicked row. Check repeated attachment for attachment-bound work.
-Browser behavior needs a browser check; visual quality needs rendered inspection
-at desktop and narrow widths. Report
-commands actually run and untested boundaries; a successful build is not proof of
-those interactions. Record changed integration decisions in the application's own
-instructions without copying the library's maintainer policy.
+The requested application behavior works against the installed package, preserves
+unrelated edits/focus and ownership, and has evidence for the affected interaction
+and cleanup boundary. Use the application's checks; browser interactions require
+browser evidence. Report actual results and untested boundaries. Record changed
+integration decisions in the application's notes, keeping API details in the docs.

--- a/skills/marionette/SKILL.md
+++ b/skills/marionette/SKILL.md
@@ -32,7 +32,8 @@ hashes do not prove a custom runtime matches them; test uncertain runtime behavi
 
 ## Select the relevant contract
 
-Read the task's page using its source path from the manifest or returned local path:
+Pass the task page's `source` field from the manifest or `--list` output to
+`--page`. The returned absolute `path` is for reading the file directly:
 
 | Task | Packaged page |
 | --- | --- |

--- a/test/fixtures/data-package-starter/AGENTS.md
+++ b/test/fixtures/data-package-starter/AGENTS.md
@@ -1,18 +1,12 @@
 # Work on this Marionette application
 
-Read the installed contract in
-`node_modules/marionette/dist/docs/docs/agents.md`, then its compact reference
-and the page relevant to the task. `dist/docs/manifest.json` records the package
-version and source. Use this application's lockfile; do not substitute current
-website examples for a different installed version.
+Use `node_modules/marionette/dist/docs/docs/agents.md` for application architecture
+and its task links for specific contracts. The compact reference is an optional
+overview. `dist/docs/manifest.json` and this application's lockfile identify the
+installed version and source; do not substitute mismatched website examples.
 
-Optional skill setup: `node_modules/marionette/dist/docs/docs/agent-tools.md`.
-That guide also describes documentation retrieval. The website's MCP setup is
-at https://marionettejs.com/docs/mcp/. Read `marionette://catalog` and use remote
-docs only when version and source match this installation. Pass the exact installed
-`version` to each tool; follow `nextOffset` until it is `null`. Local Markdown
-remains sufficient. Website WebMCP operates its
-workshop, not this application.
+For skill setup or remote documentation retrieval, consult the installed
+`docs/agent-tools.md` under `dist/docs`. Local Markdown is sufficient.
 
 ## Existing architecture
 
@@ -32,9 +26,10 @@ workshop, not this application.
 - The loader is a local demonstration without persistence. Add real data access
   at `main.ts`'s loader boundary; connect URL handling to `navigate` if needed.
 
-## Verify changes
+## Setup and checks
 
-Run commands from this directory:
+Choose commands for the task from this directory; setup is needed only for a new
+installation:
 
 - Rename the shipped `gitignore` to `.gitignore` before committing application files.
 - First registry setup: `npm install`; subsequent locked installs: `npm ci`.
@@ -44,5 +39,7 @@ Run commands from this directory:
 
 Extend `workspace.test.mjs` for data/loading behavior and
 `workspace.browser.spec.mjs` for DOM interaction and cleanup. Use public APIs and
-observable behavior; do not inspect private framework fields. Run relevant checks
-and report actual results. Keep these architecture notes current as the app grows.
+observable behavior; do not inspect private framework fields. Completion means the
+requested behavior and its affected ownership/cancellation boundary work, with
+actual check results and any untested scope reported. Keep these architecture
+notes current as the app grows.


### PR DESCRIPTION
## What
- Narrow the shipped Marionette skill and route tasks directly to version-matched references.
- Replace repeated mandatory reads and procedural review loops with completion criteria in consumer, starter, and maintainer guidance.
- Consolidate retrieval details while retaining lifecycle, public-test, provenance, evaluation-budget, and release boundaries.

## Why
Apply OpenAI's [Rethinking skills and prompts for GPT-6 Astra](https://developers.openai.com/blog/rethinking-skills-and-prompts-for-gpt-6-astra) guidance to reduce unnecessary instruction loading while preserving Marionette-specific knowledge. No model performance improvement is claimed.

## Scope
Seven documentation/instruction files covering the shipped skill, consumer guide/template, starter instructions, and library maintenance. No production source, API, dependency, or benchmark changes. Preserves the current master branch's evaluation policy and focused-editor guidance.

## Deployment Impact
No forms or form bundles are involved. Consumer documentation and skill changes reach npm users with a future package release; no publication is part of this PR. The existing documentation workflow may deploy on merge to master when enabled. No runtime redeployment is required.

## Testing
- `npm run docs:check`: passed; 114 pages built, 115 HTML files and 1,743 internal links validated.
- `node --test test/agent-docs/lookup.test.mjs`: 9/9 passed, including workspace resolution, version/hash rejection, traversal protection, and provenance.
- `uv run --with pyyaml python /Users/paulfalgout/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/marionette`: passed.
- `node scripts/docs/package.mjs`: passed; 50 consumer documentation pages packaged.
- `git diff --check`: passed.
- Fresh-worktree documentation build initially lacked generated `src/version.js`; `npm exec -- rollup -c rollup.config.mjs --noConflict` generated build outputs, then documentation checks passed.
- No paid agent evaluation or full runtime suite: this change only edits guidance.

## Breaking changes
None. No public runtime behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines Marionette consumer and maintainer guidance: replaces mandatory reading loops with completion criteria, narrows the shipped skill's scope, and clarifies lookup inputs and which checks apply.

- Updates the skill, consumer guide, starter template, maintainer docs, and the fixture starter's agent instructions.
- Routes tasks directly to version-matched references instead of full overview reads; the skill documents its `--list`/`--page` lookup inputs and provenance rules.
- Consolidates retrieval rules into the agent tools guide and ties checks to change type (prose/link edits need `npm run docs:check`); retains lifecycle, provenance, evaluation-budget, and release boundaries.
- Guidance-only: no runtime, API, dependency, or benchmark impact; no migration steps.

<sup>Written for commit 5b6e53228accc515e62a0653e55a93f8391e1c5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and maintainer guidance for setup, completion criteria, verification, and evidence reporting.
  * Clarified documentation for collection conversion behavior, personalized applications, tool usage, and source/version matching.
  * Revised Marionette skill guidance to emphasize contract preservation and targeted validation.
  * Updated starter project instructions for installation checks and reporting untested areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->