### PR TITLE
docs(agents): explain target inspection before migration

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -92,15 +92,16 @@ and lockfile, including any npm alias. A v4 application may use
 marionette found” does not mean the application has no Marionette dependency.
 
 Download the exact target into a temporary directory without installing it in the
-application. This example inspects `5.0.0-beta.2`; replace that literal only with
-the release selected for your migration, not `latest` or `next`. Downloading
+application. This example inspects `5.0.0-beta.2`; set `migration_target_version` to
+the exact release selected for your migration, not `latest` or `next`. Downloading
 requires npm registry access; reading the extracted docs requires Node 24 or later.
 Run these commands in the same shell:
 
 ```sh
+migration_target_version="5.0.0-beta.2"
 migration_target_dir="$(mktemp -d)"
-npm pack marionette@5.0.0-beta.2 --ignore-scripts --pack-destination "$migration_target_dir"
-tar -xzf "$migration_target_dir/marionette-5.0.0-beta.2.tgz" -C "$migration_target_dir"
+npm pack "marionette@$migration_target_version" --ignore-scripts --pack-destination "$migration_target_dir"
+tar -xzf "$migration_target_dir/marionette-$migration_target_version.tgz" -C "$migration_target_dir"
 node "$migration_target_dir/package/dist/agent-skill/scripts/docs.mjs" --package-root "$migration_target_dir/package" --list
 node "$migration_target_dir/package/dist/agent-skill/scripts/docs.mjs" --package-root "$migration_target_dir/package" --page docs/migration-from-v4.md
 node "$migration_target_dir/package/dist/agent-skill/scripts/docs.mjs" --package-root "$migration_target_dir/package" --page upgradeGuide.md

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -1,7 +1,9 @@
 # Set up an agent
 
 Use the installed package's documentation and a small application instruction file
-first. The optional Marionette skill helps an agent select those documents and
+first. For migration planning before installing the target, use the
+[pre-migration path](#inspect-a-target-release-before-migrating) below. The optional
+Marionette skill helps an agent select those documents and
 apply their lifecycle and integration rules. None of these resources requires an
 account, network access, hosted model, or shared API key to read.
 
@@ -80,6 +82,50 @@ built from that revision. Check installed exports and test uncertain behavior. A
 alpha version alone cannot identify a source commit; `sourceDirty: true` means
 local changes are included. Older packages without docs require an exact release
 or known source checkout, not an automatic fallback to today's website.
+
+## Inspect a target release before migrating
+
+Keep the application's installed version separate from the proposed target.
+First record the current dependency name and resolved version from its manifest
+and lockfile, including any npm alias. A v4 application may use
+`backbone.marionette`; the helper searches for `marionette`, so “No installed
+marionette found” does not mean the application has no Marionette dependency.
+
+Download the exact target into a temporary directory without installing it in the
+application. This example inspects `5.0.0-beta.2`; replace that literal only with
+the release selected for your migration, not `latest` or `next`. Downloading
+requires npm registry access; reading the extracted docs requires Node 24 or later.
+Run these commands in the same shell:
+
+```sh
+migration_target_dir="$(mktemp -d)"
+npm pack marionette@5.0.0-beta.2 --ignore-scripts --pack-destination "$migration_target_dir"
+tar -xzf "$migration_target_dir/marionette-5.0.0-beta.2.tgz" -C "$migration_target_dir"
+node "$migration_target_dir/package/dist/agent-skill/scripts/docs.mjs" --package-root "$migration_target_dir/package" --list
+node "$migration_target_dir/package/dist/agent-skill/scripts/docs.mjs" --package-root "$migration_target_dir/package" --page docs/migration-from-v4.md
+node "$migration_target_dir/package/dist/agent-skill/scripts/docs.mjs" --package-root "$migration_target_dir/package" --page upgradeGuide.md
+```
+
+These commands leave the application's dependencies and lockfile unchanged.
+Check that the helper reports the selected target version, and record its source
+revision, `sourceDirty`, and content digest as **target documentation evidence**.
+They do not describe the installed v4 runtime or prove migration success. Continue
+to use the current version's matching docs and public APIs when investigating
+existing behavior.
+
+To install the optional skill before upgrading, use
+`$migration_target_dir/package/dist/agent-skill` as the source directory in the
+[skill installation steps](#install-the-consumer-skill). Keep the extracted package
+available and pass its explicit `--package-root` when reading target docs; copying
+the skill does not change what `--project` resolves.
+
+Use the [migration guide](./migration-from-v4.md) and
+[upgrade guide](../upgradeGuide.md) to plan the change. Discover what the
+application's wrappers and routing integrations own, then verify that behavior
+against the target contract. Record application-specific findings in the
+application; the generic skill is not a complete migration plan. After an
+approved dependency change, resolve the installed package with `--project` again
+and verify the migrated behavior with the application's tests.
 
 ## Record the application decisions
 

--- a/skills/marionette/SKILL.md
+++ b/skills/marionette/SKILL.md
@@ -38,6 +38,7 @@ Pass the task page's `source` field from the manifest or `--list` output to
 | Task | Packaged page |
 | --- | --- |
 | New application | `docs/development.md` for the typed starter; `docs/choosing-integrations.md` for integration decisions |
+| Migrating an existing application | `docs/agent-tools.md` (pre-migration setup); `docs/migration-from-v4.md` and `upgradeGuide.md` from that target |
 | Application architecture or unfamiliar ownership | `docs/agents.md` |
 | Rendering or screen replacement | `docs/marionette.view.md`, `docs/marionette.region.md`, `docs/view.lifecycle.md` |
 | Changing lists or observable records | `docs/marionette.collectionview.md`, `docs/data.api.md` |


### PR DESCRIPTION
## What
- Document downloading and inspecting an exact target release before changing application dependencies, using the existing packaged helper.
- Keep installed-version evidence separate from target documentation provenance and explain the v4 package-name lookup gap.
- Add a direct migration entry to the consumer skill, routing to setup and both migration guides.

## Why
A v4 consumer can have no installed `marionette` package for the helper to locate. The setup previously assumed the target was already installed, leaving agents without an explicit pre-migration path. This supplies that path without adding tooling or embedding application-specific migration answers.

## Scope
Only `docs/agent-tools.md` and the migration routing entry in `skills/marionette/SKILL.md`. No production source, helper behavior, dependency, or application changes. Runtime cost is zero.

## Deployment Impact
No forms or form bundles require redeployment. The packaged guidance ships in a future npm release; the website can consume the updated documentation artifact through its normal deployment. Existing beta.2 tarballs remain unchanged. This PR does not publish or deploy anything.

## Testing
- Ran the documented `npm pack marionette@5.0.0-beta.2 --ignore-scripts` / extraction / helper sequence successfully against the published artifact. Retrieved both migration guides and verified target version `5.0.0-beta.2`, clean provenance, and source revision `13f4954c352e646c413091ffdd83f6da59404573`.
- `npm run build` passed in the isolated PR worktree, including type checks and documentation packaging.
- `npm run docs:check` passed: 11 tests, 30 executable-example mappings, and 1,747 internal links. The initial fresh-worktree attempt lacked generated `src/version.js`; the standard build supplied it before the successful rerun.
- `git diff --check` passed.
- These checks establish packaging and documentation retrieval, not migration success. No application migration was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents a pre-migration path in the agent setup so agents can inspect an exact target release before changing dependencies. The setup previously assumed the target was already installed, leaving v4 consumers without a route when no `marionette` package is present.

- Downloads and extracts the target with the packaged helper, leaving the application's dependencies and lockfile unchanged.
- Defines the target version once in a variable for all inspection commands.
- Keeps installed-version evidence separate from target documentation provenance and explains the `backbone.marionette` vs `marionette` lookup gap.
- Adds a migration routing entry to the consumer skill pointing to setup and both migration guides.
- Docs-only change: no production, helper, dependency, or application changes, and nothing is deployed.

<sup>Written for commit f750a5a2d0bad449810c82e11cc5fa9a2f04105b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marionettejs/marionette/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for inspecting a target release before migration without modifying application dependencies or the lockfile.
  - Documented how to record installed dependencies, retrieve exact target releases, and review bundled migration documentation.
  - Added instructions for installing the optional migration skill and verifying behavior after an approved dependency update.
  - Updated the Marionette skill documentation to link existing-application migration tasks to the relevant guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->