### PR TITLE
chore(docs): request website reading-copy sync after merges

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,30 @@
+name: Request website documentation sync
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - 'docs-site/navigation.json'
+      - 'docs-site/README.md'
+      - 'packages/*/readme.md'
+      - 'upgradeGuide.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'AGENTS.md'
+  workflow_dispatch:
+permissions: {}
+concurrency:
+  group: website-docs-sync-request
+  cancel-in-progress: false
+jobs:
+  request:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Request a sync of current merged documentation
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DOCS_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/marionettejs/marionettejs.com/dispatches \
+            -f event_type=library-docs-changed

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -2,6 +2,7 @@ name: Request website documentation sync
 on:
   push:
     branches: [master]
+    # Only rendered reading copies; supporting assets remain release-pinned.
     paths:
       - 'docs/**'
       - 'docs-site/navigation.json'

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -151,7 +151,7 @@ Sources checked September 2026: [Context7 configuration](https://context7.com/do
 
 ## Continuous website reading-copy sync
 
-Merges affecting documentation request the website's single
+Merges affecting rendered reading-copy sources request the website's single
 [reading-copy sync workflow](https://github.com/marionettejs/marionettejs.com/blob/main/.github/workflows/docs-sync.yml).
 It reads the latest merged `master` Git objects, preserves website publication
 wording with a three-way merge, validates the complete website/MCP artifact, and
@@ -160,7 +160,10 @@ Dispatches contain no executable code, source URL, or revision to trust; delayed
 requests always converge on current `master`. Use **Request website documentation
 sync → Run workflow** to retry failed delivery or recover a missed event.
 
-This is development/CI tooling only: no library runtime cost. Ordinary syncs never
+This is development/CI tooling only: no library runtime cost. Supporting-resource-only changes (`docs-site/resources.json`, catalogs, skills,
+fixtures and benchmark assets) intentionally do not dispatch: the receiver leaves
+those archived assets pinned and synchronizes Markdown pages only.
+Ordinary syncs never
 run a library build, change package versions, import a new npm archive, or copy
 skill/starter assets. Reading-copy edits carry their exact source revisions and
 hashes separately from the immutable npm archive. Conflicting publication edits
@@ -175,10 +178,17 @@ this sender. See the website's `scripts/docs-sync/README.md` for receiver setup,
 branch rules, validation, conflict recovery, and token rotation. The default
 `GITHUB_TOKEN` cannot dispatch across repositories.
 
-An npm release remains an explicit `npm run docs:import -- /path/to/package/dist/docs`
-operation in the website, using the exact published package. Review publication
-edits and supplemental schema provenance together with that import. A documentation
-merge must never substitute `.docs-export` for the published npm snapshot.
+An npm release remains an explicit import in the website. Read the exact revision
+from the published package's `dist/docs/manifest.json`, export with `npm run docs:export`
+from a clean checkout of that revision, and import the complete `.docs-export` with
+`npm run docs:import -- /path/to/released-source/.docs-export`. The full export
+preserves maintainer pages that the narrower npm `dist/docs` directory omits.
+Require matching version/repository/revision, `sourceDirty: false`, identical
+metadata and bytes for every npm consumer page/asset, and the reviewed maintainer
+route inventory. Website `npm run check` verifies the npm subset against the pinned
+installed package; review the full manifest diff for maintainer scope. Review
+publication edits and supplemental schema provenance with that import. Ordinary
+merges must never import a moving or unreleased export into this archive.
 
 Neither workflow merges PRs or deploys. After the website sync PR merges, manually
 build and deploy the complete website and MCP from the same reviewed website

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -148,3 +148,40 @@ Sources checked September 2026: [Context7 configuration](https://context7.com/do
 [Context7 ownership](https://context7.com/docs/howto/claiming-libraries),
 [Context7 plans](https://context7.com/plans), and
 [Cloudflare Pages pricing](https://developers.cloudflare.com/pages/functions/pricing/).
+
+## Continuous website reading-copy sync
+
+Merges affecting documentation request the website's single
+[reading-copy sync workflow](https://github.com/marionettejs/marionettejs.com/blob/main/.github/workflows/docs-sync.yml).
+It reads the latest merged `master` Git objects, preserves website publication
+wording with a three-way merge, validates the complete website/MCP artifact, and
+creates or updates `automation/library-docs-sync` as one ready website PR.
+Dispatches contain no executable code, source URL, or revision to trust; delayed
+requests always converge on current `master`. Use **Request website documentation
+sync → Run workflow** to retry failed delivery or recover a missed event.
+
+This is development/CI tooling only: no library runtime cost. Ordinary syncs never
+run a library build, change package versions, import a new npm archive, or copy
+skill/starter assets. Reading-copy edits carry their exact source revisions and
+hashes separately from the immutable npm archive. Conflicting publication edits
+stop for review rather than overwriting website wording.
+
+Setup: create the repository secret `WEBSITE_DOCS_DISPATCH_TOKEN` in this library
+repository. Use a fine-grained token restricted to `marionettejs/marionettejs.com`
+with **Contents: write**, the permission required by GitHub's repository dispatch
+endpoint; no access to write this library is needed. Store the value only in
+Actions secrets. Configure the receiver and its PR credential first, then enable
+this sender. See the website's `scripts/docs-sync/README.md` for receiver setup,
+branch rules, validation, conflict recovery, and token rotation. The default
+`GITHUB_TOKEN` cannot dispatch across repositories.
+
+An npm release remains an explicit `npm run docs:import -- /path/to/package/dist/docs`
+operation in the website, using the exact published package. Review publication
+edits and supplemental schema provenance together with that import. A documentation
+merge must never substitute `.docs-export` for the published npm snapshot.
+
+Neither workflow merges PRs or deploys. After the website sync PR merges, manually
+build and deploy the complete website and MCP from the same reviewed website
+commit, record the corpus hash, and follow `mcp/DEPLOYMENT.md`. Existing diagnostic
+Pages hosting is a separate opt-in workflow; this sync grants no Pages, deployment,
+package, or release permissions.


### PR DESCRIPTION
## What
- Dispatch a website reading-copy sync after relevant documentation merges to `master`, with a manual retry through the same workflow.
- Document the receiver dependency, scoped credential, explicit npm import boundary, and manual website/MCP deployment process.

## Why
Library documentation currently requires a separate manual website edit. The website receiver coalesces changed reading copies into one reviewed PR while preserving publication wording and the immutable npm archive.

## Scope
Documentation/CI only, with no production library runtime cost. No source/API, package version, release artifact, marketing, or skill/starter changes. Receiver implementation: https://github.com/marionettejs/marionettejs.com/pull/23 (merge first).

## Deployment Impact
Merge the website receiver first, configure both documented secrets, then merge this sender. No forms require redeployment. Neither this workflow nor the receiver merges or deploys. After reviewing and merging a sync PR, manually deploy website and MCP from one reviewed website commit/corpus hash. The existing separately gated diagnostic Pages workflow is unchanged; `DOCS_PAGES_ENABLED` is currently unset.

## Testing
- `npm run build` passed (needed to generate the fresh worktree's version/build files).
- `npm run docs:check` passed after rebasing onto `1b78ab04173feaa47a96c2957016c8fa4f35ea45`: 11 tests, 30 example-marker checks, 115 HTML files and 1,747 internal links.
- `npm run check:workflows` passed: eight workflows, including pinned actionlint.
- Website receiver tests cover repeated/no-op syncs, publication conflicts, source-history and validation boundaries, and one-PR updates.
- Live dispatch is not tested: `WEBSITE_DOCS_DISPATCH_TOKEN` and website `DOCS_SYNC_PR_TOKEN` are not configured. No credentials or repository settings were changed.
